### PR TITLE
add action policy

### DIFF
--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -128,6 +128,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 			WithTurboProbe(probe.NewProbeBuilder(config.tapSpec.TargetType, config.tapSpec.ProbeCategory).
 				WithDiscoveryOptions(probe.FullRediscoveryIntervalSecondsOption(int32(config.DiscoveryIntervalSec))).
 				RegisteredBy(registrationClient).
+				WithActionPolicies(registrationClient).
 				DiscoversTarget(config.tapSpec.TargetIdentifier, discoveryClient).
 				ExecutesActionsBy(actionHandler)).
 			Create()

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -1,6 +1,7 @@
 package registration
 
 import (
+	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 
 	"github.com/turbonomic/turbo-go-sdk/pkg/builder"
@@ -42,6 +43,7 @@ func (rClient *K8sRegistrationClient) GetSupplyChainDefinition() []*proto.Templa
 	supplyChainFactory := NewSupplyChainFactory(rClient.config.stitchingPropertyType, rClient.config.vmPriority, rClient.config.vmIsBase)
 	supplyChain, err := supplyChainFactory.createSupplyChain()
 	if err != nil {
+		glog.Errorf("Failed to create supply chain: %v", err)
 		// TODO error handling
 	}
 	return supplyChain
@@ -70,4 +72,47 @@ func (rClient *K8sRegistrationClient) GetAccountDefinition() []*proto.AccountDef
 
 func (rClient *K8sRegistrationClient) GetIdentifyingFields() string {
 	return TargetIdentifierField
+}
+
+func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO {
+	glog.V(3).Infof("Begin to build Action Policies")
+	ab := builder.NewActionPolicyBuilder()
+	supported := proto.ActionPolicyDTO_SUPPORTED
+	recommend := proto.ActionPolicyDTO_NOT_EXECUTABLE
+	notSupported := proto.ActionPolicyDTO_NOT_SUPPORTED
+
+	//1. containerPod: move, provision; not resize;
+	pod := proto.EntityDTO_CONTAINER_POD
+	podPolicy := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
+	podPolicy[proto.ActionItemDTO_MOVE] = supported
+	podPolicy[proto.ActionItemDTO_PROVISION] = supported
+	podPolicy[proto.ActionItemDTO_RIGHT_SIZE] = notSupported
+	addActionPolicy(ab, pod, podPolicy)
+
+	//2. container: support resize; recommend provision; not move;
+	container := proto.EntityDTO_CONTAINER
+	containerPolicy := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
+	containerPolicy[proto.ActionItemDTO_RIGHT_SIZE] = supported
+	containerPolicy[proto.ActionItemDTO_PROVISION] = recommend
+	containerPolicy[proto.ActionItemDTO_MOVE] = notSupported
+	addActionPolicy(ab, container, containerPolicy)
+
+	//3. application: only recommend provision; all else are not supported
+	app := proto.EntityDTO_APPLICATION
+	appPolicy := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
+	appPolicy[proto.ActionItemDTO_PROVISION] = recommend
+	appPolicy[proto.ActionItemDTO_RIGHT_SIZE] = notSupported
+	appPolicy[proto.ActionItemDTO_MOVE] = notSupported
+	addActionPolicy(ab, app, appPolicy)
+
+	return ab.Create()
+}
+
+func addActionPolicy(ab *builder.ActionPolicyBuilder,
+	entity proto.EntityDTO_EntityType,
+	policies map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability) {
+
+	for action, policy := range policies {
+		ab.WithEntityActions(entity, action, policy)
+	}
 }

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -1,0 +1,83 @@
+package registration
+
+import (
+	"fmt"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"testing"
+)
+
+func xcheck(expected map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability,
+	elements []*proto.ActionPolicyDTO_ActionPolicyElement) error {
+
+	if len(expected) != len(elements) {
+		return fmt.Errorf("length not equal: %d Vs. %d", len(expected), len(elements))
+	}
+
+	for _, e := range elements {
+		action := e.GetActionType()
+		capability := e.GetActionCapability()
+		p, exist := expected[action]
+		if !exist {
+			return fmt.Errorf("action type(%v) not exist.", action)
+		}
+
+		if p != capability {
+			return fmt.Errorf("action(%v) policy mismatch %v Vs %v", action, capability, p)
+		}
+	}
+
+	return nil
+}
+
+func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
+	conf := NewRegistrationClientConfig(stitching.UUID, 0, true)
+	reg := NewK8sRegistrationClient(conf)
+
+	supported := proto.ActionPolicyDTO_SUPPORTED
+	recommend := proto.ActionPolicyDTO_NOT_EXECUTABLE
+	notSupported := proto.ActionPolicyDTO_NOT_SUPPORTED
+
+	pod := proto.EntityDTO_CONTAINER_POD
+	container := proto.EntityDTO_CONTAINER
+	app := proto.EntityDTO_APPLICATION
+
+	move := proto.ActionItemDTO_MOVE
+	resize := proto.ActionItemDTO_RIGHT_SIZE
+	provision := proto.ActionItemDTO_PROVISION
+
+	expected_pod := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
+	expected_pod[move] = supported
+	expected_pod[resize] = notSupported
+	expected_pod[provision] = supported
+
+	expected_container := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
+	expected_container[move] = notSupported
+	expected_container[resize] = supported
+	expected_container[provision] = recommend
+
+	expected_app := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
+	expected_app[move] = notSupported
+	expected_app[resize] = notSupported
+	expected_app[provision] = recommend
+
+	policies := reg.GetActionPolicy()
+
+	for _, item := range policies {
+		entity := item.GetEntityType()
+		expected := expected_pod
+
+		if entity == pod {
+		} else if entity == container {
+			expected = expected_container
+		} else if entity == app {
+			expected = expected_app
+		} else {
+			t.Errorf("Unknown entity type: %v", entity)
+		}
+
+		if err := xcheck(expected, item.GetPolicyElement()); err != nil {
+			t.Errorf("Failed action policy check for entity(%v) %v", entity, err)
+		}
+	}
+}

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -68,12 +68,14 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 		expected := expected_pod
 
 		if entity == pod {
+			expected = expected_pod
 		} else if entity == container {
 			expected = expected_container
 		} else if entity == app {
 			expected = expected_app
 		} else {
 			t.Errorf("Unknown entity type: %v", entity)
+			continue
 		}
 
 		if err := xcheck(expected, item.GetPolicyElement()); err != nil {


### PR DESCRIPTION
[OM-34771](https://vmturbo.atlassian.net/browse/OM-34771)

**Problem**
The default action policy in _kubeturbo_ is enable to the execution of  container provision and application provision.  Both actions are generated during the app cloning, but only pod provision is allowed.

**Solution**
  Define the action policy explicitly for Pod, Container and Application:
      **Pod**:  support _Move_ and _Provision_; not support _Resize_;
      **Container**: support _Resize_; recommend _Provision_; not support _Move_;
      **Application**: recommend _Provision_; not support _Move_ or _Resize_;


