### PR TITLE
Add features to support non-disruptive actions

### DIFF
--- a/pkg/action/executor/constants.go
+++ b/pkg/action/executor/constants.go
@@ -11,21 +11,23 @@ const (
 	podDeletionGracePeriodMax int64 = 0
 
 	DefaultNoneExistSchedulerName = "turbo-none-exist-scheduler"
-	kindReplicationController     = "ReplicationController"
-	kindReplicaSet                = "ReplicaSet"
-	kindDeployment                = "Deployment"
 
 	HigherK8sVersion = "1.6.0"
 
-	defaultRetryLess int = 3
-	defaultRetryMore int = 6
+	defaultRetryLess = 3
+	defaultRetryMore = 6
 
 	defaultWaitLockTimeOut = time.Second * 300
 	defaultWaitLockSleep   = time.Second * 10
 
-	defaultPodCreateSleep       = time.Second * 30
-	defaultUpdateSchedulerSleep = time.Second * 20
-	defaultCheckSchedulerSleep  = time.Second * 5
-	defaultUpdateReplicaSleep   = time.Second * 20
-	defaultMoreGrace            = time.Second * 20
+	defaultPodCreateSleep            = time.Second * 30
+	defaultUpdateSchedulerSleep      = time.Second * 20
+	defaultCheckSchedulerSleep       = time.Second * 5
+	defaultCheckUpdateReplicaSleep   = time.Second * 5
+	defaultCheckUpdateReplicaTimeout = time.Second * 180
+	defaultCheckUpdateReplicaRetry   = 36
+	defaultUpdateReplicaSleep        = time.Second * 20
+	defaultUpdateReplicaTimeout      = time.Second * 180
+	defaultUpdateReplicaRetry        = 10
+	defaultMoreGrace                 = time.Second * 20
 )

--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -222,7 +222,7 @@ func (h *HorizontalScaler) getProviderPod_hard(action *proto.ActionItemDTO) (*ap
 		return nil, err
 	}
 
-	return util.GetPodFromDisplayName(h.kubeClient, displayName, podId)
+	return util.GetPodFromDisplayNameOrUUID(h.kubeClient, displayName, podId)
 }
 
 // getProviderPod, "easy" means that we will get Pod info from Entity properties

--- a/pkg/action/executor/nondisruptive_helper.go
+++ b/pkg/action/executor/nondisruptive_helper.go
@@ -1,0 +1,187 @@
+package executor
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	autil "github.com/turbonomic/kubeturbo/pkg/action/util"
+	"github.com/turbonomic/kubeturbo/pkg/util"
+	kclient "k8s.io/client-go/kubernetes"
+)
+
+// Performs operations for non-disruptive action (container resize and pod move).
+// If there is only one child pod for the associated controller, the process is:
+//  - update the replicas to 2 (pod p1 created by controller)
+//  - perform the action on the target object
+//  - delete p1 (pod p2 created by controller)
+//  - update the replicas to 1 (p2 deleted by controller)
+type NonDisruptiveHelper struct {
+	namespace string
+	contKind  string
+	contName  string
+	targetPod string
+	client    *kclient.Clientset
+
+	podToClean string
+}
+
+func NewNonDisruptiveHelper(client *kclient.Clientset, namespace, contKind, contName, targetPod string) *NonDisruptiveHelper {
+	p := &NonDisruptiveHelper{
+		namespace: namespace,
+		contKind:  contKind,
+		contName:  contName,
+		targetPod: targetPod,
+		client:    client,
+	}
+
+	return p
+}
+
+// Performs operations before executing a disruptive action (container resize and pod move).
+// It will update the controller replicas to 2 and save the new pod created by controller internally
+// for cleanup after the action is performed.
+func (h *NonDisruptiveHelper) OperateForNonDisruption() error {
+	replicas, _, err := autil.GetReplicaStatus(h.client, h.namespace, h.contName, h.contKind)
+	if err != nil {
+		glog.Errorf("Error getting replica status for %s %s/%s: %s", h.contKind, h.namespace, h.contName, err)
+		return fmt.Errorf("failed operations for non-disruptive action")
+	}
+
+	if replicas != 1 {
+		return nil
+	}
+
+	glog.V(2).Infof("Started non-disruptive operations on %s %s/%s", h.contKind, h.namespace, h.contName)
+
+	// Update replicas to 2
+	newReplicas := replicas + 1
+	glog.V(4).Infof("Updating replicas to %d", newReplicas)
+	if err := h.updateReplicaWithRetry(newReplicas); err != nil {
+		glog.Errorf("Error updating replica to 2 for %s %s/%s: %s", h.contKind, h.namespace, h.contName, err)
+		return fmt.Errorf("failed operations for non-disruptive action")
+	}
+
+	// Get the new pod
+	glog.V(4).Infof("Getting the new pod")
+	pods, err := autil.FindPodsByController(h.client, h.namespace, h.contName, h.contKind)
+	if err != nil {
+		glog.Errorf("Error finding pods by %s %s/%s: %s", h.contKind, h.namespace, h.contName, err)
+		return fmt.Errorf("failed operations for non-disruptive action")
+	}
+
+	// There should be exactly two pods
+	if len(pods) != newReplicas {
+		glog.Errorf("Found %d (not 2) pods by %s %s/%s", len(pods), h.contKind, h.namespace, h.contName)
+		return fmt.Errorf("failed operations for non-disruptive action")
+	}
+
+	for _, p1 := range pods {
+		if p1.Name != h.targetPod {
+			h.podToClean = p1.Name
+			break
+		}
+	}
+
+	glog.V(4).Infof("The pod to clean up: %s", h.podToClean)
+
+	glog.V(2).Infof("Finished non-disruptive operations on %s %s/%s", h.contKind, h.namespace, h.contName)
+
+	return nil
+}
+
+// Cleans up the pod created in the operation for non-disruptive action support.
+// The pod, if exists, will be deleted and the replicas of the associated controller
+// will be set to one.
+func (h *NonDisruptiveHelper) CleanUp() {
+	if h.podToClean == "" { // No operations for non-disruptive actions
+		glog.V(4).Infof("No need to clean up for non-disruptive operations on %s %s/%s", h.contKind, h.namespace, h.contName)
+		return
+	}
+
+	glog.V(2).Infof("Started clean up for non-disruptive operations on %s %s/%s", h.contKind, h.namespace, h.contName)
+
+	// Wait for at least two pods ready before deleting the podToClean
+	glog.V(2).Infof("Wait for the target pod to be ready...")
+	err := util.RetryDuring(defaultCheckUpdateReplicaRetry, defaultCheckUpdateReplicaTimeout, defaultCheckUpdateReplicaSleep, func() error {
+		ctrlReplicas, ctrlReadyReplicas, err := autil.GetReplicaStatus(h.client, h.namespace, h.contName, h.contKind)
+		if err != nil {
+			return err
+		}
+
+		glog.V(2).Infof("replicas: %d, readyReplicas: %d", ctrlReplicas, ctrlReadyReplicas)
+
+		if ctrlReadyReplicas > 1 {
+			return nil
+		}
+
+		return fmt.Errorf("the operation for the target pod has not yet finished")
+	})
+
+	if err != nil {
+		glog.Errorf("Error updating replica to 1 for %s %s/%s: %s", h.contKind, h.namespace, h.contName, err)
+	}
+
+	// Delete podToClean
+	glog.V(4).Infof("Deleting pod: %s", h.podToClean)
+	err = autil.DeletePod(h.client, h.namespace, h.podToClean, podDeletionGracePeriodDefault)
+
+	if err != nil {
+		glog.Errorf("Error while deleting pod %s: %s", h.podToClean, err)
+	}
+
+	// Set replica = 1
+	// Check if the current replica = 2 as our action may take several minutes,
+	// user may modify the replicaNum during this period.
+	ctrlReplicas, _, err := autil.GetReplicaStatus(h.client, h.namespace, h.contName, h.contKind)
+	if err != nil {
+		glog.Errorf("Error while getting replica status for %s %s/%s: %s", h.contKind, h.namespace, h.contName, err)
+		return
+	}
+
+	if ctrlReplicas != 2 {
+		glog.Errorf("Clean up terminated: the controller replica is not 2")
+		return
+	}
+
+	glog.V(4).Infof("Updating replicas to 1")
+	if err := h.updateReplicaWithRetry(1); err != nil {
+		glog.Errorf("Clean up failed while updating replica to 1 for %s %s/%s: %s", h.contKind, h.namespace, h.contName, err)
+		return
+	}
+
+	glog.V(2).Infof("Finished clean up for non-disruptive operations on %s %s/%s", h.contKind, h.namespace, h.contName)
+}
+
+func (h *NonDisruptiveHelper) updateReplicaWithRetry(newReplicas int) error {
+	// With retrying several times
+	glog.V(2).Infof("updateReplicaWithRetry: newReplicas = %d", newReplicas)
+	err := util.RetryDuring(defaultUpdateReplicaRetry, defaultUpdateReplicaTimeout, defaultUpdateReplicaSleep, func() error {
+		return autil.UpdateReplicas(h.client, h.namespace, h.contName, h.contKind, newReplicas)
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Wait for the update to finish
+	glog.V(2).Infof("Wait for the update to finish...")
+	err = util.RetryDuring(defaultCheckUpdateReplicaRetry, defaultCheckUpdateReplicaTimeout, defaultCheckUpdateReplicaSleep, func() error {
+		ctrlReplicas, ctrlReadyReplicas, err := autil.GetReplicaStatus(h.client, h.namespace, h.contName, h.contKind)
+		if err != nil {
+			return err
+		}
+
+		glog.V(4).Infof("replicas: %d, readyReplicas: %d", ctrlReplicas, ctrlReadyReplicas)
+
+		if ctrlReplicas == newReplicas && ctrlReadyReplicas == newReplicas {
+			return nil
+		}
+
+		return fmt.Errorf("the replica update has not yet finished")
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -242,6 +242,22 @@ func (r *ReScheduler) moveControllerPod(pod *api.Pod, parentKind, parentName, no
 		glog.V(3).Infof("Move pod[%s] failed: Failed to acuire lock parent[%s]", pod.Name, parentName)
 		return nil, err
 	}
+
+	// Performs operations for actions to be non-disruptive (when the pod is the only one for the controller)
+	// NOTE: It doesn't support the case of the pod associated to Deployment in version lower than 1.6.0.
+	//       In such case, the action execution will fail.
+	contKind, contName, err := util.GetPodGrandInfo(r.kubeClient, pod)
+	nonDisruptiveHelper := NewNonDisruptiveHelper(r.kubeClient, pod.Namespace, contKind, contName, pod.Name)
+
+	// Performs operations for non-disruptive move actions
+	if err := nonDisruptiveHelper.OperateForNonDisruption(); err != nil {
+		glog.V(3).Infof("Move pod[%s] failed: Failed to perform non-disruptive operations", pod.Name)
+		return nil, err
+	}
+
+	// Performs cleanup for non-disruptive move actions
+	defer nonDisruptiveHelper.CleanUp()
+
 	defer func() {
 		helper.CleanUp()
 		util.CleanPendingPod(r.kubeClient, pod.Namespace, noexist, parentKind, parentName, highver)
@@ -278,7 +294,7 @@ func (r *ReScheduler) moveBarePod(pod *api.Pod, nodeName string) (*api.Pod, erro
 	interval := defaultWaitLockSleep
 	err = helper.Trylock(timeout, interval)
 	if err != nil {
-		glog.Errorf("move pod[%s] failed: failed to acquire lock of pod[%s]", podkey)
+		glog.Errorf("move pod[%s] failed: failed to acquire lock of pod[%s]", podkey, podkey)
 		return nil, err
 	}
 	defer helper.ReleaseLock()

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -133,7 +133,7 @@ func (r *ReScheduler) getPodNode(action *proto.ActionItemDTO) (*api.Pod, *api.No
 
 	//2. get pod from k8s
 	target := action.GetTargetSE()
-	pod, err := util.GetPodFromDisplayName(r.kubeClient, target.GetDisplayName(), target.GetId())
+	pod, err := util.GetPodFromDisplayNameOrUUID(r.kubeClient, target.GetDisplayName(), target.GetId())
 	if err != nil {
 		err = fmt.Errorf("Move Action aborted: failed to find pod(%v) in k8s: %v", target.GetDisplayName(), err)
 		glog.Errorf(err.Error())

--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -180,7 +180,7 @@ func (r *ContainerResizer) buildResizeAction(actionItem *proto.ActionItemDTO) (*
 	}
 
 	// the displayName is "namespace/podName"
-	pod, err := util.GetPodFromDisplayName(r.kubeClient, podEntity.GetDisplayName(), podId)
+	pod, err := util.GetPodFromDisplayNameOrUUID(r.kubeClient, podEntity.GetDisplayName(), podId)
 	if err != nil {
 		glog.Errorf("failed to get hosting Pod to build resizeAction: %v", err)
 		return nil, nil, err

--- a/pkg/action/executor/scheduler_helper.go
+++ b/pkg/action/executor/scheduler_helper.go
@@ -54,14 +54,14 @@ func NewSchedulerHelper(client *kclient.Clientset, nameSpace, name, kind, parent
 	}
 
 	switch p.kind {
-	case kindReplicationController:
+	case util.KindReplicationController:
 		p.getSchedulerName = autil.GetRCschedulerName
 		p.updateSchedulerName = autil.UpdateRCscheduler
 		if !highver {
 			p.getSchedulerName = autil.GetRCschedulerName15
 			p.updateSchedulerName = autil.UpdateRCscheduler15
 		}
-	case kindReplicaSet:
+	case util.KindReplicaSet:
 		p.getSchedulerName = autil.GetRSschedulerName
 		p.updateSchedulerName = autil.UpdateRSscheduler
 		if !highver {

--- a/pkg/action/util/util.go
+++ b/pkg/action/util/util.go
@@ -218,7 +218,15 @@ func GetPodFromUUID(kubeClient *client.Clientset, podUUID string) (*api.Pod, err
 //      if serviceEntity is a container, then displayName is "namespace/podName/containerName";
 // uuid is the pod's UUID
 // Note: displayName for application is "App-namespace/podName", the pods info can be got by the provider's displayname
-func GetPodFromDisplayName(kclient *client.Clientset, displayname, uuid string) (*api.Pod, error) {
+func GetPodFromDisplayNameOrUUID(kclient *client.Clientset, displayname, uuid string) (*api.Pod, error) {
+	if pod, err := getaPodFromDisplayName(kclient, displayname, uuid); err == nil {
+		return pod, err
+	}
+
+	return GetPodFromUUID(kclient, uuid)
+}
+
+func getaPodFromDisplayName(kclient *client.Clientset, displayname, uuid string) (*api.Pod, error) {
 	sep := "/"
 	items := strings.Split(displayname, sep)
 	if len(items) < 2 {
@@ -260,8 +268,7 @@ func GetPodFromDisplayName(kclient *client.Clientset, displayname, uuid string) 
 		return pod, nil
 	}
 
-	//5. finally, try to get the Pod by UUID
-	return GetPodFromUUID(kclient, uuid)
+	return nil, fmt.Errorf("Failed getting pod from DisplayName %s", displayname)
 }
 
 // Find which pod is the app running based on the received action request.

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -159,7 +159,7 @@ func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node) ([]*
 	clusterMetricUID := metrics.GenerateEntityStateMetricUID(task.ClusterType, "", metrics.Cluster)
 	clusterInfo, err := builder.metricsSink.GetMetric(clusterMetricUID)
 	if err != nil {
-		glog.Errorf("Failed to get %s used for current Kubernetes Cluster%s", metrics.Cluster)
+		glog.Errorf("Failed to get %s used for current Kubernetes Cluster %s", metrics.Cluster, clusterInfo)
 	} else {
 		clusterCommodityKey, ok := clusterInfo.GetValue().(string)
 		if !ok {

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -85,7 +85,7 @@ func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod) ([]*proto.E
 		providerNodeUID, exist := builder.nodeNameUIDMap[pod.Spec.NodeName]
 		if !exist {
 			glog.Errorf("Error when create commoditiesBought for pod %s: Cannot find uuid for provider "+
-				"node.", displayName, err)
+				"node.", displayName)
 			continue
 		}
 		provider := sdkbuilder.CreateProvider(proto.EntityDTO_VIRTUAL_MACHINE, providerNodeUID)
@@ -211,7 +211,7 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBought(pod *api.Pod, cpuFre
 	clusterMetricUID := metrics.GenerateEntityStateMetricUID(task.ClusterType, "", metrics.Cluster)
 	clusterInfo, err := builder.metricsSink.GetMetric(clusterMetricUID)
 	if err != nil {
-		glog.Errorf("Failed to get %s used for current Kubernetes Cluster%s", metrics.Cluster)
+		glog.Errorf("Failed to get %s used for current Kubernetes Cluster %s", metrics.Cluster, clusterInfo)
 	} else {
 		clusterCommodityKey, ok := clusterInfo.GetValue().(string)
 		if !ok {

--- a/pkg/discovery/util/key_func_test.go
+++ b/pkg/discovery/util/key_func_test.go
@@ -46,7 +46,7 @@ func TestParseContainerId(t *testing.T) {
 		}
 
 		if podId != test.podId || index != test.index {
-			t.Error("mismatch: [%s, %d] Vs. [%s, %d]", podId, index, test.podId, test.index)
+			t.Errorf("mismatch: [%s, %d] Vs. [%s, %d]", podId, index, test.podId, test.index)
 		}
 	}
 }
@@ -62,7 +62,7 @@ func TestParseContainerID2(t *testing.T) {
 	}
 
 	if podId != expectPodId || index != expectIndex {
-		t.Error("mismatch: [%s, %d] Vs. [%s, %d]", podId, index, expectPodId, expectIndex)
+		t.Errorf("mismatch: [%s, %d] Vs. [%s, %d]", podId, index, expectPodId, expectIndex)
 	}
 
 	//2. bad

--- a/pkg/discovery/worker/compliance/compliance_processor_test.go
+++ b/pkg/discovery/worker/compliance/compliance_processor_test.go
@@ -425,7 +425,7 @@ func TestAddCommodityBought(t *testing.T) {
 						}
 					}
 					if !found {
-						t.Errorf("Test case %d failed: didn't find the expected provider %s", i, item.provider)
+						t.Errorf("Test case %d failed: didn't find the expected provider %v", i, item.provider)
 					}
 				}
 			}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,0 +1,7 @@
+package util
+
+const (
+	KindReplicationController = "ReplicationController"
+	KindReplicaSet            = "ReplicaSet"
+	KindDeployment            = "Deployment"
+)


### PR DESCRIPTION
Add features to support non-disruptive actions for container resize and pod move for ReplicationController and ReplicaSet. If the controller replica size is one, then perform the operations to enable non-disruptive action execution. The process is as follows:
- Update the replica to 2 (new pod p1 created by controller)
- Perform the action (resize or move)
- Delete the pod p1 (new pod p2 created by controller)
- Update the replica to 1 (pod p2 deleted by controller)