### PR TITLE
Stitch quota VDCs with VM

### DIFF
--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -225,7 +225,9 @@ func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_Re
 	}
 	propertyNames := []string{builder.PropertyCapacity, builder.PropertyUsed}
 	replacementEntityMetaDataBuilder.PatchSellingWithProperty(proto.CommodityDTO_CLUSTER, propertyNames).
-		PatchSellingWithProperty(proto.CommodityDTO_VMPM_ACCESS, propertyNames)
+		PatchSellingWithProperty(proto.CommodityDTO_VMPM_ACCESS, propertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_CPU_ALLOCATION, propertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_MEM_ALLOCATION, propertyNames)
 	meta := replacementEntityMetaDataBuilder.Build()
 	return meta, nil
 }

--- a/pkg/discovery/worker/quotas_discovery_worker.go
+++ b/pkg/discovery/worker/quotas_discovery_worker.go
@@ -71,13 +71,14 @@ func (worker *k8sResourceQuotasDiscoveryWorker) Do(quotaMetricsList []*repositor
 		}
 		quotaEntity.AverageNodeCpuFrequency = averageNodeFrequency
 
+		// Bought resources from each node
 		// create provider entity for each node
 		for _, node := range kubeNodes {
 			nodeUID := node.UID
 			quotaEntity.AddNodeProvider(nodeUID, quotaMetrics.AllocationBoughtMap[nodeUID])
 		}
 
-		// Set for allocation sold usage if it is not available from the namespace quota objects
+		// Create sold allocation commodity for the types that are not defined in the namespace quota objects
 		for resourceType, used := range quotaMetrics.AllocationSold {
 			existingResource, _ := quotaEntity.GetResource(resourceType)
 			// allocation usage is available from the namespace resource quota objects
@@ -99,7 +100,7 @@ func (worker *k8sResourceQuotasDiscoveryWorker) Do(quotaMetricsList []*repositor
 	}
 
 	// Create DTOs for each quota entity
-	quotaDtoBuilder := dtofactory.NewQuotaEntityDTOBuilder(worker.Cluster.QuotaMap)
+	quotaDtoBuilder := dtofactory.NewQuotaEntityDTOBuilder(worker.Cluster.QuotaMap, worker.Cluster.Nodes)
 	quotaDtos, _ := quotaDtoBuilder.BuildEntityDTOs()
 	return quotaDtos, nil
 }


### PR DESCRIPTION
Need to stitch the resource quota VDCs with the hypervisor VMs discovered by another probe. This is similar to container Pod being stitched with external VMs by specifying the stitching metadata in the supply chain.
- Changed the quota node supply chain to include an external link to VMs
- Quota DTOs will supply the VM ID and IP properties for identifying the VMs
- Proxy VM reconciliation metadata will list the allocation commodities that quota VDCs buy from VMs
