### PR TITLE
Add prefix to kubernetes target id.

### DIFF
--- a/pkg/discovery/configs/target_config.go
+++ b/pkg/discovery/configs/target_config.go
@@ -43,6 +43,11 @@ func (config *K8sTargetConfig) ValidateK8sTargetConfig() error {
 			return errors.New("targetIdentifier is not provided")
 		}
 	}
+
+	// Prefix target id (address) with the target type (i.e., "Kubernetes-") to
+	// avoid duplicate target id with other types of targets (e.g., aws).
+	config.TargetIdentifier = defaultTargetType + "-" + config.TargetIdentifier
+
 	if config.TargetUsername == "" {
 		config.TargetUsername = defaultUsername
 	}

--- a/pkg/discovery/configs/target_config.go
+++ b/pkg/discovery/configs/target_config.go
@@ -10,7 +10,7 @@ const (
 	// When user doesn't specify username and password, the default username and password will be used.
 	defaultUsername      = "defaultUser"
 	defaultPassword      = "defaultPassword"
-	defaultProbeCategory = "CloudNative"
+	defaultProbeCategory = "Cloud Native"
 	defaultTargetType    = "Kubernetes"
 )
 
@@ -55,9 +55,7 @@ func (config *K8sTargetConfig) ValidateK8sTargetConfig() error {
 		config.TargetPassword = defaultPassword
 	}
 	if config.ProbeCategory == "" {
-		// Append a random string to avoid communication issues when there are multiple k8s clusters
-		// (as a workaround)
-		config.ProbeCategory = appendRandomName(defaultProbeCategory, config.TargetIdentifier)
+		config.ProbeCategory = defaultProbeCategory
 	}
 	if config.TargetType == "" {
 		// Append a random string to avoid communication issues when there are multiple k8s clusters

--- a/pkg/k8s_tap_service_test.go
+++ b/pkg/k8s_tap_service_test.go
@@ -20,7 +20,7 @@ func TestParseK8sTAPServiceSpec(t *testing.T) {
 	// Check target config
 	checkStartWith(got.TargetType, "Kubernetes-", t)
 	checkStartWith(got.ProbeCategory, "CloudNative-", t)
-	check(got.TargetIdentifier, defaultTargetName, t)
+	check(got.TargetIdentifier, "Kubernetes-"+defaultTargetName, t)
 	check(got.TargetPassword, "defaultPassword", t)
 	check(got.TargetUsername, "defaultUser", t)
 
@@ -44,7 +44,7 @@ func TestParseK8sTAPServiceSpecWithTargetConfig(t *testing.T) {
 	checkStartWith(got.TargetType, "Kubernetes-", t)
 	checkStartWith(got.ProbeCategory, "CloudNative-", t)
 	// The target name should be the one from the config file
-	check(got.TargetIdentifier, "cluster-foo", t)
+	check(got.TargetIdentifier, "Kubernetes-cluster-foo", t)
 	check(got.TargetPassword, "defaultPassword", t)
 	check(got.TargetUsername, "defaultUser", t)
 }
@@ -62,7 +62,7 @@ func TestParseK8sTAPServiceSpecWithOldConfig(t *testing.T) {
 	// Check target config
 	checkStartWith(got.TargetType, "tt1", t)
 	checkStartWith(got.ProbeCategory, "pc1", t)
-	check(got.TargetIdentifier, "addr1", t)
+	check(got.TargetIdentifier, "Kubernetes-addr1", t)
 	// The files of username and password are ignored when parsing the json file
 	check(got.TargetPassword, "defaultPassword", t)
 	check(got.TargetUsername, "defaultUser", t)

--- a/pkg/k8s_tap_service_test.go
+++ b/pkg/k8s_tap_service_test.go
@@ -19,7 +19,7 @@ func TestParseK8sTAPServiceSpec(t *testing.T) {
 
 	// Check target config
 	checkStartWith(got.TargetType, "Kubernetes-", t)
-	checkStartWith(got.ProbeCategory, "CloudNative-", t)
+	checkStartWith(got.ProbeCategory, "Cloud Native", t)
 	check(got.TargetIdentifier, "Kubernetes-"+defaultTargetName, t)
 	check(got.TargetPassword, "defaultPassword", t)
 	check(got.TargetUsername, "defaultUser", t)
@@ -42,7 +42,7 @@ func TestParseK8sTAPServiceSpecWithTargetConfig(t *testing.T) {
 
 	// Check target config
 	checkStartWith(got.TargetType, "Kubernetes-", t)
-	checkStartWith(got.ProbeCategory, "CloudNative-", t)
+	checkStartWith(got.ProbeCategory, "Cloud Native", t)
 	// The target name should be the one from the config file
 	check(got.TargetIdentifier, "Kubernetes-cluster-foo", t)
 	check(got.TargetPassword, "defaultPassword", t)


### PR DESCRIPTION
Add "Kubernetes-" prefix to k8s target id to avoid having same id as other targets of different types (e.g., aws).