### PR TITLE
fix issue of coverage test for go tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,20 @@
 language: go
 
 go:
-  - 1.8
+  - 1.9
   - tip
 
 go_import_path: github.com/turbonomic/kubeturbo
 
 before_install:
-  - go get github.com/mattn/goveralls
+  - go get -v github.com/mattn/goveralls
 
+matrix:
+  allow_failures:
+    - go: tip
 
-##TODO: goveralls is not compatible with -race for "go tip",
-#       so the 'make test' is still here. 
-#       Will remove 'make test' if the goveralls with -race can success  
 script:
+  - make fmtcheck 
+  - make vet
   - make product
-  - make test
-  - $HOME/gopath/bin/goveralls -v -service=travis-ci 
+  - if [ "$TRAVIS_GO_VERSION" == "tip" ] ; then make test ; else $HOME/gopath/bin/goveralls -v -race -service=travis-ci ; fi 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 OUTPUT_DIR=./_output
 
+SOURCE_DIRS = cmd pkg
+PACKAGES := go list ./... | grep -v /vendor | grep -v /out
+
+
 product: clean
 	env GOOS=linux GOARCH=amd64 go build -o ${OUTPUT_DIR}/kubeturbo.linux ./cmd/kubeturbo
 
@@ -8,7 +12,15 @@ build: clean
 
 test: clean
 	@go test -v -race ./pkg/...
-	
+
 .PHONY: clean
 clean:
 	@: if [ -f ${OUTPUT_DIR} ] then rm -rf ${OUTPUT_DIR} fi
+
+.PHONY: fmtcheck
+fmtcheck:
+	@gofmt -l $(SOURCE_DIRS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
+
+.PHONY: vet
+vet:
+	@go vet $(shell $(PACKAGES))

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -225,10 +225,10 @@ func keepAlive(tracker sdkprobe.ActionProgressTracker, stop chan struct{}) {
 			t := time.NewTimer(time.Second * 3)
 			select {
 			case <-stop:
+				glog.V(3).Infof("action keepAlive goroutine exit.")
 				return
 			case <-t.C:
 			}
 		}
-		glog.V(3).Infof("action keepAlive goroutine exit.")
 	}()
 }

--- a/pkg/cache/fifohashed.go
+++ b/pkg/cache/fifohashed.go
@@ -73,7 +73,7 @@ func (f *HashedFIFO) HasSynced() bool {
 func (f *HashedFIFO) Add(obj interface{}) error {
 	id, err := f.keyFunc(obj)
 	if err != nil {
-		return cache.KeyError{obj, err}
+		return cache.KeyError{Obj: obj, Err: err}
 	}
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -95,7 +95,7 @@ func (f *HashedFIFO) Add(obj interface{}) error {
 func (f *HashedFIFO) AddIfNotPresent(obj interface{}) error {
 	id, err := f.keyFunc(obj)
 	if err != nil {
-		return cache.KeyError{obj, err}
+		return cache.KeyError{Obj: obj, Err: err}
 	}
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -121,7 +121,7 @@ func (f *HashedFIFO) Update(obj interface{}) error {
 func (f *HashedFIFO) Delete(obj interface{}) error {
 	id, err := f.keyFunc(obj)
 	if err != nil {
-		return cache.KeyError{obj, err}
+		return cache.KeyError{Obj: obj, Err: err}
 	}
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -159,7 +159,7 @@ func (f *HashedFIFO) ListKeys() []string {
 func (f *HashedFIFO) Get(obj interface{}) (item interface{}, exists bool, err error) {
 	key, err := f.keyFunc(obj)
 	if err != nil {
-		return nil, false, cache.KeyError{obj, err}
+		return nil, false, cache.KeyError{Obj: obj, Err: err}
 	}
 	return f.GetByKey(key)
 }
@@ -211,7 +211,7 @@ func (f *HashedFIFO) Replace(list []interface{}, resourceVersion string) error {
 	for _, item := range list {
 		key, err := f.keyFunc(item)
 		if err != nil {
-			return cache.KeyError{item, err}
+			return cache.KeyError{Obj: item, Err: err}
 		}
 		items[key] = item
 	}

--- a/pkg/cache/fifohashed_test.go
+++ b/pkg/cache/fifohashed_test.go
@@ -1,0 +1,30 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+)
+
+func myKeyFunc(obj interface{}) (string, error) {
+	s, ok := obj.(string)
+	if !ok {
+		return "", fmt.Errorf("no string")
+	}
+	return s, nil
+}
+
+func TestHashedFIFO_GetByKey(t *testing.T) {
+	fifo := NewHashedFIFO(myKeyFunc)
+	items := []string{"hello", "world"}
+
+	for _, item := range items {
+		fifo.Add(item)
+	}
+
+	for _, item := range items {
+		_, flag, err := fifo.GetByKey(item)
+		if err != nil || !flag {
+			t.Error("test failed.")
+		}
+	}
+}

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -29,6 +29,12 @@ type ClusterScraper struct {
 	*client.Clientset
 }
 
+func NewClusterScraper(kclient *client.Clientset) *ClusterScraper {
+	return &ClusterScraper{
+		Clientset: kclient,
+	}
+}
+
 func NewClusterInfoScraper(kubeConfig *restclient.Config) (*ClusterScraper, error) {
 	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -34,7 +34,7 @@ type DiscoveryClientConfig struct {
 
 func NewDiscoveryConfig(kubeClient *kubeClient.Clientset, probeConfig *configs.ProbeConfig, targetConfig *configs.K8sTargetConfig) *DiscoveryClientConfig {
 	return &DiscoveryClientConfig{
-		k8sClusterScraper: &cluster.ClusterScraper{kubeClient},
+		k8sClusterScraper: cluster.NewClusterScraper(kubeClient),
 		probeConfig:       probeConfig,
 		targetConfig:      targetConfig,
 	}

--- a/pkg/discovery/monitoring/k8sconntrack/k8sconntrack_monitor.go
+++ b/pkg/discovery/monitoring/k8sconntrack/k8sconntrack_monitor.go
@@ -106,7 +106,7 @@ func (m *K8sConntrackMonitor) RetrieveResourceStat() error {
 			case <-m.stopCh:
 				return
 			default:
-				m.scrapeK8sConntrack(node)
+				m.scrapeK8sConntrack(n)
 			}
 		}(node)
 	}

--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -52,7 +52,7 @@ func (d *Dispatcher) Init(c *ResultCollector) {
 		wid := fmt.Sprintf("w%d", i)
 		discoveryWorker, err := NewK8sDiscoveryWorker(workerConfig, wid)
 		if err != nil {
-			fmt.Errorf("failed to build discovery worker %s", err)
+			glog.Fatalf("failed to build discovery worker %s", err)
 		}
 
 		go discoveryWorker.RegisterAndRun(d, c)

--- a/pkg/turbostore/broker.go
+++ b/pkg/turbostore/broker.go
@@ -60,7 +60,9 @@ func (b *PodBroker) UnSubscribe(key string, consumer Consumer) error {
 		}
 	}
 	if foundIndex == -1 {
-		fmt.Errorf("Consumer %v is not subscribed to listen on %s", consumer, key)
+		err := fmt.Errorf("Consumer %v is not subscribed to listen on %s", consumer, key)
+		glog.Error(err.Error())
+		return err
 	}
 	consumerList = append(consumerList[:foundIndex], consumerList[foundIndex+1:]...)
 	if len(consumerList) == 0 {


### PR DESCRIPTION
This is a temporary fix for the issue about travis.ci:

 travis.ci check will failed with [errors](https://travis-ci.org/turbonomic/kubeturbo/jobs/303619319):
```console
/tmp/go-build066555952/b001/_testmain.go:85:91: undefined: cluster.GoCover_0
/tmp/go-build066555952/b001/_testmain.go:89:82: undefined: task.GoCover_1
/tmp/go-build066555952/b001/_testmain.go:93:80: undefined: turbostore.GoCover_2
/tmp/go-build066555952/b001/_testmain.go:95:82: undefined: turbostore.GoCover_3
/tmp/go-build066555952/b001/_testmain.go:97:82: undefined: turbostore.GoCover_4
/tmp/go-build066555952/b001/_testmain.go:99:85: undefined: turbostore.GoCover_5
/tmp/go-build066555952/b001/_testmain.go:103:87: undefined: metrics.GoCover_6
/tmp/go-build066555952/b001/_testmain.go:105:92: undefined: metrics.GoCover_7
/tmp/go-build066555952/b001/_testmain.go:109:95: undefined: "github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types".GoCover_8
/tmp/go-build066555952/b001/_testmain.go:113:94: undefined: util.GoCover_9
/tmp/go-build066555952/b001/_testmain.go:113:94: too many errors
```

It looks like a bug in Golang, as discussed on [travis-ci](https://github.com/travis-ci/travis-ci/issues/8744) and [Golang](https://github.com/golang/go/issues/22679).

**Soultion**:
    Allow failure for  '**tip**' in `travis.ci.yml`.

Other Updates:
    **1.** Add `gofmt` check via `test -z "$(gofmt -l $GO_FILES)"`;
   **2.** Add `go vet` check;
  
To pass `go vet` check, these files are also update:
```console
pkg/action/action_handler.go
pkg/cache/fifohashed.go
pkg/cluster/cluster_info_scraper.go
pkg/discovery/k8s_discovery_client.go
pkg/discovery/monitoring/k8sconntrack/k8sconntrack_monitor.go
pkg/discovery/worker/dispatcher.go
pkg/turbostore/broker.go
```
    
    




 

