### PR TITLE
Add logging-agent sidecar container

### DIFF
--- a/logging-agent/README.md
+++ b/logging-agent/README.md
@@ -5,7 +5,7 @@ The logging agent by default performs daily rotation and compression to the `kub
 
 ### Deploy `kubeturbo` with the sidecar container
 
-To deploy `kubeturbo` with the sidecar container, add the container of logging agent in the `kubeturbo` yaml file as follows. In this yaml file, there is one additional volume `varlog`. `varlog` is shared between `kubeturbo` and `sidecar` containers and is mounted to `/var/log` as shown in their container config (`volumeMounts`).
+To deploy `kubeturbo` with the sidecar container, add the container of logging agent in the `kubeturbo` yaml file as in the following example. In this yaml file, there is one additional volume `varlog`. `varlog` is shared between `kubeturbo` and `sidecar` containers and is mounted to `/var/log` as shown in their container config (see `volumeMounts`).
 
 ```yaml
 apiVersion: extensions/v1beta1
@@ -24,7 +24,7 @@ spec:
       containers:
         - name: kubeturbo
           # Replace the image with desired version
-          image: vmturbo/kubeturbo:6.1dev
+          image: vmturbo/kubeturbo:redhat-6.1dev
           imagePullPolicy: IfNotPresent
           args:
             - --turboconfig=/etc/kubeturbo/turbo.config
@@ -39,7 +39,7 @@ spec:
           - name: varlog
             mountPath: /var/log
         - name: logging-agent
-          image: vmturbo/logging-agent:dev
+          image: vmturbo/logging-agent:redhat-dev
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - name: varlog
@@ -57,6 +57,6 @@ spec:
 
 Use the following `kubectl` command to retrieve the log files created by `kubeturbo`
 
-``
+```console
 $kubectl cp <POD_NAME>:/var/log -c kubeturbo <DESTINATION_DIR>
-``
+```

--- a/logging-agent/README.md
+++ b/logging-agent/README.md
@@ -39,7 +39,7 @@ spec:
           - name: varlog
             mountPath: /var/log
         - name: logging-agent
-          image: vmturbo/logging-agent:redhat-dev
+          image: vmturbo/logging-agent:redhat-6.1dev
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - name: varlog
@@ -58,5 +58,6 @@ spec:
 Use the following `kubectl` command to retrieve the log files created by `kubeturbo`
 
 ```console
-$kubectl cp <POD_NAME>:/var/log -c kubeturbo <DESTINATION_DIR>
+$kubectl cp <POD_NAME>:/var/log -c kubeturbo <LOCAL_DIR>
 ```
+

--- a/logging-agent/README.md
+++ b/logging-agent/README.md
@@ -1,0 +1,62 @@
+### Logging Agent
+The logging agent is a sidecar container for `kubeturbo` to perform rotation and compression of log files.
+
+The logging agent by default performs daily rotation and compression to the `kubeturbo` log files located in `/var/log`. The files will be kept for 30 days before cleaned up.
+
+### Deploy `kubeturbo` with the sidecar container
+
+To deploy `kubeturbo` with the sidecar container, add the container of logging agent in the `kubeturbo` yaml file as follows. In this yaml file, there is one additional volume `varlog`. `varlog` is shared between `kubeturbo` and `sidecar` containers and is mounted to `/var/log` as shown in their container config (`volumeMounts`).
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kubeturbo
+  labels:
+    app: kubeturbo
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kubeturbo
+    spec:
+      containers:
+        - name: kubeturbo
+          # Replace the image with desired version
+          image: vmturbo/kubeturbo:6.1dev
+          imagePullPolicy: IfNotPresent
+          args:
+            - --turboconfig=/etc/kubeturbo/turbo.config
+            - --v=3
+            # Uncomment the following two args if running in Openshift
+            #- --kubelet-https=true
+            #- --kubelet-port=10250
+          volumeMounts:
+          - name: turbo-config
+            mountPath: /etc/kubeturbo
+            readOnly: true
+          - name: varlog
+            mountPath: /var/log
+        - name: logging-agent
+          image: vmturbo/logging-agent:dev
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - name: varlog
+            mountPath: /var/log
+      volumes:
+      - name: turbo-config
+        configMap:
+          name: turbo-config
+      - name: varlog
+        emptyDir: {}
+      restartPolicy: Always
+```
+
+### Retrieve log files
+
+Use the following `kubectl` command to retrieve the log files created by `kubeturbo`
+
+``
+$kubectl cp <POD_NAME>:/var/log -c kubeturbo <DESTINATION_DIR>
+``

--- a/logging-agent/docker/Dockerfile
+++ b/logging-agent/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM registry.access.redhat.com/rhel-atomic:7.4-97
 
 COPY logrotate.sh /
 

--- a/logging-agent/docker/Dockerfile
+++ b/logging-agent/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.7
+
+COPY logrotate.sh /
+
+RUN chmod 755 /logrotate.sh
+
+ENTRYPOINT /logrotate.sh

--- a/logging-agent/docker/Dockerfile
+++ b/logging-agent/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel-atomic:7.4-97
+FROM registry.access.redhat.com/rhel7:7.4-129
 
 COPY logrotate.sh /
 

--- a/logging-agent/docker/build.sh
+++ b/logging-agent/docker/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+repo="vmturbo/logging-agent"
+tag="dev"
+docker build -t $repo:$tag .

--- a/logging-agent/docker/build.sh
+++ b/logging-agent/docker/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 repo="vmturbo/logging-agent"
-tag="redhat-dev"
+tag="redhat-6.1dev"
 docker build -t $repo:$tag .

--- a/logging-agent/docker/build.sh
+++ b/logging-agent/docker/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 repo="vmturbo/logging-agent"
-tag="dev"
+tag="redhat-dev"
 docker build -t $repo:$tag .

--- a/logging-agent/docker/logrotate.sh
+++ b/logging-agent/docker/logrotate.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# The directory for kubeturbo logs. Default is /var/log.
+LOG_DIR="${LOG_DIR:-/var/log}"
+
+# Number of log copies to keep. Default is 30 days.
+LOG_COPIES="${LOG_COPIES:-30}"
+
+# The log rotation period. Default is 24 hours.
+LOG_ROTATION_PERIOD="${LOG_ROTATION_PERIOD:-86400}"
+
+echo "Performing log rotatation with parameters: LOG_DIR: $LOG_DIR, LOG_COPIES: $LOG_COPIES, LOG_ROTATION_PERIOD: $LOG_ROTATION_PERIOD"
+
+
+
+# The pattern of kubeturbo log files
+# The log filenames created by glog will end up with the associated pid in the format:
+# "<program name>.<hostname>.<user name>.log.<severity level>.<date>.<time>.<pid>"
+# (e.g., "hello_world.example.com.hamaji.log.INFO.20080709-222411.10474")
+# So, the filenames end up with a digit while the rotated files end up with .log as defined below
+# so that the rotation will not include those rotated files
+LOG_FILES=$LOG_DIR/*.log.[INFO,ERROR,WARNING]*[0-9]
+
+# Keep running log rotation with period of $PERIOD seconds
+# Compress the rotated files except for the latest one (i.e., delay compression)
+while true; do
+  for file in $LOG_FILES; do
+    # Check if the file exists
+    [ -e "$file" ] || continue
+
+    echo "perform log rotating for file $file"
+    i=$LOG_COPIES
+    while [ "$i" != "1" ]; do
+      if [ -f $file.`expr $i - 1`.log.gz ]; then
+        mv -f $file.`expr $i - 1`.log.gz $file.$i.log.gz
+      fi
+
+      # Move $file.1.log to $file.2.log and compress it
+      if [ "$i" == "2" ] && [ -f $file.1.log ]; then
+        mv -f $file.1.log $file.2.log
+        gzip $file.2.log
+      fi
+
+      i=`expr $i - 1`
+    done
+    cp -p $file $file.1.log
+    >$file
+  done
+
+  sleep $LOG_ROTATION_PERIOD
+done

--- a/logging-agent/docker/logrotate.sh
+++ b/logging-agent/docker/logrotate.sh
@@ -9,7 +9,8 @@ LOG_COPIES="${LOG_COPIES:-30}"
 # The log rotation period. Default is 24 hours.
 LOG_ROTATION_PERIOD="${LOG_ROTATION_PERIOD:-86400}"
 
-echo "Performing log rotatation with parameters: LOG_DIR: $LOG_DIR, LOG_COPIES: $LOG_COPIES, LOG_ROTATION_PERIOD: $LOG_ROTATION_PERIOD"
+echo "Performing periodic log rotatation with parameters: LOG_DIR: $LOG_DIR, \
+LOG_COPIES: $LOG_COPIES, LOG_ROTATION_PERIOD: $LOG_ROTATION_PERIOD seconds"
 
 
 
@@ -24,6 +25,8 @@ LOG_FILES=$LOG_DIR/*.log.[INFO,ERROR,WARNING]*[0-9]
 # Keep running log rotation with period of $PERIOD seconds
 # Compress the rotated files except for the latest one (i.e., delay compression)
 while true; do
+  sleep $LOG_ROTATION_PERIOD
+
   for file in $LOG_FILES; do
     # Check if the file exists
     [ -e "$file" ] || continue
@@ -47,5 +50,5 @@ while true; do
     >$file
   done
 
-  sleep $LOG_ROTATION_PERIOD
+  echo "Finished log rotation at $(date)"
 done

--- a/logging-agent/kubeturbo.yaml
+++ b/logging-agent/kubeturbo.yaml
@@ -1,0 +1,43 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kubeturbo
+  labels:
+    app: kubeturbo
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kubeturbo
+    spec:
+      containers:
+        - name: kubeturbo
+          # Replace the image with desired version
+          image: vmturbo/kubeturbo:6.1dev
+          imagePullPolicy: Always
+          args:
+            - --turboconfig=/etc/kubeturbo/turbo.config
+            - --v=3
+            # Uncomment the following two args if running in Openshift
+            #- --kubelet-https=true
+            #- --kubelet-port=10250
+          volumeMounts:
+          - name: turbo-config
+            mountPath: /etc/kubeturbo
+            readOnly: true
+          - name: varlog
+            mountPath: /var/log
+        - name: logging-agent
+          image: vmturbo/logging-agent:dev
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: varlog
+            mountPath: /var/log
+      volumes:
+      - name: turbo-config
+        configMap:
+          name: turbo-config
+      - name: varlog
+        emptyDir: {}
+      restartPolicy: Always

--- a/logging-agent/kubeturbo.yaml
+++ b/logging-agent/kubeturbo.yaml
@@ -14,7 +14,7 @@ spec:
       containers:
         - name: kubeturbo
           # Replace the image with desired version
-          image: vmturbo/kubeturbo:6.1dev
+          image: vmturbo/kubeturbo:redhat-6.1dev
           imagePullPolicy: Always
           args:
             - --turboconfig=/etc/kubeturbo/turbo.config
@@ -29,7 +29,7 @@ spec:
           - name: varlog
             mountPath: /var/log
         - name: logging-agent
-          image: vmturbo/logging-agent:dev
+          image: vmturbo/logging-agent:redhat-dev
           imagePullPolicy: Always
           volumeMounts:
           - name: varlog

--- a/logging-agent/kubeturbo.yaml
+++ b/logging-agent/kubeturbo.yaml
@@ -29,7 +29,7 @@ spec:
           - name: varlog
             mountPath: /var/log
         - name: logging-agent
-          image: vmturbo/logging-agent:redhat-dev
+          image: vmturbo/logging-agent:redhat-6.1dev
           imagePullPolicy: Always
           volumeMounts:
           - name: varlog


### PR DESCRIPTION
Add logging-agent container. The logging agent is a sidecar container for kubeturbo to perform rotation and compression of log files.

The logging agent by default performs daily rotation and compression (to gz files) to the kubeturbo log files located in /var/log. The files will be kept for 30 days before cleaned up.

Users then can perform kubectl command to retrieve the log files: 

_kubectl cp <POD_NAME>:/var/log -c kubeturbo <DESTINATION_DIR>_