### PR TITLE
OM-32235: discard dangling services

### DIFF
--- a/pkg/discovery/dtofactory/service_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/service_entity_dto_builder.go
@@ -66,7 +66,7 @@ func (builder *ServiceEntityDTOBuilder) BuildSvcEntityDTO(servicePodMap map[*api
 }
 
 func (builder *ServiceEntityDTOBuilder) createCommodityBought(ebuilder *sdkbuilder.EntityDTOBuilder, pods []*api.Pod, appDTOs map[string]*proto.EntityDTO) error {
-
+	foundProvider := false
 	for _, pod := range pods {
 		podId := string(pod.UID)
 		for i := range pod.Spec.Containers {
@@ -87,7 +87,14 @@ func (builder *ServiceEntityDTOBuilder) createCommodityBought(ebuilder *sdkbuild
 			}
 			provider := sdkbuilder.CreateProvider(proto.EntityDTO_APPLICATION, appId)
 			ebuilder.Provider(provider).BuysCommodities(bought)
+			foundProvider = true
 		}
+	}
+
+	if !foundProvider {
+		err := fmt.Errorf("Failed to found any provider for service")
+		glog.Warning(err.Error())
+		return err
 	}
 
 	return nil

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -163,13 +163,12 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework() ([]*proto.EntityDTO, er
 	quotasDiscoveryWorker := worker.Newk8sResourceQuotasDiscoveryWorker(clusterSummary)
 	quotaDtos, _ := quotasDiscoveryWorker.Do(quotaMetricsList)
 
-	// All the DTO's
+	// All the DTOs
 	entityDTOs = append(entityDTOs, quotaDtos...)
-	glog.V(2).Infof("Discovery workers have finished discovery work with %d entityDTOs built. "+
-		"		Now performing service discovery...", len(entityDTOs))
+	glog.V(2).Infof("Discovery workers have finished discovery work with %d entityDTOs built.", len(entityDTOs))
 
 	// affinity process
-	glog.V(2).Infof("begin to process affinity.")
+	glog.V(2).Infof("Begin to process affinity.")
 	affinityProcessorConfig := compliance.NewAffinityProcessorConfig(dc.k8sClusterScraper)
 	affinityProcessor, err := compliance.NewAffinityProcessor(affinityProcessorConfig)
 	if err != nil {
@@ -185,6 +184,7 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework() ([]*proto.EntityDTO, er
 	if svcDiscResult.Err() != nil {
 		glog.Errorf("Failed to discover services from current Kubernetes cluster with the new discovery framework: %s", svcDiscResult.Err())
 	} else {
+		glog.V(2).Infof("There are %d vApp entityDTOs.", len(svcDiscResult.Content()))
 		entityDTOs = append(entityDTOs, svcDiscResult.Content()...)
 	}
 

--- a/pkg/discovery/worker/service_discovery_worker_test.go
+++ b/pkg/discovery/worker/service_discovery_worker_test.go
@@ -1,0 +1,76 @@
+package worker
+
+import (
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/client-go/pkg/api/v1"
+	"testing"
+)
+
+func getEndPointSubset() api.EndpointSubset {
+
+	targetRef1 := &api.ObjectReference{
+		Kind:      "Pod",
+		Name:      "pod-1",
+		Namespace: "default",
+	}
+	targetRef2 := &api.ObjectReference{
+		Kind:      "Node",
+		Name:      "node-1",
+		Namespace: "",
+	}
+
+	addr1 := api.EndpointAddress{
+		TargetRef: targetRef1,
+	}
+	addr2 := api.EndpointAddress{
+		TargetRef: targetRef2,
+	}
+
+	addrs := []api.EndpointAddress{addr1, addr2}
+
+	result := api.EndpointSubset{
+		Addresses: addrs,
+	}
+
+	return result
+}
+
+func TestFindPodEndpoints(t *testing.T) {
+	svc := &api.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-1",
+			Namespace: "default",
+			UID:       "svc-1-uuid",
+		},
+	}
+
+	subset := getEndPointSubset()
+
+	endpoint := &api.Endpoints{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Endpoints",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-1",
+			Namespace: "default",
+			UID:       "endpoint-1-uuid",
+		},
+
+		Subsets: []api.EndpointSubset{subset},
+	}
+
+	endpointMap := make(map[string]*api.Endpoints)
+	svcId := util.GetEndpointsClusterID(endpoint)
+	endpointMap[svcId] = endpoint
+
+	result := findPodEndpoints(svc, endpointMap)
+	if len(result) != 1 {
+		t.Errorf("Failed to find service's pod endpoints: %d Vs. %d", 1, len(result))
+	}
+}


### PR DESCRIPTION
[OM-32235](https://vmturbo.atlassian.net/browse/OM-32235) 

**Problem**: There are some dangling services, who will fail the supply chain check, and won't be able to be assigned to any hosting cluster (as shown in [OM-32235](https://vmturbo.atlassian.net/browse/OM-32235)).


**Dangling services**: services for whom kubeturbo fails to find the supporting pods.

**Solutions**: Discard these kinds of services during discovery.



