### PR TITLE
OM-31206 : Validate node using InternalIP Address

### DIFF
--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -97,7 +97,7 @@ func (processor *ClusterProcessor) connectToNodes() error {
 }
 
 func checkNode(node *v1.Node, kc kubeclient.KubeHttpClientInterface) (float64, error) {
-	ip := repository.ParseNodeIP(node)
+	ip := repository.ParseNodeIP(node, v1.NodeInternalIP)
 	cpuFreq, err := kc.GetMachineCpuFrequency(ip)
 
 	if err != nil {

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -50,7 +50,7 @@ var (
 func createMockNodes(allocatableMap map[v1.ResourceName]resource.Quantity) []*v1.Node {
 	var nodeList []*v1.Node
 	for _, mockNode := range mockNodes {
-		nodeAddresses := []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: mockNode.ipAddress}}
+		nodeAddresses := []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: mockNode.ipAddress}}
 
 		node := &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -195,10 +195,10 @@ func ParseNodeIP(apiNode *v1.Node) string {
 	nodeAddresses := apiNode.Status.Addresses
 	// Use external IP if it is available. Otherwise use legacy host IP.
 	for _, nodeAddress := range nodeAddresses {
-		if nodeAddress.Type == v1.NodeExternalIP && nodeAddress.Address != "" {
+		if nodeAddress.Type == v1.NodeInternalIP && nodeAddress.Address != "" {
 			nodeStitchingIP = nodeAddress.Address
 		}
-		if nodeStitchingIP == "" && nodeAddress.Address != "" && nodeAddress.Type == v1.NodeInternalIP {
+		if nodeStitchingIP == "" && nodeAddress.Address != "" && nodeAddress.Type == v1.NodeExternalIP {
 			nodeStitchingIP = nodeAddress.Address
 		}
 	}


### PR DESCRIPTION
- Use Internal IP for connecting to cluster node during validation.
- Use ExternalIP values, if available, for stitching metadata property.