### PR TITLE
non-disruptive flag and deployment support check

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -70,7 +70,7 @@ type VMTServer struct {
 	NoneSchedulerName string
 
 	// Flag for supporting non-disruptive action
-	disableNonDisruptiveSupport bool
+	enableNonDisruptiveSupport bool
 }
 
 // NewVMTServer creates a new VMTServer with default parameters
@@ -97,7 +97,7 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableKubeletHttps, "kubelet-https", kubelet.DefaultKubeletHttps, "Indicate if Kubelet is running on https server")
 	fs.StringVar(&s.K8sVersion, "k8sVersion", executor.HigherK8sVersion, "the kubernetes server version; for openshift, it is the underlying Kubernetes' version.")
 	fs.StringVar(&s.NoneSchedulerName, "noneSchedulerName", executor.DefaultNoneExistSchedulerName, "a none-exist scheduler name, to prevent controller to create Running pods during move Action.")
-	fs.BoolVar(&s.disableNonDisruptiveSupport, "disable-non-disruptive-support", false, "Indicate if nondisruptive action support is disabled")
+	fs.BoolVar(&s.enableNonDisruptiveSupport, "enable-non-disruptive-support", false, "Indicate if nondisruptive action support is enabled")
 
 	//leaderelection.BindFlags(&s.LeaderElection, fs)
 }
@@ -248,7 +248,7 @@ func (s *VMTServer) Run(_ []string) error {
 		WithK8sVersion(s.K8sVersion).
 		WithNoneScheduler(s.NoneSchedulerName).
 		WithRecorder(createRecorder(kubeClient)).
-		WithDisableNonDisruptiveFlag(s.disableNonDisruptiveSupport)
+		WithEnableNonDisruptiveFlag(s.enableNonDisruptiveSupport)
 	glog.V(3).Infof("Finished creating turbo configuration: %+v", vmtConfig)
 
 	vmtService := kubeturbo.NewKubeturboService(vmtConfig)

--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -68,6 +68,9 @@ type VMTServer struct {
 	// for Move Action
 	K8sVersion        string
 	NoneSchedulerName string
+
+	// Flag for supporting non-disruptive action
+	disableNonDisruptiveSupport bool
 }
 
 // NewVMTServer creates a new VMTServer with default parameters
@@ -94,6 +97,7 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableKubeletHttps, "kubelet-https", kubelet.DefaultKubeletHttps, "Indicate if Kubelet is running on https server")
 	fs.StringVar(&s.K8sVersion, "k8sVersion", executor.HigherK8sVersion, "the kubernetes server version; for openshift, it is the underlying Kubernetes' version.")
 	fs.StringVar(&s.NoneSchedulerName, "noneSchedulerName", executor.DefaultNoneExistSchedulerName, "a none-exist scheduler name, to prevent controller to create Running pods during move Action.")
+	fs.BoolVar(&s.disableNonDisruptiveSupport, "disable-non-disruptive-support", false, "Indicate if nondisruptive action support is disabled")
 
 	//leaderelection.BindFlags(&s.LeaderElection, fs)
 }
@@ -243,7 +247,8 @@ func (s *VMTServer) Run(_ []string) error {
 		WithBroker(broker).
 		WithK8sVersion(s.K8sVersion).
 		WithNoneScheduler(s.NoneSchedulerName).
-		WithRecorder(createRecorder(kubeClient))
+		WithRecorder(createRecorder(kubeClient)).
+		WithDisableNonDisruptiveFlag(s.disableNonDisruptiveSupport)
 	glog.V(3).Infof("Finished creating turbo configuration: %+v", vmtConfig)
 
 	vmtService := kubeturbo.NewKubeturboService(vmtConfig)

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -38,18 +38,18 @@ type ActionHandlerConfig struct {
 	stitchType        stitching.StitchingPropertyType
 
 	// Flag for supporting non-disruptive action
-	disableNonDisruptiveSupport bool
+	enableNonDisruptiveSupport bool
 }
 
-func NewActionHandlerConfig(kubeClient *client.Clientset, kubeletClient *kubelet.KubeletClient, k8sVersion, noneSchedulerName string, stype stitching.StitchingPropertyType, disableNonDisruptiveSupport bool) *ActionHandlerConfig {
+func NewActionHandlerConfig(kubeClient *client.Clientset, kubeletClient *kubelet.KubeletClient, k8sVersion, noneSchedulerName string, stype stitching.StitchingPropertyType, enableNonDisruptiveSupport bool) *ActionHandlerConfig {
 	config := &ActionHandlerConfig{
 		kubeClient:    kubeClient,
 		kubeletClient: kubeletClient,
 
-		k8sVersion:                  k8sVersion,
-		noneSchedulerName:           noneSchedulerName,
-		stitchType:                  stype,
-		disableNonDisruptiveSupport: disableNonDisruptiveSupport,
+		k8sVersion:                 k8sVersion,
+		noneSchedulerName:          noneSchedulerName,
+		stitchType:                 stype,
+		enableNonDisruptiveSupport: enableNonDisruptiveSupport,
 
 		StopEverything: make(chan struct{}),
 	}
@@ -84,14 +84,14 @@ func NewActionHandler(config *ActionHandlerConfig) *ActionHandler {
 // As action executor is stateless, they can be safely reused.
 func (h *ActionHandler) registerActionExecutors() {
 	c := h.config
-	reScheduler := executor.NewReScheduler(c.kubeClient, c.k8sVersion, c.noneSchedulerName, h.lockMap, c.stitchType, c.disableNonDisruptiveSupport)
+	reScheduler := executor.NewReScheduler(c.kubeClient, c.k8sVersion, c.noneSchedulerName, h.lockMap, c.stitchType, c.enableNonDisruptiveSupport)
 	h.actionExecutors[turboActionMove] = reScheduler
 
 	horizontalScaler := executor.NewHorizontalScaler(c.kubeClient, h.lockMap)
 	h.actionExecutors[turboActionProvision] = horizontalScaler
 	h.actionExecutors[turboActionUnbind] = horizontalScaler
 
-	containerResizer := executor.NewContainerResizer(c.kubeClient, c.kubeletClient, c.k8sVersion, c.noneSchedulerName, h.lockMap, c.disableNonDisruptiveSupport)
+	containerResizer := executor.NewContainerResizer(c.kubeClient, c.kubeletClient, c.k8sVersion, c.noneSchedulerName, h.lockMap, c.enableNonDisruptiveSupport)
 	h.actionExecutors[turboActionContainerResize] = containerResizer
 }
 

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -36,16 +36,20 @@ type ActionHandlerConfig struct {
 	k8sVersion        string
 	noneSchedulerName string
 	stitchType        stitching.StitchingPropertyType
+
+	// Flag for supporting non-disruptive action
+	disableNonDisruptiveSupport bool
 }
 
-func NewActionHandlerConfig(kubeClient *client.Clientset, kubeletClient *kubelet.KubeletClient, k8sVersion, noneSchedulerName string, stype stitching.StitchingPropertyType) *ActionHandlerConfig {
+func NewActionHandlerConfig(kubeClient *client.Clientset, kubeletClient *kubelet.KubeletClient, k8sVersion, noneSchedulerName string, stype stitching.StitchingPropertyType, disableNonDisruptiveSupport bool) *ActionHandlerConfig {
 	config := &ActionHandlerConfig{
 		kubeClient:    kubeClient,
 		kubeletClient: kubeletClient,
 
-		k8sVersion:        k8sVersion,
-		noneSchedulerName: noneSchedulerName,
-		stitchType:        stype,
+		k8sVersion:                  k8sVersion,
+		noneSchedulerName:           noneSchedulerName,
+		stitchType:                  stype,
+		disableNonDisruptiveSupport: disableNonDisruptiveSupport,
 
 		StopEverything: make(chan struct{}),
 	}
@@ -80,14 +84,14 @@ func NewActionHandler(config *ActionHandlerConfig) *ActionHandler {
 // As action executor is stateless, they can be safely reused.
 func (h *ActionHandler) registerActionExecutors() {
 	c := h.config
-	reScheduler := executor.NewReScheduler(c.kubeClient, c.k8sVersion, c.noneSchedulerName, h.lockMap, c.stitchType)
+	reScheduler := executor.NewReScheduler(c.kubeClient, c.k8sVersion, c.noneSchedulerName, h.lockMap, c.stitchType, c.disableNonDisruptiveSupport)
 	h.actionExecutors[turboActionMove] = reScheduler
 
 	horizontalScaler := executor.NewHorizontalScaler(c.kubeClient, h.lockMap)
 	h.actionExecutors[turboActionProvision] = horizontalScaler
 	h.actionExecutors[turboActionUnbind] = horizontalScaler
 
-	containerResizer := executor.NewContainerResizer(c.kubeClient, c.kubeletClient, c.k8sVersion, c.noneSchedulerName, h.lockMap)
+	containerResizer := executor.NewContainerResizer(c.kubeClient, c.kubeletClient, c.k8sVersion, c.noneSchedulerName, h.lockMap, c.disableNonDisruptiveSupport)
 	h.actionExecutors[turboActionContainerResize] = containerResizer
 }
 

--- a/pkg/action/executor/nondisruptive_helper_test.go
+++ b/pkg/action/executor/nondisruptive_helper_test.go
@@ -1,0 +1,36 @@
+package executor
+
+import (
+	"testing"
+
+	kclient "k8s.io/client-go/kubernetes"
+)
+
+func TestNonDisruptiveHelper_isOperationSupported(t *testing.T) {
+	tests := []struct {
+		name   string
+		helper *NonDisruptiveHelper
+		want   bool
+	}{
+		{name: "DP-k8s-1.5.0", helper: createHelper("Deployment", "1.5.0"), want: false},
+		{name: "DP-k8s-1.8.0", helper: createHelper("Deployment", "1.8.0"), want: true},
+		{name: "RC-k8s-1.5.0", helper: createHelper("ReplicationController", "1.5.0"), want: true},
+		{name: "RC-k8s-1.8.0", helper: createHelper("ReplicationController", "1.8.0"), want: true},
+		{name: "RS-k8s-1.5.0", helper: createHelper("ReplicaSet", "1.5.0"), want: true},
+		{name: "RS-k8s-1.8.0", helper: createHelper("ReplicaSet", "1.8.0"), want: true},
+		{name: "UK-k8s-1.5.0", helper: createHelper("foo", "1.5.0"), want: false},
+		{name: "UK-k8s-1.8.0", helper: createHelper("foo", "1.8.0"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.helper.isOperationSupported(); got != tt.want {
+				t.Errorf("isOperationSupported() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func createHelper(contKind, ks8Version string) *NonDisruptiveHelper {
+	return NewNonDisruptiveHelper(&kclient.Clientset{}, "ns-1", contKind, "cont", "pod-1", ks8Version)
+}

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -16,10 +16,10 @@ import (
 )
 
 type ReScheduler struct {
-	kubeClient        *kclient.Clientset
-	k8sVersion        string
-	noneSchedulerName string
-	stitchType        stitching.StitchingPropertyType
+	kubeClient                  *kclient.Clientset
+	k8sVersion                  string
+	noneSchedulerName           string
+	stitchType                  stitching.StitchingPropertyType
 	disableNonDisruptiveSupport bool
 
 	lockMap *util.ExpirationMap
@@ -27,11 +27,11 @@ type ReScheduler struct {
 
 func NewReScheduler(client *kclient.Clientset, k8sver, noschedulerName string, lmap *util.ExpirationMap, stype stitching.StitchingPropertyType, disableNonDisruptiveSupport bool) *ReScheduler {
 	return &ReScheduler{
-		kubeClient:        client,
-		k8sVersion:        k8sver,
-		noneSchedulerName: noschedulerName,
-		lockMap:           lmap,
-		stitchType:        stype,
+		kubeClient:                  client,
+		k8sVersion:                  k8sver,
+		noneSchedulerName:           noschedulerName,
+		lockMap:                     lmap,
+		stitchType:                  stype,
 		disableNonDisruptiveSupport: disableNonDisruptiveSupport,
 	}
 }
@@ -253,7 +253,7 @@ func (r *ReScheduler) moveControllerPod(pod *api.Pod, parentKind, parentName, no
 		if err != nil {
 			return nil, err
 		}
-		nonDisruptiveHelper := NewNonDisruptiveHelper(r.kubeClient, pod.Namespace, contKind, contName, pod.Name)
+		nonDisruptiveHelper := NewNonDisruptiveHelper(r.kubeClient, pod.Namespace, contKind, contName, pod.Name, r.k8sVersion)
 
 		// Performs operations for non-disruptive move actions
 		if err := nonDisruptiveHelper.OperateForNonDisruption(); err != nil {

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -16,23 +16,23 @@ import (
 )
 
 type ReScheduler struct {
-	kubeClient                  *kclient.Clientset
-	k8sVersion                  string
-	noneSchedulerName           string
-	stitchType                  stitching.StitchingPropertyType
-	disableNonDisruptiveSupport bool
+	kubeClient                 *kclient.Clientset
+	k8sVersion                 string
+	noneSchedulerName          string
+	stitchType                 stitching.StitchingPropertyType
+	enableNonDisruptiveSupport bool
 
 	lockMap *util.ExpirationMap
 }
 
-func NewReScheduler(client *kclient.Clientset, k8sver, noschedulerName string, lmap *util.ExpirationMap, stype stitching.StitchingPropertyType, disableNonDisruptiveSupport bool) *ReScheduler {
+func NewReScheduler(client *kclient.Clientset, k8sver, noschedulerName string, lmap *util.ExpirationMap, stype stitching.StitchingPropertyType, enableNonDisruptiveSupport bool) *ReScheduler {
 	return &ReScheduler{
-		kubeClient:                  client,
-		k8sVersion:                  k8sver,
-		noneSchedulerName:           noschedulerName,
-		lockMap:                     lmap,
-		stitchType:                  stype,
-		disableNonDisruptiveSupport: disableNonDisruptiveSupport,
+		kubeClient:                 client,
+		k8sVersion:                 k8sver,
+		noneSchedulerName:          noschedulerName,
+		lockMap:                    lmap,
+		stitchType:                 stype,
+		enableNonDisruptiveSupport: enableNonDisruptiveSupport,
 	}
 }
 
@@ -245,7 +245,7 @@ func (r *ReScheduler) moveControllerPod(pod *api.Pod, parentKind, parentName, no
 		return nil, err
 	}
 
-	if !r.disableNonDisruptiveSupport {
+	if r.enableNonDisruptiveSupport {
 		// Performs operations for actions to be non-disruptive (when the pod is the only one for the controller)
 		// NOTE: It doesn't support the case of the pod associated to Deployment in version lower than 1.6.0.
 		//       In such case, the action execution will fail.

--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -31,10 +31,10 @@ type containerResizeSpec struct {
 }
 
 type ContainerResizer struct {
-	kubeClient        *kclient.Clientset
-	kubeletClient     *kubelet.KubeletClient
-	k8sVersion        string
-	noneSchedulerName string
+	kubeClient                  *kclient.Clientset
+	kubeletClient               *kubelet.KubeletClient
+	k8sVersion                  string
+	noneSchedulerName           string
 	disableNonDisruptiveSupport bool
 
 	spec *containerResizeSpec
@@ -52,12 +52,12 @@ func NewContainerResizeSpec(idx int) *containerResizeSpec {
 
 func NewContainerResizer(client *kclient.Clientset, kubeletClient *kubelet.KubeletClient, k8sver, noschedulerName string, lmap *util.ExpirationMap, disableNonDisruptiveSupport bool) *ContainerResizer {
 	return &ContainerResizer{
-		kubeClient:        client,
-		kubeletClient:     kubeletClient,
-		k8sVersion:        k8sver,
-		noneSchedulerName: noschedulerName,
+		kubeClient:                  client,
+		kubeletClient:               kubeletClient,
+		k8sVersion:                  k8sver,
+		noneSchedulerName:           noschedulerName,
 		disableNonDisruptiveSupport: disableNonDisruptiveSupport,
-		lockMap:           lmap,
+		lockMap:                     lmap,
 	}
 }
 
@@ -301,7 +301,7 @@ func (r *ContainerResizer) resizeControllerContainer(pod *k8sapi.Pod, parentKind
 		if err != nil {
 			return err
 		}
-		nonDisruptiveHelper := NewNonDisruptiveHelper(r.kubeClient, pod.Namespace, contKind, contName, pod.Name)
+		nonDisruptiveHelper := NewNonDisruptiveHelper(r.kubeClient, pod.Namespace, contKind, contName, pod.Name, r.k8sVersion)
 
 		// Performs operations for non-disruptive resize actions
 		if err := nonDisruptiveHelper.OperateForNonDisruption(); err != nil {

--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -31,11 +31,11 @@ type containerResizeSpec struct {
 }
 
 type ContainerResizer struct {
-	kubeClient                  *kclient.Clientset
-	kubeletClient               *kubelet.KubeletClient
-	k8sVersion                  string
-	noneSchedulerName           string
-	disableNonDisruptiveSupport bool
+	kubeClient                 *kclient.Clientset
+	kubeletClient              *kubelet.KubeletClient
+	k8sVersion                 string
+	noneSchedulerName          string
+	enableNonDisruptiveSupport bool
 
 	spec *containerResizeSpec
 	//a map for concurrent control of Actions
@@ -50,14 +50,14 @@ func NewContainerResizeSpec(idx int) *containerResizeSpec {
 	}
 }
 
-func NewContainerResizer(client *kclient.Clientset, kubeletClient *kubelet.KubeletClient, k8sver, noschedulerName string, lmap *util.ExpirationMap, disableNonDisruptiveSupport bool) *ContainerResizer {
+func NewContainerResizer(client *kclient.Clientset, kubeletClient *kubelet.KubeletClient, k8sver, noschedulerName string, lmap *util.ExpirationMap, enableNonDisruptiveSupport bool) *ContainerResizer {
 	return &ContainerResizer{
-		kubeClient:                  client,
-		kubeletClient:               kubeletClient,
-		k8sVersion:                  k8sver,
-		noneSchedulerName:           noschedulerName,
-		disableNonDisruptiveSupport: disableNonDisruptiveSupport,
-		lockMap:                     lmap,
+		kubeClient:                 client,
+		kubeletClient:              kubeletClient,
+		k8sVersion:                 k8sver,
+		noneSchedulerName:          noschedulerName,
+		enableNonDisruptiveSupport: enableNonDisruptiveSupport,
+		lockMap:                    lmap,
 	}
 }
 
@@ -293,7 +293,7 @@ func (r *ContainerResizer) resizeControllerContainer(pod *k8sapi.Pod, parentKind
 	glog.V(3).Infof("resizeContainer [%s]: got lock for parent[%s]", id, parentName)
 	helper.KeepRenewLock()
 
-	if !r.disableNonDisruptiveSupport {
+	if r.enableNonDisruptiveSupport {
 		// Performs operations for actions to be non-disruptive (when the pod is the only one for the controller)
 		// NOTE: It doesn't support the case of the pod associated to Deployment in version lower than 1.6.0.
 		//       In such case, the action execution will fail.

--- a/pkg/action/util/util.go
+++ b/pkg/action/util/util.go
@@ -511,7 +511,8 @@ func FindPodsByController(kubeClient *client.Clientset, namespace, contName, con
 
 	for i := range podList.Items {
 		pod := &(podList.Items[i])
-		_, name, err := GetPodParentInfo(pod)
+		_, name, err := GetPodGrandInfo(kubeClient, pod)
+
 		if err != nil {
 			continue
 		}

--- a/pkg/kubeturbo_service.go
+++ b/pkg/kubeturbo_service.go
@@ -30,7 +30,7 @@ func NewKubeturboService(c *Config) *KubeturboService {
 
 	// Create action handler.
 	stype := c.ProbeConfig.StitchingPropertyType
-	actionHandlerConfig := action.NewActionHandlerConfig(c.Client, c.KubeletClient, c.k8sVersion, c.noneSchedulerName, stype)
+	actionHandlerConfig := action.NewActionHandlerConfig(c.Client, c.KubeletClient, c.k8sVersion, c.noneSchedulerName, stype, c.disableNonDisruptiveSupport)
 	actionHandler := action.NewActionHandler(actionHandlerConfig)
 
 	k8sTAPServiceConfig := NewK8sTAPServiceConfig(c.Client, c.ProbeConfig, c.tapSpec)

--- a/pkg/kubeturbo_service.go
+++ b/pkg/kubeturbo_service.go
@@ -30,7 +30,7 @@ func NewKubeturboService(c *Config) *KubeturboService {
 
 	// Create action handler.
 	stype := c.ProbeConfig.StitchingPropertyType
-	actionHandlerConfig := action.NewActionHandlerConfig(c.Client, c.KubeletClient, c.k8sVersion, c.noneSchedulerName, stype, c.disableNonDisruptiveSupport)
+	actionHandlerConfig := action.NewActionHandlerConfig(c.Client, c.KubeletClient, c.k8sVersion, c.noneSchedulerName, stype, c.enableNonDisruptiveSupport)
 	actionHandler := action.NewActionHandler(actionHandlerConfig)
 
 	k8sTAPServiceConfig := NewK8sTAPServiceConfig(c.Client, c.ProbeConfig, c.tapSpec)

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -39,6 +39,9 @@ type Config struct {
 	k8sVersion        string
 	noneSchedulerName string
 
+	// Flag for supporting non-disruptive action
+	disableNonDisruptiveSupport bool
+
 	// Close this to stop all reflectors
 	StopEverything chan struct{}
 }
@@ -90,6 +93,11 @@ func (c *Config) WithTapSpec(spec *K8sTAPServiceSpec) *Config {
 
 func (c *Config) WithRecorder(rc record.EventRecorder) *Config {
 	c.Recorder = rc
+	return c
+}
+
+func (c *Config) WithDisableNonDisruptiveFlag(disableNonDisruptiveSupport bool) *Config {
+	c.disableNonDisruptiveSupport = disableNonDisruptiveSupport
 	return c
 }
 

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -40,7 +40,7 @@ type Config struct {
 	noneSchedulerName string
 
 	// Flag for supporting non-disruptive action
-	disableNonDisruptiveSupport bool
+	enableNonDisruptiveSupport bool
 
 	// Close this to stop all reflectors
 	StopEverything chan struct{}
@@ -96,8 +96,8 @@ func (c *Config) WithRecorder(rc record.EventRecorder) *Config {
 	return c
 }
 
-func (c *Config) WithDisableNonDisruptiveFlag(disableNonDisruptiveSupport bool) *Config {
-	c.disableNonDisruptiveSupport = disableNonDisruptiveSupport
+func (c *Config) WithEnableNonDisruptiveFlag(enableNonDisruptiveSupport bool) *Config {
+	c.enableNonDisruptiveSupport = enableNonDisruptiveSupport
 	return c
 }
 


### PR DESCRIPTION
This PR includes two changes:

- Add a flag to kubeturbo config to allow users to disable non-disruptive support
- Add k8s version check for non-disruptive support for Deployment controllers