### PR TITLE
Update OpenShift deployment documentation to use same image as in k8s

### DIFF
--- a/deploy/kubeturbo-for-openshift/README.md
+++ b/deploy/kubeturbo-for-openshift/README.md
@@ -85,12 +85,9 @@ spec:
   containers:
   - name: kubeturbo
     # The image is the same one as used in non-OpenShift k8s distributions
-    image: vmturbo/kubeturbo:60
+    image: vmturbo/kubeturbo:6.0
     args:
-      # Need specify the admin.kubeconfig file only for OpenShift version before 3.6
-      # - --kubeconfig=/etc/kubeturbo/admin.kubeconfig
       - --turboconfig=/etc/kubeturbo/config
-      - --k8sVersion=1.6
       # Need specify the kubelet port and https enabled
       - --kubelet-https=true
       - --kubelet-port=10250

--- a/deploy/kubeturbo-for-openshift/README.md
+++ b/deploy/kubeturbo-for-openshift/README.md
@@ -84,10 +84,16 @@ spec:
     kubeturbo: deployable
   containers:
   - name: kubeturbo
-    image: vmturbo/kubeturbo:60os
+    # The image is the same one as used in non-OpenShift k8s distributions
+    image: vmturbo/kubeturbo:60
     args:
-      - --kubeconfig=/etc/kubeturbo/admin.kubeconfig
+      # Need specify the admin.kubeconfig file only for OpenShift version before 3.6
+      # - --kubeconfig=/etc/kubeturbo/admin.kubeconfig
       - --turboconfig=/etc/kubeturbo/config
+      - --k8sVersion=1.6
+      # Need specify the kubelet port and https enabled
+      - --kubelet-https=true
+      - --kubelet-port=10250
     volumeMounts:
     - name: turbo-config
       mountPath: /etc/kubeturbo

--- a/deploy/kubeturbo-for-openshift/kubeturbo-openshift.yaml
+++ b/deploy/kubeturbo-for-openshift/kubeturbo-openshift.yaml
@@ -10,12 +10,9 @@ spec:
   containers:
   - name: kubeturbo
     # The image is the same one as used in non-OpenShift k8s distributions
-    image: vmturbo/kubeturbo:60
+    image: vmturbo/kubeturbo:6.0
     args:
-      # Need to specify the admin.kubeconfig file for OS version before 3.6
-      # - --kubeconfig=/etc/kubeturbo/admin.kubeconfig
       - --turboconfig=/etc/kubeturbo/config
-      - --k8sVersion=1.6
       - --kubelet-https=true
       - --kubelet-port=10250
     volumeMounts:

--- a/deploy/kubeturbo-for-openshift/kubeturbo-openshift.yaml
+++ b/deploy/kubeturbo-for-openshift/kubeturbo-openshift.yaml
@@ -9,10 +9,15 @@ spec:
     kubeturbo: deployable
   containers:
   - name: kubeturbo
-    image: vmturbo/kubeturbo:60os
+    # The image is the same one as used in non-OpenShift k8s distributions
+    image: vmturbo/kubeturbo:60
     args:
-      - --kubeconfig=/etc/kubeturbo/admin.kubeconfig
+      # Need to specify the admin.kubeconfig file for OS version before 3.6
+      # - --kubeconfig=/etc/kubeturbo/admin.kubeconfig
       - --turboconfig=/etc/kubeturbo/config
+      - --k8sVersion=1.6
+      - --kubelet-https=true
+      - --kubelet-port=10250
     volumeMounts:
     - name: vmt-config
       mountPath: /etc/kubeturbo


### PR DESCRIPTION
For OpenShift kubeturbo deployment, we can use the same image as other distributions with additional parameters specified: kubelet-https=true and kubelet-port=10250 as OpenShift is not using the same default values as in Kubernetes clusters.

Tested in OpenShift clusters of version 3.4 and 3.7, kubeturbo worked as expected in both.