### PR TITLE
Remove access commodities from supply chain 

### DIFF
--- a/pkg/discovery/worker/metrics_collector.go
+++ b/pkg/discovery/worker/metrics_collector.go
@@ -203,10 +203,12 @@ func (collector *MetricsCollector) CollectNodeMetrics(podCollection PodMetricsBy
 	nodeMetricsCollection := make(map[string]*repository.NodeMetrics)
 
 	//Iterate over all the nodes in the collection
-	for nodeName, podsByQuotaMap := range podCollection {
-		node := collector.Cluster.NodeMap[nodeName]
-		if node == nil {
-			continue
+	for _, node := range collector.NodeList {
+		nodeName := node.Name
+		podsByQuotaMap, exists := podCollection[nodeName]
+		if !exists {
+			glog.V(4).Infof("cannot find pod metrics for node %s", nodeName)
+			podsByQuotaMap = make(map[string]PodMetricsList)
 		}
 
 		// collect the metrics for all the pods running on this node across all quotas

--- a/pkg/discovery/worker/metrics_collector_test.go
+++ b/pkg/discovery/worker/metrics_collector_test.go
@@ -29,7 +29,7 @@ func TestPodMetricsListAllocationUsage(t *testing.T) {
 		ComputeUsed: allocation1,
 	}
 	podMetrics2 := &repository.PodMetrics{
-		PodName:     "pod1",
+		PodName:     "pod1", //TODO:
 		ComputeUsed: allocation2,
 	}
 
@@ -75,7 +75,7 @@ var (
 		},
 	}
 
-	pod11 = &v1.Pod{
+	pod_ns1_n1 = &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod11",
 			Namespace: ns1,
@@ -85,7 +85,7 @@ var (
 		},
 	}
 
-	pod12 = &v1.Pod{
+	pod_ns1_n2 = &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod12",
 			Namespace: ns1,
@@ -95,7 +95,7 @@ var (
 		},
 	}
 
-	pod21 = &v1.Pod{
+	pod_ns2_n1 = &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod21",
 			Namespace: ns2,
@@ -105,7 +105,7 @@ var (
 		},
 	}
 
-	pod22 = &v1.Pod{
+	pod_ns2_n2 = &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod22",
 			Namespace: ns2,
@@ -115,7 +115,7 @@ var (
 		},
 	}
 
-	pod31 = &v1.Pod{
+	pod1_ns3_n1 = &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod31",
 			Namespace: ns3,
@@ -125,7 +125,7 @@ var (
 		},
 	}
 
-	pod32 = &v1.Pod{
+	pod2_ns3_n1 = &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod32",
 			Namespace: ns3,
@@ -181,30 +181,33 @@ var (
 			ns4: kubens4,
 		},
 	}
+	cpuUsed_pod_n1_ns1 = 2.0
+	cpuUsed_pod_n1_ns2 = 2.0
+	cpuUsed_pod_n1_ns3 = 2.0
+	cpuUsed_pod_n2_ns1 = 2.0
+	cpuUsed_pod_n2_ns2 = 2.0
+	cpuUsed_pod_n2_ns3 = 0.0
 
-	metricsSink   = metrics.NewEntityMetricSink()
-	etype         = metrics.PodType
-	cpuUsed_pod11 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod11), metrics.CPU, metrics.Used, 2.0)
-	cpuUsed_pod12 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod12), metrics.CPU, metrics.Used, 2.0)
-	cpuUsed_pod21 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod21), metrics.CPU, metrics.Used, 2.0)
-	cpuUsed_pod22 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod22), metrics.CPU, metrics.Used, 2.0)
-	cpuUsed_pod31 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod31), metrics.CPU, metrics.Used, 1.0)
-	cpuUsed_pod32 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod32), metrics.CPU, metrics.Used, 1.0)
+	metricsSink                = metrics.NewEntityMetricSink()
+	etype                      = metrics.PodType
+	metric_cpuUsed_pod_ns1_n1  = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n1), metrics.CPU, metrics.Used, cpuUsed_pod_n1_ns1) //2.0)
+	metric_cpuUsed_pod_ns1_n2  = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n2), metrics.CPU, metrics.Used, cpuUsed_pod_n2_ns1)
+	metric_cpuUsed_pod_ns2_n1  = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns2_n1), metrics.CPU, metrics.Used, cpuUsed_pod_n1_ns2)
+	metric_cpuUsed_pod_ns2_n2  = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns2_n2), metrics.CPU, metrics.Used, cpuUsed_pod_n2_ns2)
+	metric_cpuUsed_pod1_ns3_n1 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod1_ns3_n1), metrics.CPU, metrics.Used, cpuUsed_pod_n1_ns3/2)
+	metric_cpuUsed_pod2_ns3_n1 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod2_ns3_n1), metrics.CPU, metrics.Used, cpuUsed_pod_n1_ns3/2)
+
+	cpuUsed_pod_n1 = cpuUsed_pod_n1_ns1 + cpuUsed_pod_n1_ns2 + cpuUsed_pod_n1_ns3
 )
 
 func TestPodMetrics(t *testing.T) {
-
-	etype := metrics.PodType
-	podKey := util.PodKeyFunc(pod11)
 	quotaName := "Quota1"
+	metricsSink.AddNewMetricEntries(metric_cpuUsed_pod_ns1_n1)
 
-	cpuUsed := metrics.NewEntityResourceMetric(etype, podKey, metrics.CPU, metrics.Used, 2.0)
-	metricsSink.AddNewMetricEntries(cpuUsed)
-
-	pm := createPodMetrics(pod11, quotaName, metricsSink)
+	pm := createPodMetrics(pod_ns1_n1, quotaName, metricsSink)
 	fmt.Printf("pod metrics %++v\n", pm.AllocationBought)
-	assert.Equal(t, pm.AllocationBought[metrics.CPULimit], 2.0)
-	assert.Equal(t, pm.AllocationBought[metrics.CPURequest], 2.0)
+	assert.Equal(t, pm.AllocationBought[metrics.CPULimit], cpuUsed_pod_n1_ns1)
+	assert.Equal(t, pm.AllocationBought[metrics.CPURequest], cpuUsed_pod_n1_ns1)
 
 	assert.Equal(t, pm.AllocationBought[metrics.MemoryLimit], 0.0)
 	assert.Equal(t, pm.AllocationBought[metrics.MemoryRequest], 0.0)
@@ -223,23 +226,50 @@ func TestCreateNodeMetricsMap(t *testing.T) {
 
 	etype = metrics.PodType
 
-	podKey := util.PodKeyFunc(pod11)
+	// Pods in two different namespaces and with only CPU metrics
 	quotaName := "Quota1"
-	cpuUsed = metrics.NewEntityResourceMetric(etype, podKey, metrics.CPU, metrics.Used, 1.5)
-	metricsSink.AddNewMetricEntries(cpuUsed)
-	pm1 := createPodMetrics(pod11, quotaName, metricsSink)
+	metricsSink.AddNewMetricEntries(metric_cpuUsed_pod_ns1_n1)
+	pm1 := createPodMetrics(pod_ns1_n1, quotaName, metricsSink)
 
-	podKey = util.PodKeyFunc(pod21)
 	quotaName = "Quota2"
-	cpuUsed = metrics.NewEntityResourceMetric(etype, podKey, metrics.CPU, metrics.Used, 1.5)
-	metricsSink.AddNewMetricEntries(cpuUsed)
-	pm2 := createPodMetrics(pod21, quotaName, metricsSink)
+	metricsSink.AddNewMetricEntries(metric_cpuUsed_pod_ns2_n1)
+	pm2 := createPodMetrics(pod_ns2_n1, quotaName, metricsSink)
 
-	pmList := []*repository.PodMetrics{pm1, pm2}
+	quotaName = "Quota3"
+	metricsSink.AddNewMetricEntries(metric_cpuUsed_pod1_ns3_n1)
+	pm3 := createPodMetrics(pod1_ns3_n1, quotaName, metricsSink)
+	metricsSink.AddNewMetricEntries(metric_cpuUsed_pod2_ns3_n1)
+	pm4 := createPodMetrics(pod2_ns3_n1, quotaName, metricsSink)
+
+	pmList := []*repository.PodMetrics{pm1, pm2, pm3, pm4}
 	nm := createNodeMetrics(n1, pmList, metricsSink)
-	fmt.Printf("pod metrics %++v\n", nm.AllocationUsed)
-	assert.Equal(t, nm.AllocationUsed[metrics.CPULimit], 3.0)
-	assert.Equal(t, nm.AllocationUsed[metrics.CPURequest], 3.0)
+	assert.Equal(t, nm.AllocationUsed[metrics.CPULimit], cpuUsed_pod_n1) // used is sum of pod usages
+	assert.Equal(t, nm.AllocationUsed[metrics.CPURequest], cpuUsed_pod_n1)
+	assert.Equal(t, nm.AllocationUsed[metrics.MemoryLimit], 0.0) // pod usages is not available
+	assert.Equal(t, nm.AllocationUsed[metrics.MemoryRequest], 0.0)
+
+	assert.Equal(t, nm.AllocationCap[metrics.CPULimit], 4.0)
+	assert.Equal(t, nm.AllocationCap[metrics.CPURequest], 4.0)
+}
+
+func TestCreateMetricsMapForNodeWithEmptyPodList(t *testing.T) {
+	//allocation cap
+	//allocation used
+	etype := metrics.NodeType
+	nodeKey := util.NodeKeyFunc(n1)
+
+	cpuCap := metrics.NewEntityResourceMetric(etype, nodeKey, metrics.CPU, metrics.Capacity, 4.0)
+	metricsSink.AddNewMetricEntries(cpuCap)
+	cpuUsed := metrics.NewEntityResourceMetric(etype, nodeKey, metrics.CPU, metrics.Used, 2.0)
+	metricsSink.AddNewMetricEntries(cpuUsed)
+
+	etype = metrics.PodType
+
+	// emoty pod list for the node
+	pmList := []*repository.PodMetrics{}
+	nm := createNodeMetrics(n1, pmList, metricsSink)
+	assert.Equal(t, nm.AllocationUsed[metrics.CPULimit], 0.0)
+	assert.Equal(t, nm.AllocationUsed[metrics.CPURequest], 0.0)
 	assert.Equal(t, nm.AllocationUsed[metrics.MemoryLimit], 0.0)
 	assert.Equal(t, nm.AllocationUsed[metrics.MemoryRequest], 0.0)
 
@@ -247,29 +277,20 @@ func TestCreateNodeMetricsMap(t *testing.T) {
 	assert.Equal(t, nm.AllocationCap[metrics.CPURequest], 4.0)
 }
 
-func TestCreatePodMetricsMap(t *testing.T) {
+func TestQuotaMetricsMapAllNodes(t *testing.T) {
 	clusterSummary := repository.CreateClusterSummary(kubeCluster)
 
 	collector := &MetricsCollector{
 		Cluster:     clusterSummary,
 		MetricsSink: metricsSink,
-		PodList:     []*v1.Pod{pod11, pod12, pod21, pod22, pod31, pod32},
+		PodList:     []*v1.Pod{pod_ns1_n1, pod_ns1_n2, pod_ns2_n1, pod_ns2_n2, pod1_ns3_n1, pod1_ns3_n1},
 		NodeList:    []*v1.Node{n1, n2},
 	}
 
-	metricsSink.AddNewMetricEntries(cpuUsed_pod11, cpuUsed_pod12,
-		cpuUsed_pod21, cpuUsed_pod22,
-		cpuUsed_pod31, cpuUsed_pod32)
+	metricsSink.AddNewMetricEntries(metric_cpuUsed_pod_ns1_n1, metric_cpuUsed_pod_ns1_n2,
+		metric_cpuUsed_pod_ns2_n1, metric_cpuUsed_pod_ns2_n2,
+		metric_cpuUsed_pod1_ns3_n1, metric_cpuUsed_pod2_ns3_n1)
 	podMetricsMap := collector.CollectPodMetrics()
-	for nodeName, quotaMap := range podMetricsMap {
-		fmt.Printf("%s \n", nodeName)
-		for quotaName, podList := range quotaMap {
-			fmt.Printf("\t%s \n", quotaName)
-			for _, pod := range podList {
-				fmt.Printf("\t\t%s:%++v \n", pod.PodName, pod.AllocationBought)
-			}
-		}
-	}
 
 	nodeMetricsMap := collector.CollectNodeMetrics(podMetricsMap)
 	nm1 := nodeMetricsMap[node1]
@@ -283,38 +304,101 @@ func TestCreatePodMetricsMap(t *testing.T) {
 	for _, qm := range quotaMetricsMap {
 		if qm.QuotaName == ns1 {
 			qm1 = qm
-			fmt.Printf("qm1 %++v\n", qm1)
 		}
 		if qm.QuotaName == ns3 {
 			qm3 = qm
-			fmt.Printf("qm3 %++v\n", qm3)
 		}
 		if qm.QuotaName == ns2 {
 			qm2 = qm
-			fmt.Printf("qm2 %++v\n", qm2)
 		}
 		if qm.QuotaName == ns4 {
 			qm4 = qm
-			fmt.Printf("qm4 %++v\n", qm4)
 		}
 	}
+	// Assert that the quota metrics map is created for all quotas in the cluster
+	// Assert that the allocation bought map is created for each node handled by the metrics collector
 	assert.NotNil(t, qm1)
 	qm1Map := qm1.AllocationBoughtMap
-	assert.Equal(t, qm1Map[node1][metrics.CPULimit], 2.0)
-	assert.Equal(t, qm1Map[node2][metrics.CPULimit], 2.0)
+	assert.NotNil(t, qm1Map[node1])
+	assert.NotNil(t, qm1Map[node2])
+	assert.Equal(t, qm1Map[node1][metrics.CPULimit], cpuUsed_pod_n1_ns1)
+	assert.Equal(t, qm1Map[node2][metrics.CPULimit], cpuUsed_pod_n2_ns1)
 
 	assert.NotNil(t, qm2)
 	qm2Map := qm2.AllocationBoughtMap
-	assert.Equal(t, qm2Map[node1][metrics.CPULimit], 2.0)
-	assert.Equal(t, qm2Map[node2][metrics.CPULimit], 2.0)
+	assert.NotNil(t, qm2Map[node1])
+	assert.NotNil(t, qm2Map[node2])
+	assert.Equal(t, qm2Map[node1][metrics.CPULimit], cpuUsed_pod_n1_ns2)
+	assert.Equal(t, qm2Map[node2][metrics.CPULimit], cpuUsed_pod_n2_ns2)
 
 	assert.NotNil(t, qm3)
 	qm3Map := qm3.AllocationBoughtMap
-	assert.Equal(t, qm3Map[node1][metrics.CPULimit], 2.0)
-	assert.Equal(t, qm3Map[node2][metrics.CPULimit], 0.0)
+	assert.NotNil(t, qm3Map[node1])
+	assert.NotNil(t, qm3Map[node2])
+	assert.Equal(t, qm3Map[node1][metrics.CPULimit], cpuUsed_pod_n1_ns3)
+	assert.Equal(t, qm3Map[node2][metrics.CPULimit], cpuUsed_pod_n2_ns3)
 
 	assert.NotNil(t, qm4)
 	qm4Map := qm4.AllocationBoughtMap
+	assert.NotNil(t, qm4Map[node1])
+	assert.NotNil(t, qm4Map[node2])
 	assert.Equal(t, qm4Map[node1][metrics.CPULimit], 0.0)
 	assert.Equal(t, qm4Map[node2][metrics.CPULimit], 0.0)
+}
+
+func TestQuotaMetricsMapSingleNode(t *testing.T) {
+	clusterSummary := repository.CreateClusterSummary(kubeCluster)
+
+	collector := &MetricsCollector{
+		Cluster:     clusterSummary,
+		MetricsSink: metricsSink,
+		PodList:     []*v1.Pod{},
+		NodeList:    []*v1.Node{n1}, // Metrics collector handles only one one node in the cluster
+	}
+
+	podMetricsMap := collector.CollectPodMetrics()
+
+	var qm1, qm2, qm3, qm4 *repository.QuotaMetrics
+	quotaMetricsMap := collector.CollectQuotaMetrics(podMetricsMap)
+
+	for _, qm := range quotaMetricsMap {
+		if qm.QuotaName == ns1 {
+			qm1 = qm
+		}
+		if qm.QuotaName == ns3 {
+			qm3 = qm
+		}
+		if qm.QuotaName == ns2 {
+			qm2 = qm
+		}
+		if qm.QuotaName == ns4 {
+			qm4 = qm
+		}
+	}
+
+	// Assert that the quota metrics map is created for all quotas in the cluster
+	// Assert that the allocation bought map is created only for the node handled by the metrics collector
+	assert.NotNil(t, qm1)
+	qm1Map := qm1.AllocationBoughtMap
+	assert.NotNil(t, qm1Map[node1])
+	assert.Equal(t, qm1Map[node1][metrics.CPULimit], 0.0)
+	assert.Nil(t, qm1Map[node2])
+
+	assert.NotNil(t, qm2)
+	qm2Map := qm2.AllocationBoughtMap
+	assert.NotNil(t, qm2Map[node1])
+	assert.Equal(t, qm2Map[node1][metrics.CPULimit], 0.0)
+	assert.Nil(t, qm2Map[node2])
+
+	assert.NotNil(t, qm3)
+	qm3Map := qm3.AllocationBoughtMap
+	assert.NotNil(t, qm3Map[node1])
+	assert.Equal(t, qm3Map[node1][metrics.CPULimit], 0.0)
+	assert.Nil(t, qm3Map[node2])
+
+	assert.NotNil(t, qm4)
+	qm4Map := qm4.AllocationBoughtMap
+	assert.NotNil(t, qm4Map[node1])
+	assert.Equal(t, qm4Map[node1][metrics.CPULimit], 0.0)
+	assert.Nil(t, qm4Map[node2])
 }

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -5,22 +5,20 @@ import (
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 
+	"github.com/golang/glog"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"github.com/turbonomic/turbo-go-sdk/pkg/supplychain"
 )
 
 var (
-	vCpuType           proto.CommodityDTO_CommodityType = proto.CommodityDTO_VCPU
-	vMemType           proto.CommodityDTO_CommodityType = proto.CommodityDTO_VMEM
-	cpuProvisionedType proto.CommodityDTO_CommodityType = proto.CommodityDTO_CPU_PROVISIONED
-	memProvisionedType proto.CommodityDTO_CommodityType = proto.CommodityDTO_MEM_PROVISIONED
-	cpuAllocationType  proto.CommodityDTO_CommodityType = proto.CommodityDTO_CPU_ALLOCATION
-	memAllocationType  proto.CommodityDTO_CommodityType = proto.CommodityDTO_MEM_ALLOCATION
-	transactionType    proto.CommodityDTO_CommodityType = proto.CommodityDTO_TRANSACTION
-
-	clusterType    proto.CommodityDTO_CommodityType = proto.CommodityDTO_CLUSTER
-	appCommType    proto.CommodityDTO_CommodityType = proto.CommodityDTO_APPLICATION
-	vmPMAccessType proto.CommodityDTO_CommodityType = proto.CommodityDTO_VMPM_ACCESS
+	vCpuType          proto.CommodityDTO_CommodityType = proto.CommodityDTO_VCPU
+	vMemType          proto.CommodityDTO_CommodityType = proto.CommodityDTO_VMEM
+	cpuAllocationType proto.CommodityDTO_CommodityType = proto.CommodityDTO_CPU_ALLOCATION
+	memAllocationType proto.CommodityDTO_CommodityType = proto.CommodityDTO_MEM_ALLOCATION
+	clusterType       proto.CommodityDTO_CommodityType = proto.CommodityDTO_CLUSTER
+	vmPMAccessType    proto.CommodityDTO_CommodityType = proto.CommodityDTO_VMPM_ACCESS
+	appCommType       proto.CommodityDTO_CommodityType = proto.CommodityDTO_APPLICATION
+	transactionType   proto.CommodityDTO_CommodityType = proto.CommodityDTO_TRANSACTION
 
 	fakeKey string = "fake"
 
@@ -30,10 +28,10 @@ var (
 	memAllocationTemplateCommWithKey *proto.TemplateCommodity = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &memAllocationType}
 	cpuAllocationTemplateComm        *proto.TemplateCommodity = &proto.TemplateCommodity{CommodityType: &cpuAllocationType}
 	memAllocationTemplateComm        *proto.TemplateCommodity = &proto.TemplateCommodity{CommodityType: &memAllocationType}
-	applicationTemplateComm          *proto.TemplateCommodity = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &appCommType}
 	clusterTemplateComm              *proto.TemplateCommodity = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &clusterType}
-	transactionTemplateComm          *proto.TemplateCommodity = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &transactionType}
 	vmpmAccessTemplateComm           *proto.TemplateCommodity = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &vmPMAccessType}
+	applicationTemplateComm          *proto.TemplateCommodity = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &appCommType}
+	transactionTemplateComm          *proto.TemplateCommodity = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &transactionType}
 )
 
 type SupplyChainFactory struct {
@@ -48,51 +46,70 @@ func NewSupplyChainFactory(pType stitching.StitchingPropertyType) *SupplyChainFa
 }
 
 func (f *SupplyChainFactory) createSupplyChain() ([]*proto.TemplateDTO, error) {
-	// Node supply chain builder
-	nodeSupplyChainNodeBuilder, err := f.buildNodeSupplyBuilder()
+	// Node supply chain template
+	nodeSupplyChainNode, err := f.buildNodeSupplyBuilder()
 	if err != nil {
 		return nil, err
 	}
+	glog.V(4).Infof("supply chain node : %++v", nodeSupplyChainNode)
 
-	// Pod supply chain builder
-	podSupplyChainNodeBuilder, err := f.buildPodSupplyBuilder()
+	// Resource Quota supply chain template
+	quotaSupplyChainNode, err := f.buildQuotaSupplyBuilder()
 	if err != nil {
 		return nil, err
 	}
+	glog.V(4).Infof("supply chain node : %++v", quotaSupplyChainNode)
 
-	// Resource Quota template
-	quotaSupplyChainNodeBuilder, err := f.buildQuotaSupplyBuilder()
+	// Pod supply chain template
+	podSupplyChainNode, err := f.buildPodSupplyBuilder()
 	if err != nil {
 		return nil, err
 	}
+	glog.V(4).Infof("supply chain node : %++v", podSupplyChainNode)
 
-	// Container suplly chain builder
-	containerSupplyChainNodeBuilder, err := f.buildContainer()
+	// Container supply chain template
+	containerSupplyChainNode, err := f.buildContainer()
 	if err != nil {
 		return nil, err
 	}
+	glog.V(4).Infof("supply chain node : %++v", containerSupplyChainNode)
 
-	// Application supply chain builder
-	appSupplyChainNodeBuilder, err := f.buildApplicationSupplyBuilder()
+	// Application supply chain template
+	appSupplyChainNode, err := f.buildApplicationSupplyBuilder()
 	if err != nil {
 		return nil, err
 	}
+	glog.V(4).Infof("supply chain node : %++v", appSupplyChainNode)
 
-	// Virtual application supply chain builder
-	vAppSupplyChainNodeBuilder, err := f.buildVirtualApplicationSupplyBuilder()
+	// Virtual application supply chain template
+	vAppSupplyChainNode, err := f.buildVirtualApplicationSupplyBuilder()
 	if err != nil {
 		return nil, err
 	}
+	glog.V(4).Infof("supply chain node : %++v", vAppSupplyChainNode)
 
 	supplyChainBuilder := supplychain.NewSupplyChainBuilder()
-	supplyChainBuilder.Top(vAppSupplyChainNodeBuilder)
-	supplyChainBuilder.Entity(appSupplyChainNodeBuilder)
-	supplyChainBuilder.Entity(containerSupplyChainNodeBuilder)
-	supplyChainBuilder.Entity(podSupplyChainNodeBuilder)
-	supplyChainBuilder.Entity(quotaSupplyChainNodeBuilder)
-	supplyChainBuilder.Entity(nodeSupplyChainNodeBuilder)
+	supplyChainBuilder.Top(vAppSupplyChainNode)
+	supplyChainBuilder.Entity(appSupplyChainNode)
+	supplyChainBuilder.Entity(containerSupplyChainNode)
+	supplyChainBuilder.Entity(podSupplyChainNode)
+	supplyChainBuilder.Entity(quotaSupplyChainNode)
+	supplyChainBuilder.Entity(nodeSupplyChainNode)
 
 	return supplyChainBuilder.Create()
+}
+
+func (f *SupplyChainFactory) buildNodeSupplyBuilder() (*proto.TemplateDTO, error) {
+	nodeSupplyChainNodeBuilder := supplychain.NewSupplyChainNodeBuilder(proto.EntityDTO_VIRTUAL_MACHINE)
+
+	nodeSupplyChainNodeBuilder = nodeSupplyChainNodeBuilder.
+		Sells(vCpuTemplateComm). // sells to Pods
+		Sells(vMemTemplateComm). // sells to Pods
+		// also sells VMPMAccess, Cluster to Pods
+		Sells(cpuAllocationTemplateCommWithKey). //sells to Quotas
+		Sells(memAllocationTemplateCommWithKey)  //sells to Quotas
+
+	return nodeSupplyChainNodeBuilder.Create()
 }
 
 func (f *SupplyChainFactory) buildQuotaSupplyBuilder() (*proto.TemplateDTO, error) {
@@ -110,17 +127,9 @@ func (f *SupplyChainFactory) buildQuotaSupplyBuilder() (*proto.TemplateDTO, erro
 		Commodity(cpuAllocationType, true).
 		Commodity(memAllocationType, true)
 
-	switch f.stitchingPropertyType {
-	case stitching.UUID:
-		vmQuotaExtLinkBuilder.
-			ProbeEntityPropertyDef(supplychain.SUPPLY_CHAIN_CONSTANT_UUID, "UUID of the Node").
-			ExternalEntityPropertyDef(supplychain.VM_UUID)
-	case stitching.IP:
-		vmQuotaExtLinkBuilder.
-			ProbeEntityPropertyDef(supplychain.SUPPLY_CHAIN_CONSTANT_IP_ADDRESS, "IP of the Node").
-			ExternalEntityPropertyDef(supplychain.VM_IP)
-	default:
-		return nil, fmt.Errorf("Stitching property type %s is not supported.", f.stitchingPropertyType)
+	err := f.addVMStitchingProperty(vmQuotaExtLinkBuilder)
+	if err != nil {
+		return nil, err
 	}
 
 	vmQuotaExternalLink, err := vmQuotaExtLinkBuilder.Build()
@@ -131,34 +140,15 @@ func (f *SupplyChainFactory) buildQuotaSupplyBuilder() (*proto.TemplateDTO, erro
 	return nodeSupplyChainNodeBuilder.ConnectsTo(vmQuotaExternalLink).Create()
 }
 
-func (f *SupplyChainFactory) buildNodeSupplyBuilder() (*proto.TemplateDTO, error) {
-	nodeSupplyChainNodeBuilder := supplychain.NewSupplyChainNodeBuilder(proto.EntityDTO_VIRTUAL_MACHINE)
-	nodeSupplyChainNodeBuilder = nodeSupplyChainNodeBuilder.
-		Sells(vCpuTemplateComm).
-		Sells(vMemTemplateComm).
-		Sells(vmpmAccessTemplateComm).
-		// TODO we will re-include provisioned commodities sold by node later.
-		//Sells(cpuProvisionedTemplateComm).
-		//Sells(memProvisionedTemplateComm)
-		Sells(cpuAllocationTemplateCommWithKey).
-		Sells(memAllocationTemplateCommWithKey).
-		Sells(clusterTemplateComm)
-
-	return nodeSupplyChainNodeBuilder.Create()
-}
-
 func (f *SupplyChainFactory) buildPodSupplyBuilder() (*proto.TemplateDTO, error) {
-	// Pod supply chain node builder
 	podSupplyChainNodeBuilder := supplychain.NewSupplyChainNodeBuilder(proto.EntityDTO_CONTAINER_POD)
 	podSupplyChainNodeBuilder = podSupplyChainNodeBuilder.
-		Sells(vCpuTemplateComm).
+		Sells(vCpuTemplateComm). //sells to containers
 		Sells(vMemTemplateComm).
 		Sells(vmpmAccessTemplateComm).
 		Provider(proto.EntityDTO_VIRTUAL_MACHINE, proto.Provider_HOSTING).
-		// TODO we will re-include provisioned commodities bought by pod later.
-		//Buys(cpuProvisionedTemplateComm).
-		//Buys(memProvisionedTemplateComm).
-		Buys(clusterTemplateComm).
+		Buys(vCpuTemplateComm).
+		Buys(vMemTemplateComm).
 		Provider(proto.EntityDTO_VIRTUAL_DATACENTER, proto.Provider_LAYERED_OVER).
 		Buys(cpuAllocationTemplateComm).
 		Buys(memAllocationTemplateComm)
@@ -168,30 +158,35 @@ func (f *SupplyChainFactory) buildPodSupplyBuilder() (*proto.TemplateDTO, error)
 	vmPodExtLinkBuilder.Link(proto.EntityDTO_CONTAINER_POD, proto.EntityDTO_VIRTUAL_MACHINE, proto.Provider_HOSTING).
 		Commodity(vCpuType, false).
 		Commodity(vMemType, false).
-		//Commodity(cpuProvisionedType, false).
-		//Commodity(memProvisionedType, false).
 		Commodity(vmPMAccessType, true).
 		Commodity(clusterType, true)
 
-	switch f.stitchingPropertyType {
-	case stitching.UUID:
-		vmPodExtLinkBuilder.
-			ProbeEntityPropertyDef(supplychain.SUPPLY_CHAIN_CONSTANT_UUID, "UUID of the Node").
-			ExternalEntityPropertyDef(supplychain.VM_UUID)
-	case stitching.IP:
-		vmPodExtLinkBuilder.
-			ProbeEntityPropertyDef(supplychain.SUPPLY_CHAIN_CONSTANT_IP_ADDRESS, "IP of the Node").
-			ExternalEntityPropertyDef(supplychain.VM_IP)
-	default:
-		return nil, fmt.Errorf("Stitching property type %s is not supported.", f.stitchingPropertyType)
+	err := f.addVMStitchingProperty(vmPodExtLinkBuilder)
+	if err != nil {
+		return nil, err
 	}
 
 	vmPodExternalLink, err := vmPodExtLinkBuilder.Build()
 	if err != nil {
 		return nil, err
 	}
-
 	return podSupplyChainNodeBuilder.ConnectsTo(vmPodExternalLink).Create()
+}
+
+func (f *SupplyChainFactory) addVMStitchingProperty(extLinkBuilder *supplychain.ExternalEntityLinkBuilder) error {
+	switch f.stitchingPropertyType {
+	case stitching.UUID:
+		extLinkBuilder.
+			ProbeEntityPropertyDef(supplychain.SUPPLY_CHAIN_CONSTANT_UUID, "UUID of the Node").
+			ExternalEntityPropertyDef(supplychain.VM_UUID)
+	case stitching.IP:
+		extLinkBuilder.
+			ProbeEntityPropertyDef(supplychain.SUPPLY_CHAIN_CONSTANT_IP_ADDRESS, "IP of the Node").
+			ExternalEntityPropertyDef(supplychain.VM_IP)
+	default:
+		return fmt.Errorf("Stitching property type %s is not supported.", f.stitchingPropertyType)
+	}
+	return nil
 }
 
 func (f *SupplyChainFactory) buildContainer() (*proto.TemplateDTO, error) {
@@ -208,7 +203,6 @@ func (f *SupplyChainFactory) buildContainer() (*proto.TemplateDTO, error) {
 }
 
 func (f *SupplyChainFactory) buildApplicationSupplyBuilder() (*proto.TemplateDTO, error) {
-	// Application supply chain builder
 	appSupplyChainNodeBuilder := supplychain.NewSupplyChainNodeBuilder(proto.EntityDTO_APPLICATION)
 	appSupplyChainNodeBuilder = appSupplyChainNodeBuilder.
 		Sells(transactionTemplateComm).


### PR DESCRIPTION
Edited the supply chain to remove access commodities from the node and pod templates.
This is to avoid supply chain errors  in the server for VMs that are validated using the template from kubeturbo instead of hypervisor. VMs without any pods running on them will not have not access commodities and will be removed from the market.
Also included an orthogonal change to the quota metric collection - to ensure that the capacity and used allocation metrics are collected for all the nodes in the cluster, iterate over the list of nodes in the cluster instead of the quota map keyset. Prior to this change, nodes without any running pods were not included for creating the allocation metrics. If the capacity/used values for a resource are not set DTO builder will not build  that commodity, so the allocation commodities for these nodes were not being created.