### PR TITLE
OM-33736: Handling CPU allocation resource usage values by the Quota DTO Builder

### DIFF
--- a/pkg/discovery/dtofactory/quota_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/quota_entity_dto_builder.go
@@ -137,20 +137,21 @@ func (builder *quotaEntityDTOBuilder) getQuotaCommoditiesSold(quota *repository.
 		// For CPU resources, convert the capacity and usage values expressed in
 		// number of cores to MHz
 		if metrics.IsCPUType(resourceType) && quota.AverageNodeCpuFrequency > 0.0 {
-			// modify the capacity value
+			// always modify the capacity value
 			newVal := capacityValue * quota.AverageNodeCpuFrequency
-			glog.V(4).Infof("%s: changed %s capacity from %f -> %f\n",
+			glog.V(4).Infof("%s::%s: changed capacity from  [%f cores] to %f MHz",
 				quota.Name, resourceType, capacityValue, newVal)
 			capacityValue = newVal
 
-			// Modify the used value that is obtained from the resource quota objects
+			// Modify the used value only if the quota is set for the resource type.
+			// This is because the used value is obtained from the resource quota objects
 			// and represented in number of cores.
-			// If resource quota objects are not defined for the namespace, then the
-			// usage value if the sum of usages of all the pods in the space which
-			// have been converted to MHz
-			if len(quota.QuotaList) > 0 {
+			// If quota is not set for the resource type, the usage is sum of resource
+			// usages for all the pods in the namespace and
+			// has been converted to MHz using the hosting node's CPU frequency
+			if quota.AllocationDefined[resourceType] {
 				newVal := usedValue * quota.AverageNodeCpuFrequency
-				glog.V(4).Infof("%s: changed %s usedValue from %f -> %f\n",
+				glog.V(4).Infof("%s::%s quota defined, changed usage from [%f cores] to %f MHz",
 					quota.Name, resourceType, usedValue, newVal)
 				usedValue = newVal
 			}

--- a/pkg/discovery/dtofactory/quota_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/quota_entity_dto_builder_test.go
@@ -14,12 +14,16 @@ import (
 	"testing"
 )
 
-var TestNodes = []struct {
+const CPUFrequency float64 = 2663.778000
+
+type TestNode struct {
 	name    string
 	cpuCap  float64
 	memCap  float64
 	cluster string
-}{
+}
+
+var TestNodes = []TestNode{
 	{"node1", 4.0, 819200, "cluster1"},
 	{"node2", 5.0, 614400, "cluster1"},
 	{"node3", 6.0, 409600, "cluster1"},
@@ -47,51 +51,83 @@ func makeKubeNodes() []*repository.KubeNode {
 		n1.Status.NodeInfo.SystemUUID = "uuid-" + n1.Name
 
 		kubenode := repository.NewKubeNode(n1, testNode.cluster)
-		//fmt.Printf("%++v\n", kubenode)
 		kubenodes = append(kubenodes, kubenode)
 	}
 
 	return kubenodes
 }
 
-var TestQuotas = []struct {
+type TestQuota struct {
 	name     string
 	cpuLimit string
 	cpuUsed  string
 	memLimit string
 	memUsed  string
-}{
+}
+type TestQuotaWithMemLimit struct {
+	name     string
+	memLimit string
+	memUsed  string
+}
+
+//var TestQuotas = []struct {
+//	name     string
+//	cpuLimit string
+//	cpuUsed  string
+//	memLimit string
+//	memUsed  string
+//}
+var TestQuotas = []TestQuota{
 	{"quota1", "4", "3", "8Gi", "5Gi"},
 	{"quota2", "0.5", "0.3", "7Mi", "5Gi"},
 	{"quota3", "6000m", "300m", "6Ki", "5Ki"},
+	{"quota4", "0", "0", "6Ki", "5Ki"},
 }
 
-var TestNodeProviders = []struct {
-	node    string
-	cpuUsed float64
-	memUsed float64
-}{
-	{"node1", 1.0, 100 * 1024 * 1024.0},
-	{"node2", 0.5, 150 * 1024.0 * 1024.0},
-	{"node3", 1.5, 250 * 1024.0 * 1024.0},
+var TestQuotasWithMemLimit = []TestQuotaWithMemLimit{
+	{"quota1", "8Gi", "5Gi"},
+	{"quota2", "7Mi", "5Gi"},
+	{"quota3", "6Ki", "5Ki"},
 }
+
+//
+//var TestNodeProviders = []TestNode {
+//	{"node1", 1.0, 100 * 1024 * 1024.0},
+//	{"node2", 0.5, 150 * 1024.0 * 1024.0},
+//	{"node3", 1.5, 250 * 1024.0 * 1024.0},
+//}
 
 func makeKubeQuotas() []*repository.KubeQuota {
 	namespace := "ns1"
 	cluster := "cluster1"
 
 	var kubeQuotas []*repository.KubeQuota
-	var clusterResources map[metrics.ResourceType]*repository.KubeDiscoveredResource
+	resourceMap := make(map[metrics.ResourceType]float64)
+	for _, node := range TestNodes {
+		resourceMap[metrics.CPU] = resourceMap[metrics.CPU] + node.cpuCap
+		resourceMap[metrics.Memory] = resourceMap[metrics.Memory] + node.memCap
+	}
+	clusterResources := make(map[metrics.ResourceType]*repository.KubeDiscoveredResource)
+	for rt, resource := range resourceMap {
+		r := &repository.KubeDiscoveredResource{
+			Type:     rt,
+			Capacity: resource,
+		}
+		clusterResources[rt] = r
+	}
 	for i, testQuota := range TestQuotas {
 		uuid := fmt.Sprintf("vdc-%d", i)
 		kubeQuota := repository.CreateDefaultQuota(cluster, namespace, uuid, clusterResources)
-		hardResourceList := v1.ResourceList{
-			v1.ResourceLimitsCPU:    resource.MustParse(testQuota.cpuLimit),
-			v1.ResourceLimitsMemory: resource.MustParse(testQuota.memLimit),
+
+		hardResourceList := v1.ResourceList{}
+		usedResourceList := v1.ResourceList{}
+		if testQuota.cpuLimit != "0" {
+			hardResourceList[v1.ResourceLimitsCPU] = resource.MustParse(testQuota.cpuLimit)
+			usedResourceList[v1.ResourceLimitsCPU] = resource.MustParse(testQuota.cpuUsed)
 		}
-		usedResourceList := v1.ResourceList{
-			v1.ResourceLimitsCPU:    resource.MustParse(testQuota.cpuUsed),
-			v1.ResourceLimitsMemory: resource.MustParse(testQuota.memUsed),
+		if testQuota.memLimit != "0" {
+			hardResourceList[v1.ResourceLimitsMemory] = resource.MustParse(testQuota.memLimit)
+			usedResourceList[v1.ResourceLimitsMemory] = resource.MustParse(testQuota.memUsed)
 		}
 
 		quota := &v1.ResourceQuota{
@@ -105,18 +141,29 @@ func makeKubeQuotas() []*repository.KubeQuota {
 				Used: usedResourceList,
 			},
 		}
+
 		var quotaList []*v1.ResourceQuota
 		quotaList = append(quotaList, quota)
-		//fmt.Printf("%++v\n", quota)
 		kubeQuota.ReconcileQuotas(quotaList)
+
+		// simulate pod usage values for the allocation resource commodities without quota limit
+		for _, resourceType := range metrics.ComputeAllocationResources {
+			if !kubeQuota.AllocationDefined[resourceType] {
+				resource := kubeQuota.AllocationResources[resourceType]
+				computeType := metrics.AllocationToComputeMap[resourceType]
+				resource.Used = clusterResources[computeType].Capacity * 0.1
+			}
+		}
 
 		for _, node := range TestNodes {
 			allocationResourceMap := make(map[metrics.ResourceType]float64)
-			allocationResourceMap[metrics.CPULimit] = node.cpuCap
-			allocationResourceMap[metrics.MemoryLimit] = node.memCap
+			allocationResourceMap[metrics.CPULimit] = node.cpuCap * 0.033
+			allocationResourceMap[metrics.CPURequest] = node.cpuCap * 0.033
+			allocationResourceMap[metrics.MemoryLimit] = node.memCap * 0.033
+			allocationResourceMap[metrics.MemoryRequest] = node.memCap * 0.033
 			kubeQuota.AddNodeProvider(node.name, allocationResourceMap)
 		}
-
+		kubeQuota.AverageNodeCpuFrequency = CPUFrequency
 		kubeQuotas = append(kubeQuotas, kubeQuota)
 	}
 
@@ -159,11 +206,31 @@ func TestBuildQuotaDto(t *testing.T) {
 			comm, exists := commMap[commType]
 			assert.True(t, exists, fmt.Sprintf("%s does not exist", commType))
 			assert.EqualValues(t, dto.GetId(), comm.GetKey())
+			quota, exists := quotaMap[dto.GetId()]
+			assert.True(t, exists)
+
+			resource, exists := quota.AllocationResources[allocationResource]
+			assert.True(t, exists, fmt.Sprintf("%s does not exist", resource))
+			if metrics.IsCPUType(allocationResource) {
+				assert.EqualValues(t, resource.Capacity*CPUFrequency, comm.GetCapacity())
+			} else {
+				assert.EqualValues(t, resource.Capacity, comm.GetCapacity())
+			}
+			if metrics.IsCPUType(allocationResource) && quota.AllocationDefined[allocationResource] {
+				assert.EqualValues(t, resource.Used*CPUFrequency, comm.GetUsed())
+			}
 		}
 
 		commBoughtList := dto.GetCommoditiesBought()
+		providerMap := make(map[string]TestNode)
+		for _, node := range TestNodes {
+			providerMap[node.name] = node
+		}
 		for _, commBoughtPerProvider := range commBoughtList {
 			boughtList := commBoughtPerProvider.GetBought()
+			provider := *commBoughtPerProvider.ProviderId
+			_, exists := providerMap[provider]
+			assert.True(t, exists, fmt.Sprintf("%s provider does not exist", provider))
 			commMap = make(map[proto.CommodityDTO_CommodityType]*proto.CommodityDTO)
 			for _, commBought := range boughtList {
 				commMap[commBought.GetCommodityType()] = commBought


### PR DESCRIPTION
Quota DTO Builder handles the conversion of CPU capacity/usage from number of cores to MHZ.
When the quota is defined for the CPU resource, the usage value obtained from the quota object is in number of cores and should be converted to MHZ.
When the quota is not defined for the CPU resource, the usage value is computed using the cpu usage  of all the pods running in that namespace and is represented in MHz and the conversion is not required. The additional conversion would increase the usage values to a larger number resulting in invalid utilization values.