### PR TITLE
Changed the ID of Pod EntityDTO and Applications EntityDTO

### DIFF
--- a/examples/yaml/nodeselector_example_pod.yaml
+++ b/examples/yaml/nodeselector_example_pod.yaml
@@ -10,5 +10,4 @@ spec:
     image: nginx
     imagePullPolicy: IfNotPresent
   nodeSelector:
-    kubernetes.io/hostname: 127.0.0.1
     zone: local

--- a/hack/run_with_kubeconfig.sh
+++ b/hack/run_with_kubeconfig.sh
@@ -6,4 +6,4 @@ OUTPUT_DIR=${OUTPUT_DIR:-"_output"}
 	 --v=3 \
 	 --kubeconfig="$HOME/.kube/config" \
 	 --testingflag="./hack/testing-flag.json" \
-	 --turboconfig="./hack/container-conf.json" > "/tmp/kubeturbo.log" 2>&1 &
+	 --turboconfig="./hack/minikube-conf.json" > "/tmp/kubeturbo.log" 2>&1 &

--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -219,7 +219,7 @@ func (h *HorizontalScaler) horizontalScale(action *turboaction.TurboAction) (*tu
 			"replication controller or replica set.")
 	}
 	glog.V(3).Infof("The current horizontal scaler consumer is listening on pod created by replication "+
-		"controller or replica set with UID  %s", key)
+		"controller or replica set with key %s", key)
 	podConsumer := turbostore.NewPodConsumer(string(action.UID), key, h.broker)
 
 	// 2. scale up and down by changing the replica of replication controller or deployment.

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -52,9 +52,10 @@ func (r *ReScheduler) buildPendingReScheduleTurboAction(actionItem *proto.Action
 	error) {
 	// Find out the pod to be re-scheduled.
 	targetPod := actionItem.GetTargetSE()
-	podIdentifier := targetPod.GetId() // podIdentifier must have format as "Namespace:Name"
-	originalPod, err := util.GetPodFromCluster(r.kubeClient, podIdentifier)
+	podIdentifier := targetPod.GetId()
+	originalPod, err := util.GetPodFromIdentifier(r.kubeClient, podIdentifier)
 	if err != nil {
+		glog.Errorf("Cannot not find pod in the cluster: %s", err)
 		return nil, fmt.Errorf("Try to move pod %s, but could not find it in the cluster.", podIdentifier)
 	}
 
@@ -151,7 +152,7 @@ func (r *ReScheduler) reSchedule(action *turboaction.TurboAction) (*turboaction.
 			"replication controller or replca set.")
 	}
 	glog.V(3).Infof("The current re-scheduler consumer is listening on the any pod created by "+
-		"replication controller or replica set with UID  %s", key)
+		"replication controller or replica set with key %s", key)
 	podConsumer := turbostore.NewPodConsumer(string(action.UID), key, r.broker)
 
 	// 2. Get the target Pod

--- a/pkg/discovery/probe/node_probe.go
+++ b/pkg/discovery/probe/node_probe.go
@@ -21,14 +21,14 @@ import (
 )
 
 // key: node name; value: cAdvisor host.
-var hostSet map[string]*vmtAdvisor.Host = make(map[string]*vmtAdvisor.Host)
+var hostSet map[string]*vmtAdvisor.Host
 
 // key: node name; value: node uid.
-var nodeUIDMap map[string]string = make(map[string]string)
+var nodeUIDMap map[string]string
 
 // A map stores the machine information of each node.
 // key: node name; value: machine information.
-var nodeMachineInfoMap map[string]*cadvisor.MachineInfo = make(map[string]*cadvisor.MachineInfo)
+var nodeMachineInfoMap map[string]*cadvisor.MachineInfo
 
 // This set keeps track of unschedulable or inactive nodes, which are not monitored in Turbonomic.
 // key: node name.
@@ -46,6 +46,9 @@ type NodeProbe struct {
 func NewNodeProbe(getter NodesGetter, config *ProbeConfig, stitchingManager *stitching.StitchingManager) *NodeProbe {
 	// initiate set every time.
 	notMonitoredNodes = make(map[string]struct{})
+	hostSet = make(map[string]*vmtAdvisor.Host)
+	nodeUIDMap = make(map[string]string)
+	nodeMachineInfoMap = make(map[string]*cadvisor.MachineInfo)
 
 	return &NodeProbe{
 		nodesGetter:      getter,

--- a/pkg/discovery/probe/pod_probe_util.go
+++ b/pkg/discovery/probe/pod_probe_util.go
@@ -56,6 +56,27 @@ func GetResourceRequest(pod *api.Pod) (cpuRequest float64, memRequest float64, e
 	return
 }
 
+// Get the UUID that will be used in Turbonomic server. Here we build the UUID based on pod UID, namespace and name.
+// The out UUID is in format "UID:namespace:name"
+func GetTurboPodUUID(pod *api.Pod) string {
+	uid := string(pod.UID)
+	namespace := pod.Namespace
+	name := pod.Name
+	return uid + ":" + namespace + ":" + name
+}
+
+func BreakdownTurboPodUUID(uuid string) (uid string, namespace string, name string, err error) {
+	components := strings.Split(uuid, ":")
+	if len(components) != 3 {
+		err = fmt.Errorf("Given string %s is not a Turbo Pod UUID.", uuid)
+		return
+	}
+	uid = components[0]
+	namespace = components[1]
+	name = components[2]
+	return
+}
+
 // Returns a bool indicates whether the given pod should be monitored.
 // Do not monitor pods running on nodes those are not monitored.
 // Do not monitor mirror pods or pods created by DaemonSets.

--- a/pkg/discovery/probe/pod_probe_util_test.go
+++ b/pkg/discovery/probe/pod_probe_util_test.go
@@ -1,0 +1,129 @@
+package probe
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/uuid"
+)
+
+func TestGetTurboPodUUID(t *testing.T) {
+	table := []struct {
+		uid       types.UID
+		namespace string
+		name      string
+
+		illegal bool
+	}{
+		{
+			uid:       uuid.NewUUID(),
+			namespace: "default",
+			name:      "pod-name",
+		},
+		{
+			uid:       types.UID("abcd-e:fg"),
+			namespace: "default",
+			name:      "pod-name",
+
+			illegal: true,
+		},
+		{
+			uid:       uuid.NewUUID(),
+			namespace: "d:efault",
+			name:      "pod-name",
+
+			illegal: true,
+		},
+		{
+			uid:       uuid.NewUUID(),
+			namespace: "default",
+			name:      "pod-n:ame",
+
+			illegal: true,
+		},
+	}
+
+	for _, item := range table {
+		pod := &api.Pod{}
+		pod.UID = item.uid
+		pod.Namespace = item.namespace
+		pod.Name = item.name
+		turboPodUUID := GetTurboPodUUID(pod)
+
+		var expectedUUID string
+		if item.illegal {
+			expectedUUID = ""
+		} else {
+			expectedUUID = string(item.uid) + ":" + item.namespace + ":" + item.name
+		}
+		if expectedUUID != turboPodUUID {
+			t.Errorf("Expects %s, got %s", expectedUUID, turboPodUUID)
+		}
+	}
+}
+
+func TestBreakdownTurboPodUUID(t *testing.T) {
+	table := []struct {
+		uid       string
+		namespace string
+		name      string
+
+		expectsError bool
+	}{
+		{
+			uid: "abc",
+			namespace:"default",
+			name:"foo",
+		},
+		{
+			namespace:"default",
+			name:"foo",
+
+			expectsError:true,
+		},
+		{
+			uid: "abc",
+			name:"foo",
+
+			expectsError:true,
+		},
+		{
+			namespace:"default",
+			name:"foo",
+
+			expectsError:true,
+		},
+	}
+	for _, item := range table{
+		turboUUID := ""
+		if item.uid != "" {
+			turboUUID += item.uid + ":"
+		}
+		if item.namespace != "" {
+			turboUUID += item.namespace + ":"
+		}
+		if item.name != "" {
+			turboUUID += item.name
+		}
+		uid, ns, name, err := BreakdownTurboPodUUID(turboUUID)
+		if item.expectsError {
+			if err == nil {
+				t.Error("Expected error, but got no error.")
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Unexpected error, %s", err)
+			}
+			if uid != item.uid {
+				t.Errorf("Expects uid %s, got %s", item.uid, uid)
+			}
+			if ns != item.namespace {
+				t.Errorf("Expects namespace %s, got %s", item.namespace, ns)
+			}
+			if name != item.name {
+				t.Errorf("Expects name %s, got %s", item.name, name)
+			}
+		}
+	}
+}

--- a/pkg/discovery/target_config.go
+++ b/pkg/discovery/target_config.go
@@ -31,7 +31,7 @@ func (config *K8sTargetConfig) ValidateK8sTargetConfig() error {
 		return errors.New("Either probeCategory or targetType is not provided.")
 	}
 	if config.TargetIdentifier == "" {
-		return errors.New("targetIdenfifier is not provided.")
+		return errors.New("targetIdentifier is not provided.")
 	}
 	if config.TargetUsername == "" {
 		config.TargetUsername = defaultUsername


### PR DESCRIPTION
Before the change, we used the pod namespace and name as the ID of the entityDTO. This is fine when we only discovery one Kubernetes cluster in on Ops Manager. However, it is possible user adds multiple Kubernetes targets and within each Kubernetes cluster, pods with same namespace and name are deployed into cluster respectively. So there will be UID conflict at Turbonomic server side. 
The solution is to use PodUID combine with pod namespace and name as the id send in entityDTO. This guarantee the uniqueness of pods even in different clusters.