### PR TITLE
Changed the Key of Application Commodity as the UID of Pod

### DIFF
--- a/pkg/discovery/probe/application_probe.go
+++ b/pkg/discovery/probe/application_probe.go
@@ -152,7 +152,7 @@ func (this *ApplicationProbe) getCommoditiesBought(podNamespaceName string, appR
 	commoditiesBoughtFromPod = append(commoditiesBoughtFromPod, vMemCommBought)
 
 	appCommBought, err := builder.NewCommodityDTOBuilder(proto.CommodityDTO_APPLICATION).
-		Key(podNamespaceName).
+		Key(turboPodUUID).
 		Create()
 	if err != nil {
 		return nil, err

--- a/pkg/discovery/probe/pod_probe.go
+++ b/pkg/discovery/probe/pod_probe.go
@@ -314,7 +314,6 @@ func (podProbe *PodProbe) getPodResourceStat(pod *api.Pod, podContainers map[str
 func (podProbe *PodProbe) getCommoditiesSold(pod *api.Pod, podResourceStat *PodResourceStat) (
 	[]*proto.CommodityDTO, error) {
 
-	podNameWithNamespace := pod.Namespace + "/" + pod.Name
 	var commoditiesSold []*proto.CommodityDTO
 	vMem, err := builder.NewCommodityDTOBuilder(proto.CommodityDTO_VMEM).
 		Capacity(float64(podResourceStat.vMemCapacity)).
@@ -337,7 +336,7 @@ func (podProbe *PodProbe) getCommoditiesSold(pod *api.Pod, podResourceStat *PodR
 	commoditiesSold = append(commoditiesSold, vCpu)
 
 	appComm, err := builder.NewCommodityDTOBuilder(proto.CommodityDTO_APPLICATION).
-		Key(podNameWithNamespace).
+		Key(string(pod.UID)).
 		Capacity(1E10).
 		Create()
 	if err != nil {


### PR DESCRIPTION
the key of Application commodity used to be namespace/name of a pod. Although this key is unique within a single Kubernetes cluster, if there is multiple clusters, it is possible there is application commodities with the same key as namespace/name is not guaranteed to be unique across cluster.

So we change the key to the UID of pod.