### PR TITLE
Use UID of Pod as UUID

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -427,31 +427,31 @@
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/builder",
-			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
+			"Rev": "fa68475241847c8d1791403a7795c5cfde5577a9"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer",
-			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
+			"Rev": "fa68475241847c8d1791403a7795c5cfde5577a9"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/probe",
-			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
+			"Rev": "fa68475241847c8d1791403a7795c5cfde5577a9"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/proto",
-			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
+			"Rev": "fa68475241847c8d1791403a7795c5cfde5577a9"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/service",
-			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
+			"Rev": "fa68475241847c8d1791403a7795c5cfde5577a9"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/supplychain",
-			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
+			"Rev": "fa68475241847c8d1791403a7795c5cfde5577a9"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/version",
-			"Rev": "dd5c9b325cfc48b3280b81abd29b8c53f49a6570"
+			"Rev": "fa68475241847c8d1791403a7795c5cfde5577a9"
 		},
 		{
 			"ImportPath": "github.com/ugorji/go/codec",

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -52,11 +52,20 @@ func (r *ReScheduler) buildPendingReScheduleTurboAction(actionItem *proto.Action
 	error) {
 	// Find out the pod to be re-scheduled.
 	targetPod := actionItem.GetTargetSE()
-	podIdentifier := targetPod.GetId()
-	originalPod, err := util.GetPodFromIdentifier(r.kubeClient, podIdentifier)
+	if targetPod == nil {
+		return nil, errors.New("Target pod in actionItem is nil")
+	}
+
+	// TODO, as there is issue in server, find pod based on entity properties is not supported right now. Once the issue in server gets resolved, we should use the following code to find the pod.
+	//podProperties := targetPod.GetEntityProperties()
+	//foundPod, err:= util.GetPodFromProperties(h.kubeClient, targetEntityType, podProperties)
+
+	// TODO the following is a temporary fix.
+	originalPod, err := util.GetPodFromUUID(r.kubeClient, targetPod.GetId())
 	if err != nil {
-		glog.Errorf("Cannot not find pod in the cluster: %s", err)
-		return nil, fmt.Errorf("Try to move pod %s, but could not find it in the cluster.", podIdentifier)
+		glog.Errorf("Cannot not find pod %s in the cluster: %s", targetPod.GetDisplayName(), err)
+		return nil, fmt.Errorf("Try to move pod %s, but could not find it in the cluster.",
+			targetPod.GetDisplayName())
 	}
 
 	// Find out where to re-schedule the pod.

--- a/pkg/discovery/probe/application_probe.go
+++ b/pkg/discovery/probe/application_probe.go
@@ -192,6 +192,10 @@ func (this *ApplicationProbe) buildApplicationEntityDTOs(appName, podNamespaceNa
 	if _, exist := inactivePods[podNamespaceName]; exist {
 		entityDTOBuilder = entityDTOBuilder.Monitored(false)
 	}
+
+	appProperties := buildAppProperties(podNamespaceName)
+	entityDTOBuilder = entityDTOBuilder.WithProperties(appProperties)
+
 	entityDto, err := entityDTOBuilder.Create()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to build EntityDTO for application %s: %s", id, err)

--- a/pkg/discovery/probe/application_probe_util.go
+++ b/pkg/discovery/probe/application_probe_util.go
@@ -1,0 +1,68 @@
+package probe
+
+import (
+	"github.com/golang/glog"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+const (
+	// TODO currently in the server side only properties in "DEFAULT" namespaces are respected, ideally, we should use "Kubernetes-Application".
+	appPropertyNamespace = "DEFAULT"
+
+	appPropertyNameHostingPodNamespace = "Kubernetes-App-Pod-Namespace"
+
+	appPropertyNameHostingPodName = "Kubernetes-App-Pod-Name"
+)
+
+// Build properties of an application. The namespace and name of the hosting pod is stored in the properties.
+func buildAppProperties(podNamespaceName string) []*proto.EntityDTO_EntityProperty {
+	podNamespace, podName, err := BreakdownPodClusterID(podNamespaceName)
+	if err != nil {
+		glog.Errorf("Failed to build App properties: %s", err)
+		return nil
+	}
+	var properties []*proto.EntityDTO_EntityProperty
+	propertyNamespace := appPropertyNamespace
+	hostingPodNamespacePropertyName := appPropertyNameHostingPodNamespace
+	hostingPodNamespacePropertyValue := podNamespace
+	namespaceProperty := &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &hostingPodNamespacePropertyName,
+		Value:     &hostingPodNamespacePropertyValue,
+	}
+	properties = append(properties, namespaceProperty)
+
+	hostingPodNamePropertyName := appPropertyNameHostingPodName
+	hostingPodNamePropertyValue := podName
+	nameProperty := &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &hostingPodNamePropertyName,
+		Value:     &hostingPodNamePropertyValue,
+	}
+	properties = append(properties, nameProperty)
+
+	return properties
+}
+
+// Get the namespace and name of the pod, which hosts the application, from the properties of the application.
+func GetApplicationHostingPodInfoFromProperty(properties []*proto.EntityDTO_EntityProperty) (
+	hostingPodNamespace string, hostingPodName string) {
+	if properties == nil {
+		return
+	}
+	for _, property := range properties {
+		if property.GetNamespace() != appPropertyNamespace {
+			continue
+		}
+		if hostingPodNamespace == "" && property.GetName() == appPropertyNameHostingPodNamespace {
+			hostingPodNamespace = property.GetValue()
+		}
+		if hostingPodName == "" && property.GetName() == appPropertyNameHostingPodName {
+			hostingPodName = property.GetValue()
+		}
+		if hostingPodNamespace != "" && hostingPodName != "" {
+			return
+		}
+	}
+	return
+}

--- a/pkg/discovery/probe/node_probe.go
+++ b/pkg/discovery/probe/node_probe.go
@@ -295,12 +295,15 @@ func (nodeProbe *NodeProbe) buildVMEntityDTO(node *api.Node, commoditiesSold []*
 	entityDTOBuilder.SellsCommodities(commoditiesSold)
 
 	// property
-	property, err := nodeProbe.stitchingManager.BuildStitchingProperty(node.Name, stitching.Reconcile)
+	stitchingProperty, err := nodeProbe.stitchingManager.BuildStitchingProperty(node.Name, stitching.Reconcile)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to build EntityDTO for node %s: %s", node.Name, err)
 	}
-	entityDTOBuilder = entityDTOBuilder.WithProperty(property)
-	glog.V(4).Infof("Node %s will be reconciled with VM with %s: %s", node.Name, *property.Name, *property.Value)
+	entityDTOBuilder = entityDTOBuilder.WithProperty(stitchingProperty)
+	glog.V(4).Infof("Node %s will be reconciled with VM with %s: %s", node.Name, *stitchingProperty.Name, *stitchingProperty.Value)
+
+	nodeProperty := buildNodeProperties(node)
+	entityDTOBuilder = entityDTOBuilder.WithProperty(nodeProperty)
 
 	// reconciliation meta data
 	metaData, err := nodeProbe.stitchingManager.GenerateReconciliationMetaData()

--- a/pkg/discovery/probe/node_probe_util.go
+++ b/pkg/discovery/probe/node_probe_util.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 
 	"github.com/golang/glog"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
 // Check if a node is in Ready status.
@@ -20,4 +21,40 @@ func nodeIsReady(node *api.Node) bool {
 // Check if a node is schedulable.
 func nodeIsSchedulable(node *api.Node) bool {
 	return !node.Spec.Unschedulable
+}
+
+const (
+	// TODO currently in the server side only properties in "DEFAULT" namespaces are respected, ideally, we should use "Kubernetes-Node".
+	nodePropertyNamespace = "DEFAULT"
+
+	nodePropertyNameNodeName = "KubernetesNodeName"
+)
+
+// Build entity properties for a node. The name is the name of the node shown inside Kubernetes cluster.
+func buildNodeProperties(node *api.Node) *proto.EntityDTO_EntityProperty {
+	propertyNamespace := nodePropertyNamespace
+	propertyName := nodePropertyNameNodeName
+	propertyValue := node.Name
+	return &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &propertyName,
+		Value:     &propertyValue,
+	}
+}
+
+// Get node name from entity property.
+func GetNodeNameFromProperty(properties []*proto.EntityDTO_EntityProperty) (nodeName string) {
+	if properties == nil {
+		return
+	}
+	for _, property := range properties {
+		if property.GetNamespace() != nodePropertyNamespace {
+			continue
+		}
+		if property.GetName() == nodePropertyNameNodeName {
+			nodeName = property.GetValue()
+			return
+		}
+	}
+	return
 }

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_protobuf_endpoint.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_protobuf_endpoint.go
@@ -126,7 +126,7 @@ func (endpoint *ClientProtobufEndpoint) waitForServerMessage() {
 					continue
 				}
 
-				glog.V(3).Infof(logPrefix+"received: %++v\n", parsedMsg)
+				glog.V(3).Infof(logPrefix+"received message is: %++v\n", parsedMsg.ServerMsg.GetMediationServerMessage())
 
 				// Put the parsed message on the endpoint's channel
 				// - this will block till the upper layer receives this message


### PR DESCRIPTION
Previously we construct a long UUID by combining UID, namespace and name of a Pod. This guarantees the uniqueness of UUID while make it easy to retrieve pod in action executor. However, the constructed UUID can be very long, which exceeds the max length of the defined length in MySQL database. 
To solve this problem, we use only the UID of pod as the UUID (for example, in[ pod_probe.go](https://github.com/turbonomic/kubeturbo/pull/55/files#diff-dcfdfa7c7a3c8083f5d44b9f3697818bR434)). This still guarantees the uniqueness both in cluster and among clusters. While we can no longer breakdown UUID to get pod namespace and name, we wanted to store those information in entityProperties. However, since there is issue at the server side, this approach is not successful right now. I've implemented code (in [node_util](https://github.com/turbonomic/kubeturbo/pull/55/files#diff-12fc911298180ef752eaabb9424c280aR34), [pod_util](https://github.com/turbonomic/kubeturbo/pull/55/files#diff-a042b1467a7e7cc2dce052e7c821b7a6R203), [application_util](https://github.com/turbonomic/kubeturbo/pull/55/files#diff-62304032211e71a1d48f1024a2e55bbfR18)), but commented out the place (in [util](https://github.com/turbonomic/kubeturbo/pull/55/files#diff-1f59bdcd3b7d27d10eca4a5687ae3433R165)) it calls them. Currently the walk around is to find pod by listing all pods and compare UID of them against the Entity UUID received in ActionItemDTO (see [GetPodFromUUID](https://github.com/turbonomic/kubeturbo/pull/55/commits/07593660a23d703face82b9e657f7a47b7bae39e#diff-1f59bdcd3b7d27d10eca4a5687ae3433R184)). This approach works but will have a lot of overhead if there the number of pods is large or if there is too much API calls. So we want to come back to the approach of storing namespace and name in entity properties.