### PR TITLE
Fixed the Move Action of a Standalone Pod

### DIFF
--- a/pkg/action/executor/action_executor.go
+++ b/pkg/action/executor/action_executor.go
@@ -9,7 +9,10 @@ import (
 )
 
 const (
-	// This is the maximum time for action executor
+	// Set the maximum timeout for pod deletion to 30 seconds.
+	podDeletionTimeout time.Duration = time.Second * 30
+
+	// This is the maximum timeout for action executor.
 	secondPhaseTimeoutLimit time.Duration = time.Minute * 5
 )
 

--- a/pkg/discovery/probe/node_probe.go
+++ b/pkg/discovery/probe/node_probe.go
@@ -294,7 +294,7 @@ func (nodeProbe *NodeProbe) buildVMEntityDTO(node *api.Node, commoditiesSold []*
 
 	// We do not monitor node that is not ready or unschedulable.
 	if !nodeIsReady(node) || !nodeIsSchedulable(node) {
-		glog.V(3).Infof("Node %s is either not ready or unschedulable. Skip", node.Name)
+		glog.V(3).Infof("Node %s is either not ready or unschedulable.", node.Name)
 		//continue
 		notMonitoredNodes[node.Name] = struct{}{}
 		entityDTOBuilder.Monitored(false)


### PR DESCRIPTION
The move of a standalone pod is not correctly handled. In some cases, a pod may take longer time to terminate gracefully, which may not be fully deleted after 3s sleep period. So here the first change is to set the grace period of deletion to 0, making the pod gets deleted immediately. Then in case it stills takes time, we set a pod deletion time to 30s. Within this 30s, we continuously check if the pod gets deleted successfully every 1s. 
Another problem was the key of standalone pod passed to pub-sub is not correct. It was the UID of the  pod. But when there is new pod cloned, it has a different UID. Now we use "namespace/name" as the key in pub-sub.