### PR TITLE
Disconnect from Turbo server when Kubeturbo is terminated

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder_test.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder_test.go
@@ -1,0 +1,27 @@
+package app
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func Test_handleExit(t *testing.T) {
+	disconnectFuncGotCalled := false
+	mockDisconnectFunc := disconnectFromTurboFunc(func() {
+		fmt.Printf("Mock disconnecting process is running...")
+		disconnectFuncGotCalled = true
+	})
+
+	handleExit(mockDisconnectFunc)
+	disconnectFuncGotCalled = false
+
+	// Sending out the SIGTERM signal to trigger the disconnecting process
+	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	// Wait a bit for the channel to receive and process the signal
+	time.Sleep(100 * time.Millisecond)
+	if !disconnectFuncGotCalled {
+		t.Errorf("The disconnect function was not invoked with signal SIGTERM")
+	}
+}

--- a/cmd/kubeturbo/app/kubeturbo_builder_test.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder_test.go
@@ -2,26 +2,44 @@ package app
 
 import (
 	"fmt"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
 )
 
+type helper struct {
+	funcGotCalled bool
+}
+
+var mux sync.Mutex
+
+func (h *helper) call() {
+	mux.Lock()
+	h.funcGotCalled = true
+	mux.Unlock()
+}
+
+func (h *helper) gotCalled() bool {
+	mux.Lock()
+	defer mux.Unlock()
+	return h.funcGotCalled
+}
+
 func Test_handleExit(t *testing.T) {
-	disconnectFuncGotCalled := false
+	helper := helper{false}
 	mockDisconnectFunc := disconnectFromTurboFunc(func() {
 		fmt.Printf("Mock disconnecting process is running...")
-		disconnectFuncGotCalled = true
+		helper.call()
 	})
 
 	handleExit(mockDisconnectFunc)
-	disconnectFuncGotCalled = false
 
 	// Sending out the SIGTERM signal to trigger the disconnecting process
 	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 	// Wait a bit for the channel to receive and process the signal
 	time.Sleep(100 * time.Millisecond)
-	if !disconnectFuncGotCalled {
+	if !helper.gotCalled() {
 		t.Errorf("The disconnect function was not invoked with signal SIGTERM")
 	}
 }


### PR DESCRIPTION
When a Kubeturbo instance is terminated, the connection to Turbo server should be closed. If not, it may result in invalid endpoints at server side and fail the connection for new Kubeturbo instances.

The code change here is to add the logic to invoke DisconnectFromTurbo function when Kubeturbo is terminated.