### PR TITLE
OM-32909 use namespace+name instead of UID for metrics

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -158,7 +158,6 @@ func (builder *podEntityDTOBuilder) getNodeCPUFrequency(pod *api.Pod) (float64, 
 // VMPMAccess is used to bind container to the hosting pod so the container is not moved out of the pod
 func (builder *podEntityDTOBuilder) getPodCommoditiesSold(pod *api.Pod, cpuFrequency float64) ([]*proto.CommodityDTO, error) {
 	var commoditiesSold []*proto.CommodityDTO
-	key := util.PodKeyFunc(pod)
 
 	// cpu and cpu provisioned needs to be converted from number of cores to frequency.
 	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU, metrics.CPUProvisioned)
@@ -167,7 +166,8 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesSold(pod *api.Pod, cpuFrequ
 	attributeSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(false) }, metrics.CPU, metrics.Memory)
 
 	// Resource Commodities
-	resourceCommoditiesSold, err := builder.getResourceCommoditiesSold(metrics.PodType, key, podResourceCommoditySold, converter, attributeSetter)
+	podMId := util.PodMetricIdAPI(pod)
+	resourceCommoditiesSold, err := builder.getResourceCommoditiesSold(metrics.PodType, podMId, podResourceCommoditySold, converter, attributeSetter)
 	if err != nil {
 		return nil, err
 	}
@@ -190,17 +190,13 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesSold(pod *api.Pod, cpuFrequ
 // Commodities bought are vCPU, vMem, cpuProvisioned, memProvisioned, access, cluster
 func (builder *podEntityDTOBuilder) getPodCommoditiesBought(pod *api.Pod, cpuFrequency float64) ([]*proto.CommodityDTO, error) {
 	var commoditiesBought []*proto.CommodityDTO
-	key := util.PodKeyFunc(pod)
 
 	// cpu and cpu provisioned needs to be converted from number of cores to frequency.
 	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU, metrics.CPUProvisioned)
 
-	//// attr TODO: pod is movable, but not resizable.
-	//attributeSetter := NewCommodityAttrSetter()
-	//attributeSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(true) }, metrics.CPU, metrics.Memory)
-
 	// Resource Commodities.
-	resourceCommoditiesBought, err := builder.getResourceCommoditiesBought(metrics.PodType, key, podResourceCommodityBoughtFromNode, converter, nil)
+	podMId := util.PodMetricIdAPI(pod)
+	resourceCommoditiesBought, err := builder.getResourceCommoditiesBought(metrics.PodType, podMId, podResourceCommodityBoughtFromNode, converter, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -150,7 +150,7 @@ func (m *KubeletMonitor) parsePodStats(podStats []stats.PodStats) {
 		pod := &(podStats[i])
 		cpuUsed, memUsed := m.parseContainerStats(pod)
 
-		key := util.PodStatsKeyFunc(pod)
+		key := util.PodMetricId(&(pod.PodRef))
 		glog.V(4).Infof("Cpu usage of pod %s is %.3f core", key, cpuUsed)
 		glog.V(4).Infof("Memory usage of pod %s is %.3f Kb", key, memUsed)
 
@@ -164,7 +164,7 @@ func (m *KubeletMonitor) parseContainerStats(pod *stats.PodStats) (float64, floa
 	totalUsedCPU := float64(0.0)
 	totalUsedMem := float64(0.0)
 
-	podId := pod.PodRef.UID
+	podMId := util.PodMetricId(&(pod.PodRef))
 	containers := pod.Containers
 
 	for i := range containers {
@@ -183,14 +183,14 @@ func (m *KubeletMonitor) parseContainerStats(pod *stats.PodStats) (float64, floa
 		totalUsedMem += memUsed
 
 		//1. container Used
-		containerId := util.ContainerIdFunc(podId, i)
-		m.genUsedMetrics(metrics.ContainerType, containerId, cpuUsed, memUsed)
+		containerMId := util.ContainerMetricId(podMId, container.Name)
+		m.genUsedMetrics(metrics.ContainerType, containerMId, cpuUsed, memUsed)
 
 		glog.V(4).Infof("container[%s-%s] cpu/memory usage:%.3f, %.3f", pod.PodRef.Name, container.Name, cpuUsed, memUsed)
 
 		//2. app Used
-		appId := util.ApplicationIdFunc(containerId)
-		m.genUsedMetrics(metrics.ApplicationType, appId, cpuUsed, memUsed)
+		appMId := util.ApplicationMetricId(containerMId)
+		m.genUsedMetrics(metrics.ApplicationType, appMId, cpuUsed, memUsed)
 	}
 
 	return totalUsedCPU, totalUsedMem

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
@@ -1,15 +1,15 @@
 package kubelet
 
 import (
+	"fmt"
+	"math"
+	"testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api "k8s.io/client-go/pkg/api/v1"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
-	"testing"
 
-	"fmt"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
-	"math"
 )
 
 const (
@@ -39,8 +39,8 @@ func createContainerStat(name string, cpu, mem int) stats.ContainerStats {
 }
 
 func createPodStat() *stats.PodStats {
-	container1 := createContainerStat("container1", 5000000, 430*1024*1024)
-	container2 := createContainerStat("container2", 6000000, 71*1024*1024)
+	container1 := createContainerStat("container1", 5000000, 430*1000*1024)
+	container2 := createContainerStat("container2", 6000000, 71*1000*1024)
 	containers := []stats.ContainerStats{
 		container1,
 		container2,

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
@@ -1,0 +1,197 @@
+package kubelet
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/client-go/pkg/api/v1"
+	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+	"testing"
+
+	"fmt"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"math"
+)
+
+const (
+	myzero = float64(0.00000001)
+)
+
+func createContainerStat(name string, cpu, mem int) stats.ContainerStats {
+	usecores := uint64(cpu)
+	usesecs := uint64(2105741823718)
+	cpuInfo := &stats.CPUStats{
+		UsageNanoCores:       &usecores,
+		UsageCoreNanoSeconds: &usesecs,
+	}
+
+	usedbytes := uint64(mem)
+	memoryInfo := &stats.MemoryStats{
+		UsageBytes: &usedbytes,
+	}
+
+	container := stats.ContainerStats{
+		Name:   name,
+		CPU:    cpuInfo,
+		Memory: memoryInfo,
+	}
+
+	return container
+}
+
+func createPodStat() *stats.PodStats {
+	container1 := createContainerStat("container1", 5000000, 430*1024*1024)
+	container2 := createContainerStat("container2", 6000000, 71*1024*1024)
+	containers := []stats.ContainerStats{
+		container1,
+		container2,
+	}
+	pod := &stats.PodStats{
+		PodRef: stats.PodReference{
+			Namespace: "space1",
+			Name:      "pod1",
+			UID:       "uuid1",
+		},
+		Containers: containers,
+	}
+
+	return pod
+}
+
+func checkPodMetrics(sink *metrics.EntityMetricSink, podMId string, pod *stats.PodStats) error {
+	etype := metrics.PodType
+	resources := []metrics.ResourceType{metrics.CPU, metrics.Memory}
+
+	for _, res := range resources {
+		mid := metrics.GenerateEntityResourceMetricUID(etype, podMId, res, metrics.Used)
+		tmp, err := sink.GetMetric(mid)
+		if err != nil {
+			return fmt.Errorf("Failed to get resource[%v] used value: %v", res, err)
+		}
+
+		value := tmp.GetValue().(float64)
+		expected := float64(0.0)
+		if res == metrics.CPU {
+			for _, c := range pod.Containers {
+				expected += float64(*c.CPU.UsageNanoCores)
+			}
+			expected = expected / util.NanoToUnit
+		} else {
+			for _, c := range pod.Containers {
+				expected += float64(*c.Memory.UsageBytes)
+			}
+			expected = expected / util.KilobytesToBytes
+		}
+
+		if math.Abs(value-expected) > myzero {
+			return fmt.Errorf("pod %v used value check failed: %v Vs. %v", res, expected, value)
+		}
+	}
+
+	return nil
+}
+
+func checkContainerMetrics(sink *metrics.EntityMetricSink, containerMId string, container *stats.ContainerStats) error {
+	etype := metrics.ContainerType
+	resources := []metrics.ResourceType{metrics.CPU, metrics.Memory}
+
+	for _, res := range resources {
+		mid := metrics.GenerateEntityResourceMetricUID(etype, containerMId, res, metrics.Used)
+		tmp, err := sink.GetMetric(mid)
+		if err != nil {
+			return fmt.Errorf("Failed to get resource[%v] used value: %v", res, err)
+		}
+
+		value := tmp.GetValue().(float64)
+		expected := float64(0.0)
+		if res == metrics.CPU {
+			expected += float64(*container.CPU.UsageNanoCores)
+			expected = expected / util.NanoToUnit
+		} else {
+			expected += float64(*container.Memory.UsageBytes)
+			expected = expected / util.KilobytesToBytes
+		}
+
+		if math.Abs(value-expected) > myzero {
+			return fmt.Errorf("container %v used value check failed: %v Vs. %v", res, expected, value)
+		}
+	}
+
+	return nil
+}
+
+func checkApplicationMetrics(sink *metrics.EntityMetricSink, appMId string, container *stats.ContainerStats) error {
+	etype := metrics.ApplicationType
+	resources := []metrics.ResourceType{metrics.CPU, metrics.Memory}
+
+	for _, res := range resources {
+		mid := metrics.GenerateEntityResourceMetricUID(etype, appMId, res, metrics.Used)
+		tmp, err := sink.GetMetric(mid)
+		if err != nil {
+			return fmt.Errorf("Failed to get resource[%v] used value: %v", res, err)
+		}
+
+		value := tmp.GetValue().(float64)
+		expected := float64(0.0)
+		if res == metrics.CPU {
+			expected += float64(*container.CPU.UsageNanoCores)
+			expected = expected / util.NanoToUnit
+		} else {
+			expected += float64(*container.Memory.UsageBytes)
+			expected = expected / util.KilobytesToBytes
+		}
+
+		if math.Abs(value-expected) > myzero {
+			return fmt.Errorf("Application %v used value check failed: %v Vs. %v", res, expected, value)
+		}
+	}
+
+	return nil
+}
+
+func TestParseStats(t *testing.T) {
+	conf := &KubeletMonitorConfig{}
+
+	klet, err := NewKubeletMonitor(conf)
+	if err != nil {
+		t.Errorf("Failed to create kubeletMonitor: %v", err)
+	}
+
+	podstat := createPodStat()
+	pods := []stats.PodStats{*podstat}
+	klet.parsePodStats(pods)
+
+	//1. check pod metrics
+	podref := podstat.PodRef
+	pod := &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: podref.Namespace,
+			Name:      podref.Name,
+			UID:       "pod.real.uuid1",
+		},
+	}
+	podMId := util.PodMetricIdAPI(pod)
+	err = checkPodMetrics(klet.metricSink, podMId, podstat)
+	if err != nil {
+		t.Errorf("check pod used metrics failed: %v", err)
+		return
+	}
+
+	//2. container info
+	for _, c := range podstat.Containers {
+		containerMId := util.ContainerMetricId(podMId, c.Name)
+		err = checkContainerMetrics(klet.metricSink, containerMId, &c)
+		if err != nil {
+			t.Errorf("check container used metrics failed: %v", err)
+		}
+	}
+
+	//3. application info
+	for _, c := range podstat.Containers {
+		containerMId := util.ContainerMetricId(podMId, c.Name)
+		appMId := util.ApplicationMetricId(containerMId)
+		err = checkApplicationMetrics(klet.metricSink, appMId, &c)
+		if err != nil {
+			t.Errorf("check application used metrics failed: %v", err)
+		}
+	}
+}

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -30,7 +30,6 @@ func ApplicationMetricId(containerMId string) string {
 	return appIdPrefix + "-" + containerMId
 }
 
-
 func PodKeyFunc(pod *api.Pod) string {
 	return pod.Namespace + "/" + pod.Name
 }

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -14,14 +14,22 @@ const (
 	vdcPrefix   = "k8s-vdc"
 )
 
-// PodStatsKeyFunc and PodKeyFunc should return the same value.
-func PodStatsKeyFunc(podStat *stats.PodStats) string {
-	return podStat.PodRef.Namespace + "/" + podStat.PodRef.Name
+func PodMetricId(pod *stats.PodReference) string {
+	return pod.Namespace + "/" + pod.Name
 }
 
-func ContainerStatNameFunc(pod *stats.PodStats, containerName string) string {
-	return PodStatsKeyFunc(pod) + "/" + containerName
+func PodMetricIdAPI(pod *api.Pod) string {
+	return pod.Namespace + "/" + pod.Name
 }
+
+func ContainerMetricId(podMId string, containerName string) string {
+	return podMId + "/" + containerName
+}
+
+func ApplicationMetricId(containerMId string) string {
+	return appIdPrefix + "-" + containerMId
+}
+
 
 func PodKeyFunc(pod *api.Pod) string {
 	return pod.Namespace + "/" + pod.Name


### PR DESCRIPTION
[OM-32909](https://vmturbo.atlassian.net/browse/OM-32909)

**Problem**
the Pod metrics from Kubelet has field of `podRef`:
```json
"podRef": {
       "name": "dashboard-proxy-h27fl",
       "namespace": "kube-system",
       "uid": "ab8bc639-230b-11e8-a7bc-06df3546d87c"
   }
```
Previously, we use the `podRef.uid` to build the index of the kubelet metrics, because in general the `podRef.uid` is the UUID of the Pod found by k8s API.

But for mirror pods, the `podRef.uid` is the mirror hashing of the Pod found by k8s API:
```json
"podRef": {
     "name": "memory-static-ip-172-23-1-71.us-west-2.compute.internal",
     "namespace": "default",
     "uid": "8a6f5cfd308e9bde1d8873206f284024"
    }
```
The consequence is that for mirror Pods, kubeturbo cannot find the metrics by Pod's UUID.

**Fix**
1. the metrics from Kubelet is indexed by `pod.Ref.namespace/pod.Ref.name`;
2. kubeturbo find the metrics by `pod.namespace/pod.name`
