### PR TITLE
avoid VDC.UID clashes

### DIFF
--- a/pkg/discovery/dtofactory/quota_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/quota_entity_dto_builder.go
@@ -30,7 +30,7 @@ func (builder *quotaEntityDTOBuilder) BuildEntityDTOs() ([]*proto.EntityDTO, err
 
 	for _, quota := range builder.QuotaMap {
 		// id.
-		quotaID := "VDC-" + quota.Name + "-" + quota.ClusterName
+		quotaID := quota.UID
 		entityDTOBuilder := sdkbuilder.NewEntityDTOBuilder(proto.EntityDTO_VIRTUAL_DATACENTER, quotaID)
 
 		// display name.

--- a/pkg/discovery/dtofactory/quota_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/quota_entity_dto_builder.go
@@ -30,7 +30,7 @@ func (builder *quotaEntityDTOBuilder) BuildEntityDTOs() ([]*proto.EntityDTO, err
 
 	for _, quota := range builder.QuotaMap {
 		// id.
-		quotaID := string(quota.Name)
+		quotaID := "VDC-" + quota.Name + "-" + quota.ClusterName
 		entityDTOBuilder := sdkbuilder.NewEntityDTOBuilder(proto.EntityDTO_VIRTUAL_DATACENTER, quotaID)
 
 		// display name.

--- a/pkg/discovery/processor/namespace_processor.go
+++ b/pkg/discovery/processor/namespace_processor.go
@@ -6,10 +6,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
-)
-
-const(
-	vdcPrefix = "k8s-vdc"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 )
 
 // Class to query the multiple namespace objects data from the Kubernetes API server
@@ -42,7 +39,7 @@ func (processor *NamespaceProcessor) ProcessNamespaces() (map[string]*repository
 		}
 
 		// the default quota object
-		quotaUID := fmt.Sprintf("%s-%s", vdcPrefix, item.UID)
+		quotaUID := util.VDCIdFunc(item.UID)
 		quotaEntity := repository.CreateDefaultQuota(processor.clusterName,
 			namespace.Name,
 			quotaUID,

--- a/pkg/discovery/processor/namespace_processor.go
+++ b/pkg/discovery/processor/namespace_processor.go
@@ -39,7 +39,7 @@ func (processor *NamespaceProcessor) ProcessNamespaces() (map[string]*repository
 		}
 
 		// the default quota object
-		quotaUID := util.VDCIdFunc(item.UID)
+		quotaUID := util.VDCIdFunc(string(item.UID))
 		quotaEntity := repository.CreateDefaultQuota(processor.clusterName,
 			namespace.Name,
 			quotaUID,

--- a/pkg/discovery/processor/namespace_processor.go
+++ b/pkg/discovery/processor/namespace_processor.go
@@ -8,6 +8,10 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 )
 
+const(
+	vdcPrefix = "k8s-vdc"
+)
+
 // Class to query the multiple namespace objects data from the Kubernetes API server
 // and create the resource quota for each
 type NamespaceProcessor struct {
@@ -38,7 +42,7 @@ func (processor *NamespaceProcessor) ProcessNamespaces() (map[string]*repository
 		}
 
 		// the default quota object
-		quotaUID := fmt.Sprintf("vdc-%s", item.UID)
+		quotaUID := fmt.Sprintf("%s-%s", vdcPrefix, item.UID)
 		quotaEntity := repository.CreateDefaultQuota(processor.clusterName,
 			namespace.Name,
 			quotaUID,

--- a/pkg/discovery/processor/namespace_processor.go
+++ b/pkg/discovery/processor/namespace_processor.go
@@ -36,9 +36,12 @@ func (processor *NamespaceProcessor) ProcessNamespaces() (map[string]*repository
 			ClusterName: processor.clusterName,
 			Name:        item.Name,
 		}
+
 		// the default quota object
+		quotaUID := fmt.Sprintf("vdc-%s", item.UID)
 		quotaEntity := repository.CreateDefaultQuota(processor.clusterName,
 			namespace.Name,
+			quotaUID,
 			processor.ClusterResources)
 
 		// update the default quota limits using the defined resource quota objects

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -283,11 +283,11 @@ func (quotaEntity *KubeQuota) String() string {
 
 // Create a Quota object for a namespace.
 // The resource quota limits are based on the cluster compute resource limits.
-func CreateDefaultQuota(clusterName, namespace string,
+func CreateDefaultQuota(clusterName, namespace, uuid string,
 	clusterResources map[metrics.ResourceType]*KubeDiscoveredResource) *KubeQuota {
 	quota := &KubeQuota{
 		KubeEntity: NewKubeEntity(metrics.QuotaType, clusterName,
-			namespace, namespace, namespace),
+			namespace, namespace, uuid),
 		QuotaList: []*v1.ResourceQuota{},
 	}
 

--- a/pkg/discovery/repository/kube_cluster_test.go
+++ b/pkg/discovery/repository/kube_cluster_test.go
@@ -263,3 +263,27 @@ func TestKubeQuotaReconcile(t *testing.T) {
 	resource, _ = kubeQuota.GetAllocationResource(metrics.MemoryLimit)
 	assert.Equal(t, resource.Capacity, leastMemKB) // the least of the 3 quotas
 }
+
+func TestQuotaNames(t *testing.T) {
+	clusterName := "k8s-cluster"
+	namespaceName := "kube-system"
+	namespaceId := "21c65de7-f4e9-11e7-acc0-005056802f41"
+	clusterResources := make(map[metrics.ResourceType]*KubeDiscoveredResource)
+
+	quotaId := util.VDCIdFunc(namespaceId)
+	quota := CreateDefaultQuota(clusterName, namespaceName, quotaId, clusterResources)
+
+	if quota.UID != quotaId {
+		t.Errorf("quota.UID is wrong: %v Vs. %v", quota.UID, quotaId)
+	}
+
+	if quota.ClusterName != clusterName {
+		t.Errorf("quota.clusterName is wrong:%v Vs. %v", quota.ClusterName, clusterName)
+	}
+
+	if quota.Name != namespaceName {
+		t.Errorf("quota.name is wrong: %v Vs. %v", quota.Name, namespaceName)
+	}
+
+	fmt.Printf("quota.info=%++v", quota)
+}

--- a/pkg/discovery/repository/kube_cluster_test.go
+++ b/pkg/discovery/repository/kube_cluster_test.go
@@ -284,6 +284,4 @@ func TestQuotaNames(t *testing.T) {
 	if quota.Name != namespaceName {
 		t.Errorf("quota.name is wrong: %v Vs. %v", quota.Name, namespaceName)
 	}
-
-	fmt.Printf("quota.info=%++v", quota)
 }

--- a/pkg/discovery/repository/kube_cluster_test.go
+++ b/pkg/discovery/repository/kube_cluster_test.go
@@ -86,8 +86,9 @@ func TestKubeQuota(t *testing.T) {
 	cluster := "cluster1"
 
 	var clusterResources map[metrics.ResourceType]*KubeDiscoveredResource
-	for _, testQuota := range TestQuotas {
-		kubeQuota := CreateDefaultQuota(cluster, namespace, clusterResources)
+	for i, testQuota := range TestQuotas {
+		uuid := fmt.Sprintf("vdc-%d", i)
+		kubeQuota := CreateDefaultQuota(cluster, namespace, uuid, clusterResources)
 		hardResourceList := v1.ResourceList{
 			v1.ResourceLimitsCPU:    resource.MustParse(testQuota.cpuLimit),
 			v1.ResourceLimitsMemory: resource.MustParse(testQuota.memLimit),
@@ -145,7 +146,7 @@ func TestKubeQuotaWithMissingAllocations(t *testing.T) {
 		metrics.Memory: &KubeDiscoveredResource{Type: metrics.Memory, Capacity: 16 * 1024},
 	}
 
-	for _, testQuota := range TestQuotas {
+	for i, testQuota := range TestQuotas {
 		hardResourceList := v1.ResourceList{
 			v1.ResourceLimitsCPU: resource.MustParse(testQuota.cpuLimit),
 		}
@@ -167,7 +168,8 @@ func TestKubeQuotaWithMissingAllocations(t *testing.T) {
 		var quotaList []*v1.ResourceQuota
 		quotaList = append(quotaList, quota)
 
-		kubeQuota := CreateDefaultQuota(cluster, namespace, clusterResources)
+		uuid := fmt.Sprintf("vdc-%d", i)
+		kubeQuota := CreateDefaultQuota(cluster, namespace, uuid, clusterResources)
 		kubeQuota.ReconcileQuotas(quotaList)
 
 		resource, _ := kubeQuota.GetAllocationResource(metrics.CPULimit)
@@ -252,7 +254,7 @@ func TestKubeQuotaReconcile(t *testing.T) {
 		}
 		quotaList = append(quotaList, quota)
 	}
-	kubeQuota := CreateDefaultQuota(cluster, namespace, clusterResources)
+	kubeQuota := CreateDefaultQuota(cluster, namespace, "vdc-uuid", clusterResources)
 	kubeQuota.ReconcileQuotas(quotaList)
 
 	resource, _ := kubeQuota.GetAllocationResource(metrics.CPULimit)

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	appIdPrefix = "App"
+	vdcPrefix   = "k8s-vdc"
 )
 
 // PodStatsKeyFunc and PodKeyFunc should return the same value.
@@ -113,4 +114,8 @@ func NodeKeyFunc(node *api.Node) string {
 
 func NodeKeyFromPodFunc(pod *api.Pod) string {
 	return pod.Spec.NodeName
+}
+
+func VDCIdFunc(namespaceId string) string {
+	return fmt.Sprintf("%s-%s", vdcPrefix, namespaceId)
 }

--- a/pkg/discovery/worker/metrics_collector_test.go
+++ b/pkg/discovery/worker/metrics_collector_test.go
@@ -122,10 +122,10 @@ var (
 	clusterResources = map[metrics.ResourceType]*repository.KubeDiscoveredResource{
 		metrics.CPU: {Type: metrics.CPU, Capacity: 8.0},
 	}
-	kubeQuota1 = repository.CreateDefaultQuota(cluster1, ns1, clusterResources)
-	kubeQuota2 = repository.CreateDefaultQuota(cluster1, ns2, clusterResources)
-	kubeQuota3 = repository.CreateDefaultQuota(cluster1, ns3, clusterResources)
-	kubeQuota4 = repository.CreateDefaultQuota(cluster1, ns4, clusterResources)
+	kubeQuota1 = repository.CreateDefaultQuota(cluster1, ns1, "vdc-uuid1", clusterResources)
+	kubeQuota2 = repository.CreateDefaultQuota(cluster1, ns2, "vdc-uuid2", clusterResources)
+	kubeQuota3 = repository.CreateDefaultQuota(cluster1, ns3, "vdc-uuid3", clusterResources)
+	kubeQuota4 = repository.CreateDefaultQuota(cluster1, ns4, "vdc-uuid4", clusterResources)
 
 	kubens1 = &repository.KubeNamespace{
 		ClusterName: cluster1,


### PR DESCRIPTION
Fix [OM-31265](https://vmturbo.atlassian.net/browse/OM-31265), [Issue-144](https://github.com/turbonomic/kubeturbo/issues/144).

**Problem**:
The UUID of VDC is namespace's Name, which can be clashed easily.
In case of UUID clashes, the VDC ServiceEntity won't be created, and UI will show less VDCs than expected.

**Solution**:
Prefix with `k8s-vdc`, and append the corresponding namespace's UUID,
For example for namespace `ste`, the UID is:
`k8s-vdc-796c9d09-f57b-11e7-acc0-005056802f41`