### PR TITLE
update go-sdk to fix stitchingCapacity problem

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -206,31 +206,31 @@
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/builder",
-			"Rev": "b03f7f5f1cfdb9239186f0401855cc6f5b5106f4"
+			"Rev": "72f1a7a672eb7fb639e0b6d3d73362c719916323"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer",
-			"Rev": "b03f7f5f1cfdb9239186f0401855cc6f5b5106f4"
+			"Rev": "72f1a7a672eb7fb639e0b6d3d73362c719916323"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/probe",
-			"Rev": "b03f7f5f1cfdb9239186f0401855cc6f5b5106f4"
+			"Rev": "72f1a7a672eb7fb639e0b6d3d73362c719916323"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/proto",
-			"Rev": "b03f7f5f1cfdb9239186f0401855cc6f5b5106f4"
+			"Rev": "72f1a7a672eb7fb639e0b6d3d73362c719916323"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/service",
-			"Rev": "b03f7f5f1cfdb9239186f0401855cc6f5b5106f4"
+			"Rev": "72f1a7a672eb7fb639e0b6d3d73362c719916323"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/supplychain",
-			"Rev": "b03f7f5f1cfdb9239186f0401855cc6f5b5106f4"
+			"Rev": "72f1a7a672eb7fb639e0b6d3d73362c719916323"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-go-sdk/pkg/version",
-			"Rev": "b03f7f5f1cfdb9239186f0401855cc6f5b5106f4"
+			"Rev": "72f1a7a672eb7fb639e0b6d3d73362c719916323"
 		},
 		{
 			"ImportPath": "github.com/ugorji/go/codec",

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -153,7 +153,9 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesSold(pod *api.Pod, cpuFrequ
 
 	// vmpmAccess commodity
 	podAccessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
-		Key(string(pod.UID)).Create()
+		Key(string(pod.UID)).
+		Capacity(accessCommodityDefaultCapacity).
+		Create()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -223,8 +223,9 @@ func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_Re
 	default:
 		return nil, fmt.Errorf("Stitching property type %s is not supported.", s.stitchingPropertyType)
 	}
-	replacementEntityMetaDataBuilder.PatchSelling(proto.CommodityDTO_CLUSTER).
-		PatchSelling(proto.CommodityDTO_VMPM_ACCESS)
+	propertyNames := []string{builder.PropertyCapacity, builder.PropertyUsed}
+	replacementEntityMetaDataBuilder.PatchSellingWithProperty(proto.CommodityDTO_CLUSTER, propertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_VMPM_ACCESS, propertyNames)
 	meta := replacementEntityMetaDataBuilder.Build()
 	return meta, nil
 }

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/replacement_entity_meta_data_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/replacement_entity_meta_data_builder.go
@@ -4,6 +4,20 @@ import (
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
+const (
+	PropertyUsed = "used"
+	PropertyCapacity = "capacity"
+	PropertyResizable = "resizable"
+	PropertyLimit = "limit"
+	PropertyPeak = "peak"
+	PropertyComputeUsed = "computeUsed"
+	PropertyReservation = "reservation"
+)
+
+var (
+	defaultPropertyNames = []string{PropertyUsed, PropertyResizable, PropertyComputeUsed, PropertyCapacity}
+)
+
 type ReplacementEntityMetaDataBuilder struct {
 	metaData *proto.EntityDTO_ReplacementEntityMetaData
 }
@@ -36,9 +50,14 @@ func (builder *ReplacementEntityMetaDataBuilder) Matching(property string) *Repl
 // Set the commodity type whose metric values will be transferred to the entity
 // builder DTO will be replaced by.
 func (builder *ReplacementEntityMetaDataBuilder) PatchBuying(commType proto.CommodityDTO_CommodityType) *ReplacementEntityMetaDataBuilder {
+	return builder.PatchBuyingWithProperty(commType, defaultPropertyNames)
+}
+
+func (builder *ReplacementEntityMetaDataBuilder) PatchBuyingWithProperty(commType proto.CommodityDTO_CommodityType, names []string) *ReplacementEntityMetaDataBuilder {
 	builder.metaData.BuyingCommTypes = append(builder.metaData.GetBuyingCommTypes(),
 		&proto.EntityDTO_ReplacementCommodityPropertyData{
 			CommodityType: &commType,
+			PropertyName: names,
 		})
 	return builder
 }
@@ -46,9 +65,15 @@ func (builder *ReplacementEntityMetaDataBuilder) PatchBuying(commType proto.Comm
 // Set the commodity type whose metric values will be transferred to the entity
 //  builder DTO will be replaced by.
 func (builder *ReplacementEntityMetaDataBuilder) PatchSelling(commType proto.CommodityDTO_CommodityType) *ReplacementEntityMetaDataBuilder {
+	return builder.PatchSellingWithProperty(commType, defaultPropertyNames)
+}
+
+func (builder *ReplacementEntityMetaDataBuilder) PatchSellingWithProperty(commType proto.CommodityDTO_CommodityType, names []string) *ReplacementEntityMetaDataBuilder {
 	builder.metaData.SellingCommTypes = append(builder.metaData.GetSellingCommTypes(),
 		&proto.EntityDTO_ReplacementCommodityPropertyData{
 			CommodityType: &commType,
+			PropertyName: names,
 		})
+
 	return builder
 }

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_protobuf_endpoint.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_protobuf_endpoint.go
@@ -110,9 +110,6 @@ func (endpoint *ClientProtobufEndpoint) waitForServerMessage() {
 				return
 			//default:
 			case rawBytes, ok := <-endpoint.transport.RawMessageReceiver(): // block till  the message bytes from the transport channel,
-				// Get the message bytes from the transport channel,
-				// - this will block till the message appears on the channel
-				//rawBytes, ok := <-endpoint.transport.RawMessageReceiver()
 				if !ok {
 					glog.Errorf(logPrefix + "transport message channel is closed")
 					break

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
@@ -143,9 +143,8 @@ func (clientTransport *ClientWebSocketTransport) ListenForMessages() {
 			glog.V(4).Infof("[ListenForMessages] waiting for messages on websocket transport : %++v", clientTransport)
 			select {
 			case <-clientTransport.stopListenerCh:
-				glog.V(3).Infof("[ListenForMessages] closing inputStreamCh %+v", clientTransport.inputStreamCh)
 				close(clientTransport.inputStreamCh) // This listener routine is the writer for this channel
-				glog.V(3).Infof("[ListenForMessages] closed inputStreamCh %+v", clientTransport.inputStreamCh)
+				glog.V(4).Infof("[ListenForMessages] closed inputStreamCh %+v", clientTransport.inputStreamCh)
 				return
 			default:
 				if clientTransport.status != Ready {
@@ -217,7 +216,7 @@ func (clientTransport *ClientWebSocketTransport) Send(messageToSend *TransportMe
 		glog.Errorf("Error sending message on client transport: %s", err)
 		return fmt.Errorf("Error sending message on client transport: %s", err)
 	}
-	glog.V(3).Infof("Successfully sent message on client transport")
+	glog.V(4).Infof("Successfully sent message on client transport")
 	return nil
 }
 

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/mediation_container.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/mediation_container.go
@@ -71,7 +71,7 @@ func InitMediationContainer(probeRegisteredMsg chan bool) {
 		return
 	}
 	// Open connection to the server and start server handshake to register probes
-	glog.V(2).Infof("Registering ", len(theContainer.allProbes), " probes")
+	glog.V(2).Infof("Registering %d probes", len(theContainer.allProbes))
 
 	remoteMediationClient := theContainer.theRemoteMediationClient
 	remoteMediationClient.Init(probeRegisteredMsg)

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go
@@ -207,7 +207,7 @@ func (remoteMediationClient *remoteMediationClient) RunServerMessageHandler(tran
 				glog.Errorf(logPrefix + "endpoint message channel is closed")
 				break // return or continue ?
 			}
-			glog.V(3).Infof(logPrefix+"received: %s\n", parsedMsg)
+			glog.V(3).Infof(logPrefix+"received: %++v\n", parsedMsg)
 
 			// Handler response - find the handler to handle the message
 			serverRequest := parsedMsg.ServerMsg
@@ -232,17 +232,12 @@ func (remoteMediationClient *remoteMediationClient) RunServerMessageHandler(tran
 func (remoteMediationClient *remoteMediationClient) runProbeCallback(endpoint ProtobufEndpoint) {
 	glog.V(4).Infof("[runProbeCallback] %s : ENTER  ", time.Now())
 	for {
-		glog.V(2).Infof("[probeCallback] waiting for probe responses")
-		glog.V(4).Infof("[probeCallback] waiting for probe responses ..... on  %v\n", remoteMediationClient.probeResponseChan)
+		glog.V(4).Infof("[probeCallback] waiting for probe responses")
 		select {
 		case <-remoteMediationClient.stopMsgHandlerCh:
 			glog.V(4).Infof("[probeCallback] Exit routine *************")
 			return
-		case msg, ok := <-remoteMediationClient.probeResponseChan:
-			if !ok {
-				glog.Errorf("[probeCallback] probe response channel is closed")
-				break
-			}
+		case msg:= <-remoteMediationClient.probeResponseChan:
 			glog.V(4).Infof("[probeCallback] received response on probe channel %v\n ", remoteMediationClient.probeResponseChan)
 			endMsg := &EndpointMessage{
 				ProtobufMessage: msg,
@@ -368,7 +363,7 @@ func (discReqHandler *DiscoveryRequestHandler) keepDiscoveryAlive(msgID int32, p
 
 	// Send the response on the callback channel to send to the server
 	probeMsgChan <- clientMsg // This will block till the channel is ready to receive
-	glog.V(3).Infof("Sent keep alive response ", clientMsg.GetMessageID())
+	glog.V(3).Infof("Sent keep alive response %d", clientMsg.GetMessageID())
 }
 
 // -------------------------------- Validation Request Handler -----------------------------------
@@ -396,7 +391,7 @@ func (valReqHandler *ValidationRequestHandler) HandleMessage(serverRequest proto
 
 	// Send the response on the callback channel to send to the server
 	probeMsgChan <- clientMsg // This will block till the channel is ready to receive
-	glog.V(3).Infof("Sent validation response ", clientMsg.GetMessageID())
+	glog.V(3).Infof("Sent validation response %d", clientMsg.GetMessageID())
 }
 
 // -------------------------------- Action Request Handler -----------------------------------

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/sdk_client_protocol.go
@@ -69,7 +69,7 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) 
 		endpoint.CloseEndpoint()
 		return false
 	}
-	glog.V(3).Infof("["+endpoint.GetName()+"] : Received: %s\n", serverMsg)
+	glog.V(3).Infof("[%s] : Received: %++v\n", endpoint.GetName(),serverMsg)
 
 	// Handler response
 	negotiationResponse := protoMsg.NegotiationMsg
@@ -113,11 +113,11 @@ func (clientProtocol *SdkClientProtocol) HandleRegistration(transport ITransport
 	// Wait for the response to be received by the transport and then parsed and put on the endpoint's message channel
 	serverMsg, ok := <-endpoint.MessageReceiver()
 	if !ok {
-		glog.Errorf("[HandleRegistration] [" + endpoint.GetName() + "] : Endpoint Receiver channel is closed")
+		glog.Errorf("[HandleRegistration] [%s] : Endpoint Receiver channel is closed", endpoint.GetName())
 		endpoint.CloseEndpoint()
 		return false
 	}
-	glog.V(2).Infof("[HandleRegistration] ["+endpoint.GetName()+"] : Received: %s\n", serverMsg)
+	glog.V(2).Infof("[HandleRegistration] [%s] : Received: %++v\n", endpoint.GetName(), serverMsg)
 
 	// Handler response
 	registrationResponse := protoMsg.RegistrationMsg


### PR DESCRIPTION
Similar to the [PR(for 6.0.0 branch)](https://github.com/turbonomic/kubeturbo/pull/107), this PR is for the mainTrunk.

1. update dependency on turbo-go-sdk;
2. fix Issue [Capacity gets unset while patching the commodity during stitching with the new turbo-go-sdk](https://vmturbo.atlassian.net/browse/OM-24073);