### PR TITLE
Unschedulable Nodes are Set to Not Monitored

### DIFF
--- a/pkg/discovery/probe/node_probe_test.go
+++ b/pkg/discovery/probe/node_probe_test.go
@@ -46,7 +46,7 @@ func (fng *FakeNodeGetter) GetNodes(label labels.Selector, field fields.Selector
 func TestGetNodes(t *testing.T) {
 	fakeGetter := &FakeNodeGetter{}
 
-	nodeProbe := NewNodeProbe(fakeGetter.GetNodes, nil)
+	nodeProbe := NewNodeProbe(fakeGetter.GetNodes, nil, nil)
 
 	nodes, err := nodeProbe.GetNodes(nil, nil)
 	if err != nil {

--- a/pkg/discovery/probe/pod_probe_util.go
+++ b/pkg/discovery/probe/pod_probe_util.go
@@ -57,8 +57,13 @@ func GetResourceRequest(pod *api.Pod) (cpuRequest float64, memRequest float64, e
 }
 
 // Returns a bool indicates whether the given pod should be monitored.
+// Do not monitor pods running on nodes those are not monitored.
 // Do not monitor mirror pods or pods created by DaemonSets.
 func monitored(pod *api.Pod) bool {
+	if _, exist := notMonitoredNodes[pod.Spec.NodeName]; exist {
+		return false
+	}
+
 	if isMirrorPod(pod) || isPodCreatedBy(pod, Kind_DaemonSet) {
 		return false
 	}


### PR DESCRIPTION
Before the change, nodes those were unschedulable or not ready wont be parsed. No realtime data about the nodes was collect. No entityDTO was built.

Now we still want to get the resource consumption those nodes, but make sure those nodes don't participate in market cycle. So we get all the resource data just like any other node, but just set unschedulable nodes monitored flag to false. 