### PR TITLE
Add date to log file name in logging agent

### DIFF
--- a/logging-agent/docker/logrotate.sh
+++ b/logging-agent/docker/logrotate.sh
@@ -3,7 +3,7 @@
 # The directory for kubeturbo logs. Default is /var/log.
 LOG_DIR="${LOG_DIR:-/var/log}"
 
-# Number of log copies to keep. Default is 30 days.
+# Number of log copies to keep. Default is 30.
 LOG_COPIES="${LOG_COPIES:-30}"
 
 # The log rotation period. Default is 24 hours.
@@ -41,7 +41,7 @@ rotate () {
 
     # Move all the outdated log files to the temp files, which
     # will only keep the last outdated files
-    for gzfile in $logfiles*.$i.log.gz; do
+    for gzfile in $logfiles*.$i.log.gz $logfiles*.$i.log; do
       if [ -f "$gzfile" ]; then
         newfile=$file.tmp
         mv -f $gzfile $newfile

--- a/logging-agent/docker/logrotate.sh
+++ b/logging-agent/docker/logrotate.sh
@@ -12,43 +12,81 @@ LOG_ROTATION_PERIOD="${LOG_ROTATION_PERIOD:-86400}"
 echo "Performing periodic log rotatation with parameters: LOG_DIR: $LOG_DIR, \
 LOG_COPIES: $LOG_COPIES, LOG_ROTATION_PERIOD: $LOG_ROTATION_PERIOD seconds"
 
-
-
 # The pattern of kubeturbo log files
 # The log filenames created by glog will end up with the associated pid in the format:
 # "<program name>.<hostname>.<user name>.log.<severity level>.<date>.<time>.<pid>"
 # (e.g., "hello_world.example.com.hamaji.log.INFO.20080709-222411.10474")
 # So, the filenames end up with a digit while the rotated files end up with .log as defined below
 # so that the rotation will not include those rotated files
-LOG_FILES=$LOG_DIR/*.log.[INFO,ERROR,WARNING]*[0-9]
+INFO_LOG_FILES=$LOG_DIR/*.log.INFO*[0-9]
+WARNING_LOG_FILES=$LOG_DIR/*.log.WARNING*[0-9]
+ERROR_LOG_FILES=$LOG_DIR/*.log.ERROR*[0-9]
+
+# Function to rotate the given log files in the parameter. Delay compression applies.
+# E.g., for the log file: test.log and for LOG_COPIES=10,
+# first rotation: test-<date>.1.log (no compression)
+# second rotation: test-<date>.1.log and test-<date>.2.log.gz
+# third rotation: test-<date>.1.log, test-<date>.2.log.gz, and test-<date>.3.log.gz
+# ...
+# After the 10th rotation: test-<date>.1.log, test-<date>.2.log.gz, ..., and test-<date>.10.log.gz (max 10 copies)
+rotate () {
+  logfiles=$1
+
+  for file in $logfiles; do
+    # Check if the file exists
+    [ -e "$file" ] || continue
+
+    echo "perform log rotating for file $file"
+    i=$LOG_COPIES
+
+    # Move all the outdated log files to the temp files, which
+    # will only keep the last outdated files
+    for gzfile in $logfiles*.$i.log.gz; do
+      if [ -f "$gzfile" ]; then
+        newfile=$file.tmp
+        mv -f $gzfile $newfile
+      fi
+    done
+
+    while [ "$i" != "1" ]; do
+      # Move the .log.gz files to next index (e.g. file.<date>.3.log.gz to file.<date>.4.log.gz)
+      j=`expr $i - 1`
+      for gzfile in $logfiles*.$j.log.gz; do
+        if [ -f "$gzfile" ]; then
+          newfile=$(dirname $gzfile)/$(basename $gzfile .$j.log.gz).$i.log.gz
+          mv -f $gzfile $newfile
+        fi
+      done
+
+      # Move .1.log files to .2.log files and perform compression (to .2.log.gz)
+      if [ "$i" == "2" ]; then
+        for gzfile in $logfiles*.1.log; do
+          if [ -f "$gzfile" ]; then
+            newfile=$(dirname $gzfile)/$(basename $gzfile .1.log).2.log
+            mv -f $gzfile $newfile
+            gzip $newfile
+          fi
+        done
+      fi
+
+      i=`expr $i - 1`
+    done
+    # Copy the log file to the rotated file <date>.1.log (e.g., file.log -> file.<date>.1.log)
+    cp -p $file $file-$(date "+%Y%m%d-%H%M%S").1.log
+    >$file
+  done
+}
 
 # Keep running log rotation with period of $PERIOD seconds
 # Compress the rotated files except for the latest one (i.e., delay compression)
 while true; do
   sleep $LOG_ROTATION_PERIOD
 
-  for file in $LOG_FILES; do
-    # Check if the file exists
-    [ -e "$file" ] || continue
-
-    echo "perform log rotating for file $file"
-    i=$LOG_COPIES
-    while [ "$i" != "1" ]; do
-      if [ -f $file.`expr $i - 1`.log.gz ]; then
-        mv -f $file.`expr $i - 1`.log.gz $file.$i.log.gz
-      fi
-
-      # Move $file.1.log to $file.2.log and compress it
-      if [ "$i" == "2" ] && [ -f $file.1.log ]; then
-        mv -f $file.1.log $file.2.log
-        gzip $file.2.log
-      fi
-
-      i=`expr $i - 1`
-    done
-    cp -p $file $file.1.log
-    >$file
-  done
+  # Start rotating
+  rotate $INFO_LOG_FILES
+  rotate $WARNING_LOG_FILES
+  rotate $ERROR_LOG_FILES
 
   echo "Finished log rotation at $(date)"
 done
+

--- a/logging-agent/docker/test-logrotate.sh
+++ b/logging-agent/docker/test-logrotate.sh
@@ -5,14 +5,14 @@ set -e
 # kill -- -$$ sends a SIGTERM to the whole process group, thus killing also descendants.
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
-# The directory for kubeturbo logs. Default is /var/log.
+# The directory for kubeturbo logs
 export LOG_DIR=$PWD/var/log
 mkdir -p $LOG_DIR
 
-# Number of log copies to keep. Default is 30 days.
+# Number of log copies to keep
 export LOG_COPIES=10
 
-# The log rotation period. Default is 24 hours.
+# The log rotation period
 export LOG_ROTATION_PERIOD=5
 
 # Start log ratoation process

--- a/logging-agent/docker/test-logrotate.sh
+++ b/logging-agent/docker/test-logrotate.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+# kill -- -$$ sends a SIGTERM to the whole process group, thus killing also descendants.
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
+# The directory for kubeturbo logs. Default is /var/log.
+export LOG_DIR=$PWD/var/log
+mkdir -p $LOG_DIR
+
+# Number of log copies to keep. Default is 30 days.
+export LOG_COPIES=10
+
+# The log rotation period. Default is 24 hours.
+export LOG_ROTATION_PERIOD=5
+
+# Start log ratoation process
+./logrotate.sh &
+
+# Simulate logging process
+while true; do
+  echo "INFO: $(date)" >> $LOG_DIR/test.log.INFO.1
+  echo "WARNING: $(date)" >> $LOG_DIR/test.log.WARNING.1
+  echo "ERROR: $(date)" >> $LOG_DIR/test.log.ERROR.1
+  sleep 1
+done
+


### PR DESCRIPTION
Add the date of rotation to the log files rotated in the sidecar container of logging agent. Also, add a test script to test log rotation locally.