### PR TITLE
Added Revervation in Commodities Bought by Pod

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -427,31 +427,31 @@
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/builder",
-			"Rev": "3fa614e37da5488d7a2e826ca8c78facd2a79bdc"
+			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer",
-			"Rev": "3fa614e37da5488d7a2e826ca8c78facd2a79bdc"
+			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/probe",
-			"Rev": "3fa614e37da5488d7a2e826ca8c78facd2a79bdc"
+			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/proto",
-			"Rev": "3fa614e37da5488d7a2e826ca8c78facd2a79bdc"
+			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/service",
-			"Rev": "3fa614e37da5488d7a2e826ca8c78facd2a79bdc"
+			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/supplychain",
-			"Rev": "3fa614e37da5488d7a2e826ca8c78facd2a79bdc"
+			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/version",
-			"Rev": "3fa614e37da5488d7a2e826ca8c78facd2a79bdc"
+			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
 		},
 		{
 			"ImportPath": "github.com/ugorji/go/codec",

--- a/pkg/discovery/probe/node_probe.go
+++ b/pkg/discovery/probe/node_probe.go
@@ -142,7 +142,6 @@ func (nodeProbe *NodeProbe) createCommoditySold(node *api.Node, nodePodsMap map[
 	if err != nil {
 		return commoditiesSold, err
 	}
-	nodeID := string(node.UID)
 	vMemComm, err := builder.NewCommodityDTOBuilder(proto.CommodityDTO_VMEM).
 		Capacity(nodeResourceStat.vMemCapacity).
 		Used(nodeResourceStat.vMemUsed).
@@ -161,38 +160,29 @@ func (nodeProbe *NodeProbe) createCommoditySold(node *api.Node, nodePodsMap map[
 	}
 	commoditiesSold = append(commoditiesSold, vCpuComm)
 
-	memProvisionedComm, err := builder.NewCommodityDTOBuilder(proto.CommodityDTO_MEM_PROVISIONED).
-		//		Key("Container").
-		Capacity(float64(nodeResourceStat.memProvisionedCapacity)).
-		Used(nodeResourceStat.memProvisionedUsed).
-		Create()
-	if err != nil {
-		return nil, err
-	}
-	commoditiesSold = append(commoditiesSold, memProvisionedComm)
+	//memProvisionedComm, err := builder.NewCommodityDTOBuilder(proto.CommodityDTO_MEM_PROVISIONED).
+	//	//		Key("Container").
+	//	Capacity(float64(nodeResourceStat.memProvisionedCapacity)).
+	//	Used(nodeResourceStat.memProvisionedUsed).
+	//	Create()
+	//if err != nil {
+	//	return nil, err
+	//}
+	//commoditiesSold = append(commoditiesSold, memProvisionedComm)
+	//
+	//cpuProvisionedComm, err := builder.NewCommodityDTOBuilder(proto.CommodityDTO_CPU_PROVISIONED).
+	//	//		Key("Container").
+	//	Capacity(float64(nodeResourceStat.cpuProvisionedCapacity)).
+	//	Used(nodeResourceStat.cpuProvisionedUsed).
+	//	Create()
+	//if err != nil {
+	//	return nil, err
+	//}
+	//commoditiesSold = append(commoditiesSold, cpuProvisionedComm)
 
-	cpuProvisionedComm, err := builder.NewCommodityDTOBuilder(proto.CommodityDTO_CPU_PROVISIONED).
-		//		Key("Container").
-		Capacity(float64(nodeResourceStat.cpuProvisionedCapacity)).
-		Used(nodeResourceStat.cpuProvisionedUsed).
-		Create()
-	if err != nil {
-		return nil, err
-	}
-	commoditiesSold = append(commoditiesSold, cpuProvisionedComm)
-
-	appComm, err := builder.NewCommodityDTOBuilder(proto.CommodityDTO_APPLICATION).
-		Key(nodeID).
-		Capacity(1E10).
-		Create()
-	if err != nil {
-		return nil, err
-	}
-	commoditiesSold = append(commoditiesSold, appComm)
-
-	labelsmap := node.ObjectMeta.Labels
-	if len(labelsmap) > 0 {
-		for key, value := range labelsmap {
+	labelsMap := node.ObjectMeta.Labels
+	if len(labelsMap) > 0 {
+		for key, value := range labelsMap {
 			label := key + "=" + value
 			glog.V(4).Infof("label for this Node is : %s", label)
 			accessComm, err := builder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
@@ -354,29 +344,32 @@ func (nodeProbe *NodeProbe) getNodeResourceStat(node *api.Node, nodePodsMap map[
 	cpuUsed := float64(rootCurCpu) * float64(cpuFrequency)
 	memUsed := float64(rootCurMem)
 
-	cpuProvisionedUsed := float64(0)
-	memProvisionedUsed := float64(0)
 
-	if podList, exist := nodePodsMap[node.Name]; exist {
-		for _, pod := range podList {
-			cpuRequest, memRequest, err := GetResourceRequest(pod)
-			if err != nil {
-				return nil, fmt.Errorf("Error getting provisioned resource consumption: %s", err)
-			}
-			cpuProvisionedUsed += cpuRequest
-			memProvisionedUsed += memRequest
-		}
-	}
-	cpuProvisionedUsed *= float64(cpuFrequency)
+	// TODO we will re-include provisioned commodities sold by node later.
+	//cpuProvisionedUsed := float64(0)
+	//memProvisionedUsed := float64(0)
+	//
+	//if podList, exist := nodePodsMap[node.Name]; exist {
+	//	for _, pod := range podList {
+	//		cpuRequest, memRequest, err := GetResourceRequest(pod)
+	//		if err != nil {
+	//			return nil, fmt.Errorf("Error getting provisioned resource consumption: %s", err)
+	//		}
+	//		cpuProvisionedUsed += cpuRequest
+	//		memProvisionedUsed += memRequest
+	//	}
+	//}
+	//cpuProvisionedUsed *= float64(cpuFrequency)
 
 	return &NodeResourceStat{
 		vCpuCapacity:           nodeCpuCapacity,
 		vCpuUsed:               cpuUsed,
 		vMemCapacity:           nodeMemCapacity,
 		vMemUsed:               memUsed,
-		cpuProvisionedCapacity: nodeCpuCapacity,
-		cpuProvisionedUsed:     cpuProvisionedUsed,
-		memProvisionedCapacity: nodeMemCapacity,
-		memProvisionedUsed:     memProvisionedUsed,
+		// TODO we will re-include provisioned commodities sold by node later.
+		//cpuProvisionedCapacity: nodeCpuCapacity,
+		//cpuProvisionedUsed:     cpuProvisionedUsed,
+		//memProvisionedCapacity: nodeMemCapacity,
+		//memProvisionedUsed:     memProvisionedUsed,
 	}, nil
 }

--- a/pkg/discovery/probe/stitching/stitching_manager.go
+++ b/pkg/discovery/probe/stitching/stitching_manager.go
@@ -224,7 +224,6 @@ func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_Re
 		return nil, fmt.Errorf("Stitching property type %s is not supported.", s.stitchingPropertyType)
 	}
 	replacementEntityMetaDataBuilder.PatchSelling(proto.CommodityDTO_CLUSTER).
-		PatchSelling(proto.CommodityDTO_APPLICATION).
 		PatchSelling(proto.CommodityDTO_VMPM_ACCESS)
 	meta := replacementEntityMetaDataBuilder.Build()
 	return meta, nil

--- a/pkg/discovery/probe/type.go
+++ b/pkg/discovery/probe/type.go
@@ -1,25 +1,29 @@
 package probe
 
+// TODO we will re-include provisioned commodities sold by node later.
 type NodeResourceStat struct {
-	vCpuCapacity           float64
-	vCpuUsed               float64
-	vMemCapacity           float64
-	vMemUsed               float64
-	cpuProvisionedCapacity float64
-	cpuProvisionedUsed     float64
-	memProvisionedCapacity float64
-	memProvisionedUsed     float64
+	vCpuCapacity float64
+	vCpuUsed     float64
+	vMemCapacity float64
+	vMemUsed     float64
+	//cpuProvisionedCapacity float64
+	//cpuProvisionedUsed     float64
+	//memProvisionedCapacity float64
+	//memProvisionedUsed     float64
 }
 
+// TODO we will re-include provisioned commodities bought by pod later.
 type PodResourceStat struct {
-	vCpuCapacity           float64
-	vCpuUsed               float64
-	vMemCapacity           float64
-	vMemUsed               float64
-	cpuProvisionedCapacity float64
-	cpuProvisionedUsed     float64
-	memProvisionedCapacity float64
-	memProvisionedUsed     float64
+	vCpuCapacity float64
+	vCpuReserved float64
+	vCpuUsed     float64
+	vMemCapacity float64
+	vMemReserved float64
+	vMemUsed     float64
+	//cpuProvisionedCapacity float64
+	//cpuProvisionedUsed     float64
+	//memProvisionedCapacity float64
+	//memProvisionedUsed     float64
 }
 
 type ApplicationResourceStat struct {

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -81,9 +81,9 @@ func (f *SupplyChainFactory) buildNodeSupplyBuilder() (*proto.TemplateDTO, error
 	nodeSupplyChainNodeBuilder = nodeSupplyChainNodeBuilder.
 		Sells(vCpuTemplateComm).
 		Sells(vMemTemplateComm).
-		Sells(cpuProvisionedTemplateComm).
-		Sells(memProvisionedTemplateComm).
-		Sells(applicationTemplateComm).
+		// TODO we will re-include provisioned commodities sold by node later.
+		//Sells(cpuProvisionedTemplateComm).
+		//Sells(memProvisionedTemplateComm)
 		Sells(clusterTemplateComm)
 
 	return nodeSupplyChainNodeBuilder.Create()
@@ -97,8 +97,9 @@ func (f *SupplyChainFactory) buildPodSupplyBuilder() (*proto.TemplateDTO, error)
 		Sells(vMemTemplateComm).
 		Sells(applicationTemplateComm).
 		Provider(proto.EntityDTO_VIRTUAL_MACHINE, proto.Provider_HOSTING).
-		Buys(cpuProvisionedTemplateComm).
-		Buys(memProvisionedTemplateComm).
+		// TODO we will re-include provisioned commodities bought by pod later.
+		//Buys(cpuProvisionedTemplateComm).
+		//Buys(memProvisionedTemplateComm).
 		Buys(clusterTemplateComm)
 
 	// Link from Pod to VM
@@ -106,8 +107,8 @@ func (f *SupplyChainFactory) buildPodSupplyBuilder() (*proto.TemplateDTO, error)
 	vmPodExtLinkBuilder.Link(proto.EntityDTO_CONTAINER_POD, proto.EntityDTO_VIRTUAL_MACHINE, proto.Provider_HOSTING).
 		Commodity(vCpuType, false).
 		Commodity(vMemType, false).
-		Commodity(cpuProvisionedType, false).
-		Commodity(memProvisionedType, false).
+		//Commodity(cpuProvisionedType, false).
+		//Commodity(memProvisionedType, false).
 		Commodity(vmPMAccessType, true).
 		Commodity(clusterType, true)
 

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/commodity_dto_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/commodity_dto_builder.go
@@ -99,6 +99,14 @@ func (cb *CommodityDTOBuilder) Used(used float64) *CommodityDTOBuilder {
 	return cb
 }
 
+func (cb *CommodityDTOBuilder) Reservation(reservation float64) *CommodityDTOBuilder {
+	if cb.err != nil {
+		return cb
+	}
+	cb.reservation = &reservation
+	return cb
+}
+
 func (cb *CommodityDTOBuilder) Resizable(resizable bool) *CommodityDTOBuilder {
 	if cb.err != nil {
 		return cb


### PR DESCRIPTION
Now cpu/mem request of a pod is represented as reservation value of vCpu/vMem Commodity bought by ContainerPod. 
Provisioned Commodities are temporarily commented out as there is error in the capacity at the server side. 
ApplicationCommodity sold by Node is also removed.