### PR TITLE
Expose Kubelet Https and Port Option

### DIFF
--- a/pkg/discovery/monitoring/kubelet/config.go
+++ b/pkg/discovery/monitoring/kubelet/config.go
@@ -11,11 +11,11 @@ import (
 const (
 	APIVersion = "v1"
 
-	defaultKubeletPort        = 10255
-	disableKubeletHttps       = false
-	defaultUseServiceAccount  = false
-	defaultServiceAccountFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	defaultInClusterConfig    = true
+	DefaultKubeletPort        uint = 10255
+	DefaultKubeletHttps            = false
+	defaultUseServiceAccount       = false
+	defaultServiceAccountFile      = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	defaultInClusterConfig         = true
 )
 
 type KubeletMonitorConfig struct {
@@ -32,15 +32,25 @@ func (c KubeletMonitorConfig) GetMonitoringSource() types.MonitoringSource {
 
 // Create a new Kubelet monitor config using kubeConfig.
 // TODO Add port and https later.
-func NewKubeletMonitorConfig(kubeConfig *restclient.Config) (*KubeletMonitorConfig, error) {
+func NewKubeletMonitorConfig(kubeConfig *restclient.Config) *KubeletMonitorConfig {
 	kubeletConfig := &kubeletclient.KubeletClientConfig{
-		Port:            uint(defaultKubeletPort),
-		EnableHttps:     disableKubeletHttps,
+		Port:            uint(DefaultKubeletPort),
+		EnableHttps:     DefaultKubeletHttps,
 		TLSClientConfig: kubeConfig.TLSClientConfig,
 		BearerToken:     kubeConfig.BearerToken,
 	}
 
 	return &KubeletMonitorConfig{
 		KubeletClientConfig: kubeletConfig,
-	}, nil
+	}
+}
+
+func (kc *KubeletMonitorConfig) WithPort(port uint) *KubeletMonitorConfig {
+	kc.Port = port
+	return kc
+}
+
+func (kc *KubeletMonitorConfig) EnableHttps(enable bool) *KubeletMonitorConfig {
+	kc.KubeletClientConfig.EnableHttps = enable
+	return kc
 }


### PR DESCRIPTION
Exposed Kubelet https and port option.
By default, https is **disabled** and the kubelet port is `10255`, which is a `http` port of kubelet.

So when running in openshift, the following parameters should be provided to kubeturbo:

```
	 --kubelet-https=true 
	 --kubelet-port=10250 
```
So the pod definition will change to 
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: kubeturbo
  labels:
    name: kubeturbo
spec:
  nodeSelector:
    role: master
  containers:
  - name: kubeturbo
    image: vmturbo/kubeturbo:<VERSION>
    command:
      - /bin/kubeturbo
    args:
      - --v=3
      - --kubeconfig=/etc/kubeturbo/admin.kubeconfig
      - --turboconfig=/etc/kubeturbo/config
      - --kubelet-https=true
      - --kubelet-port=10250
    volumeMounts:
    - name: turbo-config
      mountPath: /etc/kubeturbo
      readOnly: true
  volumes:
  - name: turbo-config
    hostPath:
      path: /etc/kubeturbo
  restartPolicy: Always```