### PR TITLE
Write logs to both stderr and file

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder_test.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder_test.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/configs"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
+	restclient "k8s.io/client-go/rest"
+)
+
+func TestVMTServer_createProbeConfigOrDie(t *testing.T) {
+	type args struct {
+		kubeConfig    *restclient.Config
+		kubeletClient *kubelet.KubeletClient
+	}
+	tests := []struct {
+		name                      string
+		CAdvisorPort              int
+		UseVMWare                 bool
+		args                      args
+		wantCAdvisorPort          int
+		wantStitchingPropertyType stitching.StitchingPropertyType
+	}{
+		{
+			name:                      "test-use-vmware",
+			CAdvisorPort:              1234,
+			UseVMWare:                 false,
+			args:                      args{kubeConfig: &restclient.Config{}, kubeletClient: &kubelet.KubeletClient{}},
+			wantCAdvisorPort:          1234,
+			wantStitchingPropertyType: stitching.IP,
+		},
+		{
+			name:                      "test-not-use-vmware",
+			CAdvisorPort:              5678,
+			UseVMWare:                 true,
+			args:                      args{kubeConfig: &restclient.Config{}, kubeletClient: &kubelet.KubeletClient{}},
+			wantCAdvisorPort:          5678,
+			wantStitchingPropertyType: stitching.UUID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &VMTServer{
+				CAdvisorPort: tt.CAdvisorPort,
+				UseVMWare:    tt.UseVMWare,
+			}
+
+			got := s.createProbeConfigOrDie(tt.args.kubeConfig, tt.args.kubeletClient)
+			checkProbeConfig(t, got, tt.wantCAdvisorPort, tt.wantStitchingPropertyType)
+		})
+	}
+}
+
+func checkProbeConfig(t *testing.T, pc *configs.ProbeConfig, cadvisorPort int, stitchingPropertyType stitching.StitchingPropertyType) {
+	if pc.CadvisorPort != cadvisorPort {
+		t.Errorf("CadvisorPort = %v, want %v", pc.CadvisorPort, cadvisorPort)
+	}
+
+	if pc.StitchingPropertyType != stitchingPropertyType {
+		t.Errorf("StitchingPropertyType = %v, want %v", pc.StitchingPropertyType, stitchingPropertyType)
+	}
+}

--- a/cmd/kubeturbo/kubeturbo.go
+++ b/cmd/kubeturbo/kubeturbo.go
@@ -17,8 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"runtime"
 	goflag "flag"
+	"runtime"
 
 	"k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"

--- a/cmd/kubeturbo/kubeturbo.go
+++ b/cmd/kubeturbo/kubeturbo.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"runtime"
+	goflag "flag"
 
 	"k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
@@ -32,12 +33,18 @@ func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	glog.V(2).Infof("*** Run Kubeturbo service ***")
 
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	// The default is to log to both of stderr and file
+	// These arguments can be overloaded from the command-line args
+	goflag.Set("logtostderr", "false")
+	goflag.Set("alsologtostderr", "true")
+	goflag.Set("log_dir", "/var/log")
+
 	s := app.NewVMTServer()
 	s.AddFlags(pflag.CommandLine)
 	flag.InitFlags()
-
-	logs.InitLogs()
-	defer logs.FlushLogs()
 
 	s.Run(pflag.CommandLine.Args())
 }


### PR DESCRIPTION
The change here is to write logging messages to both stderr and files located in /var/log inside the kubeturbo container.

The command-line arguments for glog can be used to override the configurations, e.g., logging folder, logging only to stderr or files, etc. See more parameters [here](https://github.com/golang/glog/blob/master/glog.go).