### PR TITLE
Filter out pods that are not in ready status when executing discovery

### DIFF
--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -10,6 +10,7 @@ import (
 	api "k8s.io/client-go/pkg/api/v1"
 
 	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 )
 
 const (
@@ -177,7 +178,7 @@ func (s *ClusterScraper) GetKubernetesServiceID() (svcID string, err error) {
 	return
 }
 
-func (s *ClusterScraper) GetRunningPodsOnNodes(nodeList []*api.Node) []*api.Pod {
+func (s *ClusterScraper) GetRunningAndReadyPodsOnNodes(nodeList []*api.Node) []*api.Pod {
 	pods := []*api.Pod{}
 	for _, node := range nodeList {
 		nodeRunningPodsList, err := s.findRunningPodsOnNode(node.Name)
@@ -187,7 +188,7 @@ func (s *ClusterScraper) GetRunningPodsOnNodes(nodeList []*api.Node) []*api.Pod 
 		}
 		pods = append(pods, nodeRunningPodsList...)
 	}
-	return pods
+	return util.GetReadyPods(pods)
 }
 
 // TODO, create a local pod, node cache to avoid too many API request.

--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -192,7 +192,7 @@ func (builder *applicationEntityDTOBuilder) getApplicationCommoditiesBought(appI
 	if len(resourceCommoditiesBought) != len(applicationResourceCommodityBought) {
 		err = fmt.Errorf("mismatch num of commidities (%d Vs. %d) for application:%s, %s", len(resourceCommoditiesBought), len(applicationResourceCommodityBought), podName, appId)
 		glog.Error(err)
-		//return nil, err
+		return nil, err
 	}
 	commoditiesBought = append(commoditiesBought, resourceCommoditiesBought...)
 

--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -123,7 +123,7 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerK
 	if len(commodities) != len(commoditySold) {
 		err = fmt.Errorf("mismatch num of commidities (%d Vs. %d) for container:%s, %s", len(commodities), len(commoditySold), containerName, containerKey)
 		glog.Error(err)
-		// return nil, err
+		return nil, err
 	}
 	result = append(result, commodities...)
 
@@ -158,7 +158,7 @@ func (builder *containerDTOBuilder) getCommoditiesBought(podId, containerName, c
 	if len(commodities) != len(commodityBought) {
 		err = fmt.Errorf("mismatch num of commidities (%d Vs. %d) for container:%s, %s", len(commodities), len(commodityBought), containerName, containerId)
 		glog.Error(err)
-		//return nil, err
+		return nil, err
 	}
 	result = append(result, commodities...)
 

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -171,6 +171,11 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesSold(pod *api.Pod, cpuFrequ
 	if err != nil {
 		return nil, err
 	}
+	if len(resourceCommoditiesSold) != len(podResourceCommoditySold) {
+		err = fmt.Errorf("mismatch num of bought commidities from node (%d Vs. %d) for pod %s", len(resourceCommoditiesSold), len(podResourceCommoditySold), pod.Name)
+		glog.Error(err)
+		return nil, err
+	}
 	commoditiesSold = append(commoditiesSold, resourceCommoditiesSold...)
 
 	// vmpmAccess commodity
@@ -202,6 +207,11 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBought(pod *api.Pod, cpuFre
 	// Resource Commodities.
 	resourceCommoditiesBought, err := builder.getResourceCommoditiesBought(metrics.PodType, key, podResourceCommodityBoughtFromNode, converter, nil)
 	if err != nil {
+		return nil, err
+	}
+	if len(resourceCommoditiesBought) != len(podResourceCommodityBoughtFromNode) {
+		err = fmt.Errorf("mismatch num of bought commidities from node (%d Vs. %d) for pod %s", len(resourceCommoditiesBought), len(podResourceCommodityBoughtFromNode), pod.Name)
+		glog.Error(err)
 		return nil, err
 	}
 	commoditiesBought = append(commoditiesBought, resourceCommoditiesBought...)
@@ -264,6 +274,11 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBoughtFromQuota(pod *api.Po
 	// Resource Commodities.
 	resourceCommoditiesBought, err := builder.getResourceCommoditiesBought(metrics.PodType, key, podResourceCommodityBoughtFromQuota, converter, nil)
 	if err != nil {
+		return nil, err
+	}
+	if len(resourceCommoditiesBought) != len(podResourceCommodityBoughtFromQuota) {
+		err = fmt.Errorf("mismatch num of bought commidities from quota (%d Vs. %d) for pod %s", len(resourceCommoditiesBought), len(podResourceCommodityBoughtFromQuota), pod.Name)
+		glog.Error(err)
 		return nil, err
 	}
 	commoditiesBought = append(commoditiesBought, resourceCommoditiesBought...)

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -1,0 +1,31 @@
+package dtofactory
+
+import (
+	"testing"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	api "k8s.io/client-go/pkg/api/v1"
+)
+
+var builder = &podEntityDTOBuilder{
+	generalBuilder: newGeneralBuilder(metrics.NewEntityMetricSink()),
+}
+
+func Test_podEntityDTOBuilder_getPodCommoditiesSold_Error(t *testing.T) {
+	testGetCommoditiesWithError(t, builder.getPodCommoditiesSold)
+}
+
+func Test_podEntityDTOBuilder_getPodCommoditiesBought_Error(t *testing.T) {
+	testGetCommoditiesWithError(t, builder.getPodCommoditiesBought)
+}
+
+func Test_podEntityDTOBuilder_getPodCommoditiesBoughtFromQuota_Error(t *testing.T) {
+	testGetCommoditiesWithError(t, builder.getPodCommoditiesBoughtFromQuota)
+}
+
+func testGetCommoditiesWithError(t *testing.T, f func(pod *api.Pod, cpuFrequency float64) ([]*proto.CommodityDTO, error)) {
+	if _, err := f(&api.Pod{}, 100.0); err == nil {
+		t.Errorf("Error thrown expected")
+	}
+}

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -137,3 +137,29 @@ func GroupPodsByNode(pods []*api.Pod) map[string][]*api.Pod {
 	}
 	return podsNodeMap
 }
+
+// GetReadyPods returns pods that in Ready status
+func GetReadyPods(pods []*api.Pod) []*api.Pod {
+	readyPods := []*api.Pod{}
+
+	for _, pod := range pods {
+		if podIsReady(pod) {
+			readyPods = append(readyPods, pod)
+		} else {
+			glog.V(4).Infof("Pod %s is not ready", pod.Name)
+		}
+	}
+
+	return readyPods
+}
+
+// PodIsReady checks if a pod is in Ready status.
+func podIsReady(pod *api.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == api.PodReady {
+			return condition.Status == api.ConditionTrue
+		}
+	}
+	glog.Errorf("Unable to get status for pod %s", pod.Name)
+	return false
+}

--- a/pkg/discovery/util/pod_util_test.go
+++ b/pkg/discovery/util/pod_util_test.go
@@ -2,10 +2,12 @@ package util
 
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sapi "k8s.io/client-go/pkg/api/v1"
 
 	"fmt"
 	"github.com/golang/glog"
+	"reflect"
 	"testing"
 )
 
@@ -114,4 +116,92 @@ func TestIsMonitoredFromAnnotation_Namespace(t *testing.T) {
 
 	ns.Annotations = make(map[string]string)
 	checkObject(ns, t)
+}
+
+func TestGetReadyPods(t *testing.T) {
+	// Set up different PodCondition objects
+	pcReadyTrue := k8sapi.PodCondition{Type: k8sapi.PodReady, Status: k8sapi.ConditionTrue}
+	pcReadyFalse := k8sapi.PodCondition{Type: k8sapi.PodReady, Status: k8sapi.ConditionFalse}
+	pcReadyUnknown := k8sapi.PodCondition{Type: k8sapi.PodReady, Status: k8sapi.ConditionUnknown}
+	pcOther := k8sapi.PodCondition{Type: "foo", Status: "bar"}
+
+	podReady1 := newPod("pod-1", pcReadyTrue)
+	podReady2 := newPod("pod-2", pcReadyTrue, pcOther)
+	podNotReady := newPod("pod-3", pcReadyFalse, pcOther)
+	podUnknown := newPod("pod-4", pcReadyUnknown, pcOther)
+	podNoCond := newPod("pod-5", pcOther)
+
+	tests := []struct {
+		name string
+		pods []*k8sapi.Pod
+		want []*k8sapi.Pod
+	}{
+		{
+			name: "pods-nil",
+			pods: nil,
+			want: []*k8sapi.Pod{},
+		},
+		{
+			name: "pods-empty",
+			pods: []*k8sapi.Pod{},
+			want: []*k8sapi.Pod{},
+		},
+		{
+			name: "pod-ready",
+			pods: []*k8sapi.Pod{podReady1},
+			want: []*k8sapi.Pod{podReady1},
+		},
+		{
+			name: "pods-ready",
+			pods: []*k8sapi.Pod{podReady1, podReady2},
+			want: []*k8sapi.Pod{podReady1, podReady2},
+		},
+		{
+			name: "pod-not-ready",
+			pods: []*k8sapi.Pod{podNotReady},
+			want: []*k8sapi.Pod{},
+		},
+		{
+			name: "pods-not-ready",
+			pods: []*k8sapi.Pod{podNotReady, podUnknown},
+			want: []*k8sapi.Pod{},
+		},
+		{
+			name: "pod-no-cond",
+			pods: []*k8sapi.Pod{podNoCond},
+			want: []*k8sapi.Pod{},
+		},
+		{
+			name: "pods-ready-and-no-cond",
+			pods: []*k8sapi.Pod{podNoCond, podReady1},
+			want: []*k8sapi.Pod{podReady1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetReadyPods(tt.pods); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Test %s: GetReadyPods() = %++v, want %++v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func newPod(name string, podConds ...k8sapi.PodCondition) *k8sapi.Pod {
+	return &k8sapi.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+
+		Spec: k8sapi.PodSpec{},
+
+		Status: k8sapi.PodStatus{
+			Conditions: podConds,
+		},
+	}
 }

--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -81,7 +81,7 @@ func (d *Dispatcher) Dispatch(nodes []*api.Node, cluster *repository.ClusterSumm
 	for assignedNodesCount+perTaskNodeLength <= len(nodes) {
 		currNodes := nodes[assignedNodesCount : assignedNodesCount+perTaskNodeLength]
 
-		currPods := d.config.clusterInfoScraper.GetRunningPodsOnNodes(currNodes)
+		currPods := d.config.clusterInfoScraper.GetRunningAndReadyPodsOnNodes(currNodes)
 
 		currTask := task.NewTask().WithNodes(currNodes).WithPods(currPods).WithCluster(cluster)
 		d.assignTask(currTask)
@@ -92,7 +92,7 @@ func (d *Dispatcher) Dispatch(nodes []*api.Node, cluster *repository.ClusterSumm
 	}
 	if assignedNodesCount < len(nodes) {
 		currNodes := nodes[assignedNodesCount:]
-		currPods := d.config.clusterInfoScraper.GetRunningPodsOnNodes(currNodes)
+		currPods := d.config.clusterInfoScraper.GetRunningAndReadyPodsOnNodes(currNodes)
 		currTask := task.NewTask().WithNodes(currNodes).WithPods(currPods).WithCluster(cluster)
 		d.assignTask(currTask)
 


### PR DESCRIPTION
Currently, Kubeturbo sends to om server the discovered pods, including those pods not in ready status. It causes some supply-check-failed issues at the server side for those unready pods due to missing commodities (e.g., VMem).

The change here is to exclude those _unready_ pods from the topology sent to om server since currently we do (and should) not apply any actions to those pods with invalid statues (e.g., Error).