### PR TITLE
Resize resource Reservation for containers

### DIFF
--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -174,6 +174,7 @@ func (h *HorizontalScaler) getProviderPod_hard(action *proto.ActionItemDTO) (*ap
 	glog.V(3).Infof("Horizontal-Scale target type is %v", targetType.String())
 
 	podId := sId
+	displayName := action.GetTargetSE().GetDisplayName()
 	var err error = nil
 
 	switch targetType {
@@ -193,6 +194,9 @@ func (h *HorizontalScaler) getProviderPod_hard(action *proto.ActionItemDTO) (*ap
 			glog.Errorf("Failed to get podId from appId[%s]: %v", appId, err)
 			return nil, fmt.Errorf("Failed to parse appId.")
 		}
+
+		// get container's DisplayName
+		displayName = action.GetHostedBySE().GetDisplayName()
 	case proto.EntityDTO_VIRTUAL_APPLICATION:
 		currentSE := action.GetCurrentSE()
 		seType := currentSE.GetEntityType()
@@ -207,6 +211,7 @@ func (h *HorizontalScaler) getProviderPod_hard(action *proto.ActionItemDTO) (*ap
 			glog.Errorf("Failed to get podId from appId[%s]: %v", appId, err)
 			return nil, fmt.Errorf("Failed to parse appId.")
 		}
+		displayName = dutil.GetPodFullNameFromAppName(currentSE.GetDisplayName())
 	default:
 		err = fmt.Errorf("Illegal target type [%v] for horizontal scaling.", targetType.String())
 		glog.Errorf(err.Error())
@@ -217,7 +222,7 @@ func (h *HorizontalScaler) getProviderPod_hard(action *proto.ActionItemDTO) (*ap
 		return nil, err
 	}
 
-	return util.GetPodFromUUID(h.kubeClient, podId)
+	return util.GetPodFromDisplayName(h.kubeClient, displayName, podId)
 }
 
 // getProviderPod, "easy" means that we will get Pod info from Entity properties

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -2,6 +2,9 @@ package executor
 
 import (
 	"fmt"
+	"github.com/golang/glog"
+	"strings"
+
 	"github.com/turbonomic/kubeturbo/pkg/action/util"
 	kclient "k8s.io/client-go/kubernetes"
 	api "k8s.io/client-go/pkg/api/v1"
@@ -10,9 +13,6 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 	goutil "github.com/turbonomic/kubeturbo/pkg/util"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-
-	"github.com/golang/glog"
-	"strings"
 )
 
 type ReScheduler struct {
@@ -133,7 +133,7 @@ func (r *ReScheduler) getPodNode(action *proto.ActionItemDTO) (*api.Pod, *api.No
 
 	//2. get pod from k8s
 	target := action.GetTargetSE()
-	pod, err := util.GetPodFromUUID(r.kubeClient, target.GetId())
+	pod, err := util.GetPodFromDisplayName(r.kubeClient, target.GetDisplayName(), target.GetId())
 	if err != nil {
 		err = fmt.Errorf("Move Action aborted: failed to find pod(%v) in k8s: %v", target.GetDisplayName(), err)
 		glog.Errorf(err.Error())

--- a/pkg/action/executor/resize_container_util_test.go
+++ b/pkg/action/executor/resize_container_util_test.go
@@ -141,7 +141,7 @@ func TestUpdateCapacity(t *testing.T) {
 	}
 
 	//c := NewContainerResizer(nil, nil, "1.5", "aa", nil)
-	updateCapacity(pod, 0, patch)
+	updateCapacity(container, patch)
 	if err := compareResourceList(container.Resources.Limits, 250, 500); err != nil {
 		t.Error(err)
 	}

--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	AppPrefix                  string  = "App-"
 	defaultTransactionCapacity float64 = 500.0
 )
 
@@ -73,7 +72,7 @@ func (builder *applicationEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod) ([]
 			//container := &(pod.Spec.Containers[i])
 			containerId := util.ContainerIdFunc(podId, i)
 			appId := util.ApplicationIdFunc(containerId)
-			displayName := AppPrefix + podFullName
+			displayName := util.ApplicationDisplayName(podFullName)
 
 			ebuilder := sdkbuilder.NewEntityDTOBuilder(proto.EntityDTO_APPLICATION, appId).
 				DisplayName(displayName)

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	appIdPrefix = "app"
+	appIdPrefix = "App"
 )
 
 // PodStatsKeyFunc and PodKeyFunc should return the same value.
@@ -55,6 +55,20 @@ func ParseContainerId(containerId string) (string, int, error) {
 	}
 
 	return podId, index, nil
+}
+
+// Application's displayName = "App-namespace/podName"
+//podFullName should be "namespace/podName"
+func ApplicationDisplayName(podFullName string) string {
+	return fmt.Sprintf("%s-%s", appIdPrefix, podFullName)
+}
+
+func GetPodFullNameFromAppName(appName string) string {
+	i := len(appIdPrefix) + 1
+	if len(appName) < i+1 {
+		return ""
+	}
+	return appName[i:]
 }
 
 func ApplicationIdFunc(containerId string) string {

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -89,6 +89,7 @@ func (f *SupplyChainFactory) buildNodeSupplyBuilder() (*proto.TemplateDTO, error
 	nodeSupplyChainNodeBuilder = nodeSupplyChainNodeBuilder.
 		Sells(vCpuTemplateComm).
 		Sells(vMemTemplateComm).
+		Sells(vmpmAccessTemplateComm).
 		// TODO we will re-include provisioned commodities sold by node later.
 		//Sells(cpuProvisionedTemplateComm).
 		//Sells(memProvisionedTemplateComm)


### PR DESCRIPTION
1. Implement the feature to resize the reservation for containers for [Issue94](https://github.com/turbonomic/kubeturbo/issues/94).
   Currently, only support VCPU/VMEM

2. Improve the way of finding Pod from actionItem:
    First, try to find the Pod by entity's display name;
    Second, if the result of displayname is not correct, try to find the Pod by UUID.
