### PR TITLE
deploy on Openshift with special image, fewer input

### DIFF
--- a/deploy/kubeturbo-for-openshift/README.md
+++ b/deploy/kubeturbo-for-openshift/README.md
@@ -2,141 +2,11 @@
 
 This guide is about how to deploy **Kubeturbo** service in **OpenShift**.
 
-### Create cAdvisor DaemonSet
-
-**cAdvisor** is required for working with Kubeturbo. However, the cAdvisor port is closed by default in OpenShift. So we need to deploy cAdvisor onto every node in the cluster.
-
-#### Step One: Create ServiceAccount
-A ServiceAccount is needed for cAdvisor pods to access the OpenShift cluster.
-
-##### Define Turbo-user Service Account
-
-```yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: turbo-user
-  namespace: default
-```
-
-[Download example](turbo-user-service-account.yaml?raw=true)
-
-Then you would see turbo-user when you list service accounts in OpenShift.
-
-```console
-$oc get sa --namespace=default
-NAMESPACE          NAME                        SECRETS   AGE
-default            builder                     2         62d
-default            default                     2         62d
-default            deployer                    2         62d
-default            registry                    2         62d
-default            router                      2         62d
-default            turbo-user                  2         25s
-```
-
-#### Step Two: Edit Security Context Constraint
-In OpenShift, security context constraints allow administrator to control permissions for pods. As cAdvisor pods need privileged permissions, you need to add turbo-user service account to proper security context constraints. Here turbo-user is added to *privileged* security context constraint.
-
-```console
-$oc edit scc privileged
-```
-
-Then add "*system:serviceaccount:default:turbo-user*" under users, as shown
-
-```console
-users:
-- system:serviceaccount:openshift-infra:build-controller
-- system:serviceaccount:management-infra:management-admin
-- system:serviceaccount:management-infra:inspector-admin
-- system:serviceaccount:default:router
-- system:serviceaccount:default:registry
-- system:serviceaccount:default:turbo-user
-- admin
-- system
-- root
-```
-
-#### Step Three: Define cAdvisor DaemonSet
-
-```yaml
-apiVersion: extensions/v1beta1
-kind: DaemonSet
-metadata:
-  name: cadvisor
-  namespace: default
-  labels:
-    name: cadvisor
-spec:
-  template:
-    metadata:
-      labels:
-        name: cadvisor
-    spec:
-      containers:
-      - name: cadvisor
-        image: google/cadvisor:latest
-        securityContext:
-          privileged: true
-        ports:
-          - name: http
-            containerPort: 8080
-            hostPort: 9999
-        volumeMounts:
-          - name: rootfs
-            mountPath: /rootfs
-            readOnly: true
-          - name: varrun
-            mountPath: /var/run
-            readOnly: false
-          - name: varlibdocker
-            mountPath: /var/lib/docker
-            readOnly: true
-          - name: sysfs
-            mountPath: /sys
-            readOnly: true
-      serviceAccount: turbo-user
-      volumes:
-        - name: rootfs
-          hostPath:
-            path: /
-        - name: varrun
-          hostPath:
-            path: /var/run
-        - name: varlibdocker
-          hostPath:
-            path: /var/lib/docker
-        - name: sysfs
-          hostPath:
-            path: /sys
-```
-[Download example](cadvisor-daemonsets.yaml?raw=true)
-
-#### Step Four: Deploy cAdvisor DaemonSet
-
-```console
-$oc create -f cadvisor-daemonset.yaml
-daemonset "cadvisor" created
-
-$oc get ds
-NAME       DESIRED   CURRENT   NODE-SELECTOR   AGE
-cadvisor   3         3         <none>          4m
-
-$oc get po
-NAME                         READY     STATUS    RESTARTS   AGE
-cadvisor-5iyt4               1/1       Running   0          4m
-cadvisor-918d2               1/1       Running   0          4m
-cadvisor-bii3n               1/1       Running   0          4m
-```
-
-
-### Deploy Kubeturbo Service
-Now cAdvisor is up and running on every node, we are ready to deploy Kubeturbo Service.
-
-#### Step One: Label Master Node
+### Step One: Label Master Node
 As Kubeturbo is suggested to run on the master node, we need to create label for the Master node. To label the master node, simply execute the following command
 
 ```console
-$oc label nodes <MASTER_NODE_NAME> role=master
+$oc label nodes <MASTER_NODE_NAME> role=kubeturbo
 ```
 
 To see the labels on master node (*which is 10.10.174.81 in this example*),
@@ -144,15 +14,15 @@ To see the labels on master node (*which is 10.10.174.81 in this example*),
 ```console
 $oc get no --show-labels
 NAME           STATUS    AGE       LABELS
-10.10.174.81   Ready     62d       kubernetes.io/hostname=10.10.174.81,region=primary,role=master
+10.10.174.81   Ready     62d       kubernetes.io/hostname=10.10.174.81,region=primary,role=kubeturbo
 10.10.174.82   Ready     62d       kubernetes.io/hostname=10.10.174.82,region=primary
 10.10.174.83   Ready     62d       kubernetes.io/hostname=10.10.174.83,region=primary
 ```
 
-#### Step Two: Get Kubeconfig
+### Step Two: Get Kubeconfig
 A kubeconfig with proper permission is required for Kubeturbo service to interact with kube-apiserver. If you have successfully started up your OpenShift cluster, you will find admin.kubeconfig under /etc/origin/master. Copy this kubeconfig file to /etc/kubeturbo/.
 
-#### Step Three: Create Kubeturbo config
+### Step Three: Create Kubeturbo config
 
 A Kubeturbo config is required for Kubeturbo service to connect to Ops Manager server remotely. You need to specify correct **Turbonomic Server address**, **username** and **password**.
 **NOTE**: Turbonomic server address is "**IP address of your ops manager**".
@@ -181,7 +51,7 @@ Create a file called **"config"** and put it under */etc/kubeturbo/*.
 ```
 you can find an example [here](../config).
 
-#### Step Four: Create Kubeturbo Pod
+### Step Four: Create Kubeturbo Pod
 
 Make sure you have **admin.kubeconfig** and **config** under */etc/kubeturbo*.
 
@@ -196,17 +66,13 @@ metadata:
     name: kubeturbo
 spec:
   nodeSelector:
-    role: master
+    role: kubeturbo
   containers:
   - name: kubeturbo
-    image: vmturbo/kubeturbo:latest
-    command:
-      - /bin/kubeturbo
+    image: vmturbo/kubeturbo:os35
     args:
-      - --v=3
       - --kubeconfig=/etc/kubeturbo/admin.kubeconfig
       - --turboconfig=/etc/kubeturbo/config
-      - --cadvisor-port=9999
     volumeMounts:
     - name: turbo-config
       mountPath: /etc/kubeturbo
@@ -228,10 +94,7 @@ pod "kubeturbo" created
 
 $oc get pods --all-namespaces
 NAME                         READY     STATUS    RESTARTS   AGE
-cadvisor-5iyt4               1/1       Running   0          5m
-cadvisor-918d2               1/1       Running   0          5m
-cadvisor-bii3n               1/1       Running   0          5m
-kubeturbo                    2/2       Running   0          54s
+kubeturbo                    1/1       Running   0          54s
 ```
 
 ### Deploy K8sconntrack

--- a/deploy/kubeturbo-for-openshift/kubeturbo-openshift.yaml
+++ b/deploy/kubeturbo-for-openshift/kubeturbo-openshift.yaml
@@ -6,17 +6,13 @@ metadata:
     name: kubeturbo
 spec:
   nodeSelector:
-    role: master
+    role: kubeturbo
   containers:
   - name: kubeturbo
-    image: vmturbo/kubeturbo:lastest
-    command:
-      - /bin/kubeturbo
+    image: vmturbo/kubeturbo:os35
     args:
-      - --v=3
       - --kubeconfig=/etc/kubeturbo/admin.kubeconfig
       - --turboconfig=/etc/kubeturbo/config
-      - --cadvisor-port=9999
     volumeMounts:
     - name: vmt-config
       mountPath: /etc/kubeturbo

--- a/docker/openshift/build.sh
+++ b/docker/openshift/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 kubeturbo=../../_output/kubeturbo.linux
-img=vmturbo/kubeturbo:os34
+img=vmturbo/kubeturbo:os35
 
 cp $kubeturbo ./
 

--- a/docker/openshift/run_kubeturbo.sh
+++ b/docker/openshift/run_kubeturbo.sh
@@ -3,10 +3,10 @@
 kubebin=/bin/kubeturbo
 
 logv=3
-k8sVersion=1.4.0
+k8sVersion=1.5.0
 kubelet_https=true
 kubelet_port=10250
-usevmware=true
+usevmware=false
 alsologtostderr=true
 
 master=""


### PR DESCRIPTION
(1) A dedicated docker image is for openshift. 
    With this image, fewer input is needed when to deploy kubeturbo in Openshift cluster.

(2) Since the new discovery framework gets data from kubelet, cAdvisor is not needed anymore.
    The instructions about deploy cAdvisor are deleted in the document.