### PR TITLE
refactor kubeletClient for actionHandler.resize

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -62,7 +62,7 @@ type VMTServer struct {
 	UseVMWare bool
 
 	// Kubelet related config
-	KubeletPort        uint
+	KubeletPort        int
 	EnableKubeletHttps bool
 
 	// for Move Action
@@ -90,7 +90,7 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeConfig, "kubeconfig", s.KubeConfig, "Path to kubeconfig file with authorization and master location information.")
 	fs.BoolVar(&s.EnableProfiling, "profiling", false, "Enable profiling via web interface host:port/debug/pprof/.")
 	fs.BoolVar(&s.UseVMWare, "usevmware", false, "If the underlying infrastructure is VMWare.")
-	fs.UintVar(&s.KubeletPort, "kubelet-port", kubelet.DefaultKubeletPort, "The port of the kubelet runs on")
+	fs.IntVar(&s.KubeletPort, "kubelet-port", kubelet.DefaultKubeletPort, "The port of the kubelet runs on")
 	fs.BoolVar(&s.EnableKubeletHttps, "kubelet-https", kubelet.DefaultKubeletHttps, "Indicate if Kubelet is running on https server")
 	fs.StringVar(&s.K8sVersion, "k8sVersion", executor.HigherK8sVersion, "the kubernetes server version; for openshift, it is the underlying Kubernetes' version.")
 	fs.StringVar(&s.NoneSchedulerName, "noneSchedulerName", executor.DefaultNoneExistSchedulerName, "a none-exist scheduler name, to prevent controller to create Running pods during move Action.")
@@ -110,29 +110,42 @@ func createRecorder(kubecli *kubernetes.Clientset) record.EventRecorder {
 	return eventBroadcaster.NewRecorder(scheme.Scheme, apiv1.EventSource{Component: "kubeturbo"})
 }
 
-func (s *VMTServer) createKubeConfig() (*restclient.Config, error) {
+func (s *VMTServer) createKubeConfigOrDie() *restclient.Config {
 	kubeConfig, err := clientcmd.BuildConfigFromFlags(s.Master, s.KubeConfig)
 	if err != nil {
-		glog.Errorf("Error getting kubeconfig:  %s", err)
-		return nil, err
+		panic(fmt.Sprintf("Error getting kubeconfig:  %s", err))
 	}
 	// This specifies the number and the max number of query per second to the api server.
 	kubeConfig.QPS = 20.0
 	kubeConfig.Burst = 30
 
-	return kubeConfig, nil
+	return kubeConfig
 }
 
-func (s *VMTServer) createKubeClient(kubeConfig *restclient.Config) (*kubernetes.Clientset, error) {
+func (s *VMTServer) createKubeClientOrDie(kubeConfig *restclient.Config) *kubernetes.Clientset {
 	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
-		glog.Fatalf("Invalid API configuration: %v", err)
+		panic(fmt.Sprintf("Failed to create kubeClient:%v", err))
 	}
 
-	return kubeClient, nil
+	return kubeClient
 }
 
-func (s *VMTServer) createProbeConfig(kubeConfig *restclient.Config) (*configs.ProbeConfig, error) {
+func (s *VMTServer) createKubeletClientOrDie(kubeConfig *restclient.Config) *kubelet.KubeletClient {
+	kubeletClient, err := kubelet.NewKubeletConfig(kubeConfig).
+		WithPort(s.KubeletPort).
+		EnableHttps(s.EnableKubeletHttps).
+		//Timeout(to).
+		Create()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create kubeletClient: %v", err))
+	}
+
+	return kubeletClient
+}
+
+// panic on error
+func (s *VMTServer) createProbeConfigOrDie(kubeConfig *restclient.Config, kubeletClient *kubelet.KubeletClient) *configs.ProbeConfig {
 	if s.CAdvisorPort == 0 {
 		s.CAdvisorPort = K8sCadvisorPort
 	}
@@ -146,12 +159,13 @@ func (s *VMTServer) createProbeConfig(kubeConfig *restclient.Config) (*configs.P
 	}
 
 	// Create Kubelet monitoring
-	kubeletMonitoringConfig := kubelet.NewKubeletMonitorConfig(kubeConfig).WithPort(s.KubeletPort).EnableHttps(s.EnableKubeletHttps)
+	kubeletMonitoringConfig := kubelet.NewKubeletMonitorConfig(kubeletClient)
 
 	// Create cluster monitoring
 	masterMonitoringConfig, err := master.NewClusterMonitorConfig(kubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build monitoring config for master topology monitor: %s", err)
+		msg := fmt.Sprintf("Failed to build monitor-config for master topology mointor: %v", err)
+		panic(msg)
 	}
 
 	// TODO for now kubelet is the only monitoring source. As we have more sources, we should choose what to be added into the slice here.
@@ -171,7 +185,7 @@ func (s *VMTServer) createProbeConfig(kubeConfig *restclient.Config) (*configs.P
 		MonitoringConfigs:     monitoringConfigs,
 	}
 
-	return probeConfig, nil
+	return probeConfig
 }
 
 func (s *VMTServer) checkFlag() error {
@@ -209,31 +223,24 @@ func (s *VMTServer) Run(_ []string) error {
 		os.Exit(1)
 	}
 
-	kubeConfig, err := s.createKubeConfig()
-	if err != nil {
-		glog.Error(err)
-	}
-
-	kubeClient, err := s.createKubeClient(kubeConfig)
-	if err != nil {
-		glog.Errorf("Failed to get kubeClient: %v", err.Error())
-		os.Exit(1)
-	}
-
-	probeConfig, err := s.createProbeConfig(kubeConfig)
-	if err != nil {
-		glog.Errorf("Failed to build probe config: %s")
-		os.Exit(1)
-	}
-
+	kubeConfig := s.createKubeConfigOrDie()
+	kubeClient := s.createKubeClientOrDie(kubeConfig)
+	kubeletClient := s.createKubeletClientOrDie(kubeConfig)
+	probeConfig := s.createProbeConfigOrDie(kubeConfig, kubeletClient)
 	broker := turbostore.NewPodBroker()
-	vmtConfig := kubeturbo.NewVMTConfig(kubeClient, probeConfig, broker, k8sTAPSpec, s.K8sVersion, s.NoneSchedulerName)
+
+	vmtConfig := kubeturbo.NewVMTConfig2()
+	vmtConfig.WithTapSpec(k8sTAPSpec).
+		WithKubeClient(kubeClient).
+		WithKubeletClient(kubeletClient).
+		WithProbeConfig(probeConfig).
+		WithBroker(broker).
+		WithK8sVersion(s.K8sVersion).
+		WithNoneScheduler(s.NoneSchedulerName).
+		WithRecorder(createRecorder(kubeClient))
 	glog.V(3).Infof("Finished creating turbo configuration: %+v", vmtConfig)
 
-	vmtConfig.Recorder = createRecorder(kubeClient)
-
 	vmtService := kubeturbo.NewKubeturboService(vmtConfig)
-
 	run := func(_ <-chan struct{}) {
 		vmtService.Run()
 		select {}

--- a/pkg/discovery/monitoring/kubelet/config.go
+++ b/pkg/discovery/monitoring/kubelet/config.go
@@ -1,25 +1,12 @@
 package kubelet
 
 import (
-	restclient "k8s.io/client-go/rest"
-
-	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
-
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
 )
 
-const (
-	APIVersion = "v1"
-
-	DefaultKubeletPort        uint = 10255
-	DefaultKubeletHttps            = false
-	defaultUseServiceAccount       = false
-	defaultServiceAccountFile      = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	defaultInClusterConfig         = true
-)
-
 type KubeletMonitorConfig struct {
-	*kubeletclient.KubeletClientConfig
+	//a kubeletClient or a kubeletConfig?
+	kubeletClient *KubeletClient
 }
 
 // Implement MonitoringWorkerConfig interface.
@@ -30,27 +17,8 @@ func (c KubeletMonitorConfig) GetMonitoringSource() types.MonitoringSource {
 	return types.KubeletSource
 }
 
-// Create a new Kubelet monitor config using kubeConfig.
-// TODO Add port and https later.
-func NewKubeletMonitorConfig(kubeConfig *restclient.Config) *KubeletMonitorConfig {
-	kubeletConfig := &kubeletclient.KubeletClientConfig{
-		Port:            uint(DefaultKubeletPort),
-		EnableHttps:     DefaultKubeletHttps,
-		TLSClientConfig: kubeConfig.TLSClientConfig,
-		BearerToken:     kubeConfig.BearerToken,
-	}
-
+func NewKubeletMonitorConfig(kclient *KubeletClient) *KubeletMonitorConfig {
 	return &KubeletMonitorConfig{
-		KubeletClientConfig: kubeletConfig,
+		kubeletClient: kclient,
 	}
-}
-
-func (kc *KubeletMonitorConfig) WithPort(port uint) *KubeletMonitorConfig {
-	kc.Port = port
-	return kc
-}
-
-func (kc *KubeletMonitorConfig) EnableHttps(enable bool) *KubeletMonitorConfig {
-	kc.KubeletClientConfig.EnableHttps = enable
-	return kc
 }

--- a/pkg/discovery/monitoring/kubelet/kubelet_client.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_client.go
@@ -2,45 +2,43 @@ package kubelet
 
 import (
 	"fmt"
+	"github.com/golang/glog"
 	"net/http"
 	"net/url"
-
-	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
-	kClient "k8s.io/kubernetes/pkg/kubelet/client"
-
-	"github.com/turbonomic/kubeturbo/pkg/discovery/util/httputil"
+	"time"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util/httputil"
+	netutil "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
 
 const (
 	summaryPath string = "/stats/summary/"
 	specPath    string = "/spec"
+
+	DefaultKubeletPort  = 10255
+	DefaultKubeletHttps = false
+
+	defaultConnTimeOut         = 20 * time.Second
+	defaultTLSHandShakeTimeout = 10 * time.Second
 )
 
-type Host struct {
-	IP       string
-	Port     int
-	Resource string
-}
-
-type kubeletClient struct {
-	config *kClient.KubeletClientConfig
+// Since http.Client is thread safe (https://golang.org/src/net/http/client.go)
+// KubeletClient is also thread-safe if concurrent goroutines won't change the fields.
+type KubeletClient struct {
 	client *http.Client
+	scheme string
+	port   int
 }
 
-func (kc *kubeletClient) GetPort() int {
-	return int(kc.config.Port)
-}
-
-func (kc *kubeletClient) GetSummary(host Host) (*stats.Summary, error) {
+func (kc *KubeletClient) GetSummary(host string) (*stats.Summary, error) {
 	requestURL := url.URL{
-		Scheme: "http",
-		Host:   fmt.Sprintf("%s:%d", host.IP, host.Port),
+		Scheme: kc.scheme,
+		Host:   fmt.Sprintf("%s:%d", host, kc.port),
 		Path:   summaryPath,
-	}
-	if kc.config != nil && kc.config.EnableHttps {
-		requestURL.Scheme = "https"
 	}
 
 	req, err := http.NewRequest("GET", requestURL.String(), nil)
@@ -53,14 +51,11 @@ func (kc *kubeletClient) GetSummary(host Host) (*stats.Summary, error) {
 	return summary, err
 }
 
-func (kc *kubeletClient) GetMachineInfo(host Host) (*cadvisorapi.MachineInfo, error) {
+func (kc *KubeletClient) GetMachineInfo(host string) (*cadvisorapi.MachineInfo, error) {
 	requestURL := url.URL{
-		Scheme: "http",
-		Host:   fmt.Sprintf("%s:%d", host.IP, host.Port),
+		Scheme: kc.scheme,
+		Host:   fmt.Sprintf("%s:%d", host, kc.port),
 		Path:   specPath,
-	}
-	if kc.config != nil && kc.config.EnableHttps {
-		requestURL.Scheme = "https"
 	}
 	req, err := http.NewRequest("GET", requestURL.String(), nil)
 	if err != nil {
@@ -71,18 +66,124 @@ func (kc *kubeletClient) GetMachineInfo(host Host) (*cadvisorapi.MachineInfo, er
 	return &minfo, err
 }
 
-// Create a new Kubelet client from kubeletConfig.
-func NewKubeletClient(kubeletConfig *kClient.KubeletClientConfig) (*kubeletClient, error) {
-	transport, err := kClient.MakeTransport(kubeletConfig)
+// get machine single-core Frequency, in Khz
+func (kc *KubeletClient) GetMachineCpuFrequency(host string) (uint64, error) {
+	minfo, err := kc.GetMachineInfo(host)
+	if err != nil {
+		glog.Errorf("failed to get machine[%s] cpu.frequency: %v", host, err)
+		return 0, err
+	}
+
+	return minfo.CpuFrequency, nil
+}
+
+//----------------- kubeletConfig -----------------------------------
+type KubeletConfig struct {
+	kubeConfig  *rest.Config
+	enableHttps bool
+	port        int
+	timeout     time.Duration // timeout when fetching information from kubelet;
+	tlsTimeOut  time.Duration
+}
+
+// Create a new KubeletConfig based on kubeConfig.
+func NewKubeletConfig(kubeConfig *rest.Config) *KubeletConfig {
+	return &KubeletConfig{
+		kubeConfig:  kubeConfig,
+		port:        DefaultKubeletPort,
+		enableHttps: DefaultKubeletHttps,
+		timeout:     defaultConnTimeOut,
+		tlsTimeOut:  defaultTLSHandShakeTimeout,
+	}
+}
+
+func (kc *KubeletConfig) WithPort(port int) *KubeletConfig {
+	kc.port = port
+	return kc
+}
+
+func (kc *KubeletConfig) EnableHttps(enable bool) *KubeletConfig {
+	kc.enableHttps = enable
+	return kc
+}
+
+func (kc *KubeletConfig) Timeout(timeout int) *KubeletConfig {
+	kc.timeout = time.Duration(timeout) * time.Second
+	return kc
+}
+
+func (kc *KubeletConfig) Create() (*KubeletClient, error) {
+	//1. http transport
+	transport, err := makeTransport(kc.kubeConfig, kc.enableHttps, kc.tlsTimeOut)
 	if err != nil {
 		return nil, err
 	}
 	c := &http.Client{
 		Transport: transport,
-		Timeout:   kubeletConfig.HTTPTimeout,
+		Timeout:   kc.timeout,
 	}
-	return &kubeletClient{
-		config: kubeletConfig,
+
+	//2. scheme
+	scheme := "http"
+	if kc.enableHttps {
+		scheme = "https"
+	}
+
+	//3. create a KubeletClient
+	return &KubeletClient{
 		client: c,
+		scheme: scheme,
+		port:   kc.port,
 	}, nil
+}
+
+//------------Generate a http.Transport based on rest.Config-------------------
+// Note: Following code is copied from Heapster
+// https://github.com/kubernetes/heapster/blob/d2a1cf189921a68edd025d034ebdb348d7587509/metrics/sources/kubelet/util/kubelet_client.go#L48
+// The reason to copy the code from Heapster, instead of using kubernetes/pkg/kubelet/client.MakeTransport(), is that
+// Depending on Kubernetes will make it difficult to maintain the package dependency.
+// So I copied this code, which only depending on "k8s.io/client-go".
+func makeTransport(config *rest.Config, enableHttps bool, timeout time.Duration) (http.RoundTripper, error) {
+	//1. get transport.config
+	cfg := transportConfig(config, enableHttps)
+	tlsConfig, err := transport.TLSConfigFor(cfg)
+	if err != nil {
+		glog.Errorf("failed to get TLSConfig: %v", err)
+		return nil, err
+	}
+	if tlsConfig == nil {
+		glog.Warningf("tlsConfig is nil.")
+	}
+
+	//2. http client
+	rt := http.DefaultTransport
+	if tlsConfig != nil {
+		rt = netutil.SetOldTransportDefaults(&http.Transport{
+			TLSClientConfig:     tlsConfig,
+			TLSHandshakeTimeout: timeout,
+		})
+	}
+
+	return transport.HTTPWrappersForConfig(cfg, rt)
+}
+
+func transportConfig(config *rest.Config, enableHttps bool) *transport.Config {
+	cfg := &transport.Config{
+		TLS: transport.TLSConfig{
+			CAFile:   config.CAFile,
+			CAData:   config.CAData,
+			CertFile: config.CertFile,
+			CertData: config.CertData,
+			KeyFile:  config.KeyFile,
+			KeyData:  config.KeyData,
+		},
+		BearerToken: config.BearerToken,
+	}
+
+	if enableHttps && !cfg.HasCA() {
+		cfg.TLS.Insecure = true
+		glog.Warning("insecure TLS transport.")
+	}
+
+	return cfg
 }


### PR DESCRIPTION

1. Promote kubeletClient to a higher place (VMT Config.KubeletClient):
    So that kubeletClient can be used in package Discovery as well as in package ActionHander.
    For resize(CPU capacity) action,  we have to convert CPU Capacity in frequency into CPU cores.
    **kubeletClient is needed to get node CPU frequency to make this conversion possible.**  This is the main reason for this refactor.

2. Refactor KubeletClient: 
     change dependency from "k8s.io/Kubernetes" to "k8s.io/client-go".  I think this will make it easier to maintain the dependency.
