### PR TITLE
Create KubeCluster object during each discovery with all the nodes

### DIFF
--- a/pkg/discovery/discovery_performance_tuning.go
+++ b/pkg/discovery/discovery_performance_tuning.go
@@ -82,11 +82,11 @@ func (dc *K8sDiscoveryClient) discoverWithNewFrameworkWithoutCompliance() ([]*pr
 
 	clusterProcessor := processor.NewClusterProcessor(dc.k8sClusterScraper, nil)
 	// Check connection to the cluster
-	kubeCluster, err := dc.clusterProcessor.ConnectCluster()
+	err = dc.clusterProcessor.ConnectCluster()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to connect to cluster: %s", err)
 	}
-	err = clusterProcessor.DiscoverCluster(kubeCluster)
+	kubeCluster, err := clusterProcessor.DiscoverCluster()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to process cluster: %s", err)
 	}

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -41,30 +41,30 @@ func NewDiscoveryConfig(probeConfig *configs.ProbeConfig,
 type K8sDiscoveryClient struct {
 	config            *DiscoveryClientConfig
 	k8sClusterScraper *cluster.ClusterScraper
-	clusterProcessor  *processor.ClusterProcessor
-	kubeCluster       *repository.KubeCluster
 
-	dispatcher      *worker.Dispatcher
-	resultCollector *worker.ResultCollector
+	clusterProcessor *processor.ClusterProcessor
+	dispatcher       *worker.Dispatcher
+	resultCollector  *worker.ResultCollector
 
 	wg sync.WaitGroup
 }
 
 func NewK8sDiscoveryClient(config *DiscoveryClientConfig) *K8sDiscoveryClient {
-	// make maxWorkerCount of result collector twice the worker count.
-	resultCollector := worker.NewResultCollector(workerCount * 2)
 	k8sClusterScraper := cluster.NewClusterScraper(config.probeConfig.ClusterClient)
 
+	// for discovery tasks
 	clusterProcessor := processor.NewClusterProcessor(k8sClusterScraper, config.probeConfig.NodeClient)
+	// make maxWorkerCount of result collector twice the worker count.
+	resultCollector := worker.NewResultCollector(workerCount * 2)
 
 	dispatcherConfig := worker.NewDispatcherConfig(k8sClusterScraper, config.probeConfig, workerCount)
 	dispatcher := worker.NewDispatcher(dispatcherConfig)
 	dispatcher.Init(resultCollector)
 
 	dc := &K8sDiscoveryClient{
-		clusterProcessor:  clusterProcessor,
-		k8sClusterScraper: k8sClusterScraper,
 		config:            config,
+		k8sClusterScraper: k8sClusterScraper,
+		clusterProcessor:  clusterProcessor,
 		dispatcher:        dispatcher,
 		resultCollector:   resultCollector,
 	}
@@ -109,11 +109,10 @@ func (dc *K8sDiscoveryClient) Validate(accountValues []*proto.AccountValue) (*pr
 	validationResponse := &proto.ValidationResponse{}
 
 	var err error
-	var kubeCluster *repository.KubeCluster
 	if dc.clusterProcessor == nil {
 		err = fmt.Errorf("Null cluster processor")
 	} else {
-		kubeCluster, err = dc.clusterProcessor.ConnectCluster()
+		err = dc.clusterProcessor.ConnectCluster()
 	}
 	if err != nil {
 		errStr := fmt.Sprintf("%s\n", err)
@@ -127,7 +126,6 @@ func (dc *K8sDiscoveryClient) Validate(accountValues []*proto.AccountValue) (*pr
 		validationResponse.ErrorDTO = errorDtos
 	} else {
 		glog.V(2).Infof("Validation response - connected to cluster and nodes\n")
-		dc.kubeCluster = kubeCluster
 	}
 
 	return validationResponse, nil
@@ -153,11 +151,11 @@ func (dc *K8sDiscoveryClient) Discover(accountValues []*proto.AccountValue) (*pr
 
 func (dc *K8sDiscoveryClient) discoverWithNewFramework() ([]*proto.EntityDTO, error) {
 	// CREATE CLUSTER, NODES, NAMESPACES AND QUOTAS HERE
-	err := dc.clusterProcessor.DiscoverCluster(dc.kubeCluster)
+	kubeCluster, err := dc.clusterProcessor.DiscoverCluster()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to process cluster: %s", err)
 	}
-	clusterSummary := repository.CreateClusterSummary(dc.kubeCluster)
+	clusterSummary := repository.CreateClusterSummary(kubeCluster)
 
 	// Multiple discovery workers to create node and pod DTOs
 	nodes := clusterSummary.NodeList

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/configs"
@@ -45,8 +44,6 @@ type K8sDiscoveryClient struct {
 	clusterProcessor *processor.ClusterProcessor
 	dispatcher       *worker.Dispatcher
 	resultCollector  *worker.ResultCollector
-
-	wg sync.WaitGroup
 }
 
 func NewK8sDiscoveryClient(config *DiscoveryClientConfig) *K8sDiscoveryClient {

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -93,15 +93,19 @@ func (processor *ClusterProcessor) connectToNodes() (*ClusterValidationResult, e
 				fmt.Sprintf("%s [cpu:%v MHz]", node.Name, nodeCpuFrequency))
 		}
 	}
+	// collect all connection errors
+	errStr := strings.Join(connectionErrors, ", ")
 
 	// All nodes are unreachable
 	if len(unreachable) == len(nodeList) {
-		errStr := strings.Join(connectionErrors, ", ")
 		glog.Errorf("Errors connecting to nodes : %s\n", errStr)
 		validationResult.IsValidated = false
 		return validationResult, fmt.Errorf(errStr)
 	}
 
+	if len(connectionErrors) > 0 {
+		glog.Errorf("Some nodes cannot be reached: %s\n", errStr)
+	}
 	glog.V(2).Infof("Successfully connected to nodes : %s\n", strings.Join(connectionMsgs, ", "))
 	validationResult.IsValidated = true
 	return validationResult, nil

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -185,8 +185,7 @@ func (nodeEntity *KubeNode) UpdateResources(apiNode *v1.Node) {
 		nodeStitchingIP = ParseNodeIP(apiNode, v1.NodeInternalIP)
 	}
 	if nodeStitchingIP == "" {
-		glog.Errorf("Failed to find stitching IP for node %s: it does not have either external IP or legacy "+
-			"host IP.", apiNode.Name)
+		glog.Errorf("Failed to find IP for node %s", apiNode.Name)
 	} else {
 		nodeEntity.IPAddress = nodeStitchingIP
 	}

--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -224,8 +224,9 @@ func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_Re
 		return nil, fmt.Errorf("Stitching property type %s is not supported.", s.stitchingPropertyType)
 	}
 	propertyNames := []string{builder.PropertyCapacity, builder.PropertyUsed}
-	replacementEntityMetaDataBuilder.PatchSellingWithProperty(proto.CommodityDTO_CLUSTER, propertyNames).
-		PatchSellingWithProperty(proto.CommodityDTO_VMPM_ACCESS, propertyNames).
+	accessCommPropertyNames := []string{builder.PropertyCapacity}
+	replacementEntityMetaDataBuilder.PatchSellingWithProperty(proto.CommodityDTO_CLUSTER, accessCommPropertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_VMPM_ACCESS, accessCommPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_CPU_ALLOCATION, propertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_MEM_ALLOCATION, propertyNames)
 	meta := replacementEntityMetaDataBuilder.Build()


### PR DESCRIPTION
We represent the node's schedulable status as an Access commodity in the server.
When a node's schedulable status is disabled, the VM continues to sell the commodity. 
- Changed the Cluster processor code to create the KubeCluster during each discovery. KubeCluster is an internal repository for all the entities in the cluster. This will update the KubeNodes with the api.Node entity (which contains the "schedulable" status) during each discovery.