### PR TITLE
add EntityMetaData for XL

### DIFF
--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -129,6 +129,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 				WithDiscoveryOptions(probe.FullRediscoveryIntervalSecondsOption(int32(config.DiscoveryIntervalSec))).
 				RegisteredBy(registrationClient).
 				WithActionPolicies(registrationClient).
+				WithEntityMetadata(registrationClient).
 				DiscoversTarget(config.tapSpec.TargetIdentifier, discoveryClient).
 				ExecutesActionsBy(actionHandler)).
 			Create()

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -124,6 +124,7 @@ func (rclient *K8sRegistrationClient) GetEntityMetadata() []*proto.EntityIdentit
 	result := []*proto.EntityIdentityMetadata{}
 
 	entities := []proto.EntityDTO_EntityType{
+		proto.EntityDTO_VIRTUAL_DATACENTER,
 		proto.EntityDTO_VIRTUAL_MACHINE,
 		proto.EntityDTO_CONTAINER_POD,
 		proto.EntityDTO_CONTAINER,

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -12,6 +12,7 @@ const (
 	TargetIdentifierField string = "targetIdentifier"
 	Username              string = "username"
 	Password              string = "password"
+	propertyId            string = "id"
 )
 
 type RegistrationConfig struct {
@@ -131,7 +132,7 @@ func (rclient *K8sRegistrationClient) GetEntityMetadata() []*proto.EntityIdentit
 	}
 
 	for _, etype := range entities {
-		meta := rclient.newIdMetaData(etype, []string{"id"})
+		meta := rclient.newIdMetaData(etype, []string{propertyId})
 		result = append(result, meta)
 	}
 

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -84,13 +84,13 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 	}
 }
 
-
 func TestK8sRegistrationClient_GetEntityMetadata(t *testing.T) {
 	conf := NewRegistrationClientConfig(stitching.UUID, 0, true)
 	reg := NewK8sRegistrationClient(conf)
 
 	//1. all the entity types
 	entities := []proto.EntityDTO_EntityType{
+		proto.EntityDTO_VIRTUAL_DATACENTER,
 		proto.EntityDTO_VIRTUAL_MACHINE,
 		proto.EntityDTO_CONTAINER_POD,
 		proto.EntityDTO_CONTAINER,

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -83,3 +83,46 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 		}
 	}
 }
+
+
+func TestK8sRegistrationClient_GetEntityMetadata(t *testing.T) {
+	conf := NewRegistrationClientConfig(stitching.UUID, 0, true)
+	reg := NewK8sRegistrationClient(conf)
+
+	//1. all the entity types
+	entities := []proto.EntityDTO_EntityType{
+		proto.EntityDTO_VIRTUAL_MACHINE,
+		proto.EntityDTO_CONTAINER_POD,
+		proto.EntityDTO_CONTAINER,
+		proto.EntityDTO_APPLICATION,
+		proto.EntityDTO_VIRTUAL_APPLICATION,
+	}
+	entitySet := make(map[proto.EntityDTO_EntityType]struct{})
+
+	for _, etype := range entities {
+		entitySet[etype] = struct{}{}
+	}
+
+	//2. verify all the entity MetaData
+	metaData := reg.GetEntityMetadata()
+	if len(metaData) != len(entitySet) {
+		t.Errorf("EntityMetadata count dis-match: %d vs %d", len(metaData), len(entitySet))
+	}
+
+	for _, meta := range metaData {
+		etype := meta.GetEntityType()
+		if _, exist := entitySet[etype]; !exist {
+			t.Errorf("Unexpected EntityType: %v", etype)
+		}
+
+		properties := meta.GetNonVolatileProperties()
+		if len(properties) != 1 {
+			t.Errorf("Number of NonVolatieProperties should be 1 Vs. %v", len(properties))
+		}
+
+		if properties[0].GetName() != propertyId {
+			t.Errorf("Property name should be : %v Vs. %v", propertyId, properties[0].GetName())
+		}
+	}
+
+}


### PR DESCRIPTION
**Problem**
When adding this target to XL appliance, there is error:
```terminal
 topology-processor-1: 2018-05-24 18:26:53,527 ERROR [pool-8-thread-1] [OperationManager]	: Error processing discovery response:
rsyslog_1              | topology-processor-1: com.vmturbo.topology.processor.identity.IdentityMetadataMissingException: Probe 72465846442064 sends entities of type APPLICATION but provides no related identity metadata.
rsyslog_1              | topology-processor-1: 	at com.vmturbo.topology.processor.identity.IdentityProviderImpl.getIdsForEntities(IdentityProviderImpl.java:203)
rsyslog_1              | topology-processor-1: 	at com.vmturbo.topology.processor.entity.EntityStore.assignIdsToEntities(EntityStore.java:256)
rsyslog_1              | topology-processor-1: 	at com.vmturbo.topology.processor.entity.EntityStore.entitiesDiscovered(EntityStore.java:292)
rsyslog_1              | topology-processor-1: 	at com.vmturbo.topology.processor.operation.OperationManager.processDiscoveryResponse(OperationManager.java:645)
rsyslog_1              | topology-processor-1: 	at com.vmturbo.topology.processor.operation.OperationManager.lambda$notifyDiscoveryResult$9(OperationManager.java:486)
rsyslog_1              | topology-processor-1: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
rsyslog_1              | topology-processor-1: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
rsyslog_1              | topology-processor-1: 	at java.lang.Thread.run(Thread.java:748)
```

**Fix**
(1) add `GetEntityMetadata` when registrate the probe.

**Note**
Need the [fix](https://github.com/turbonomic/turbo-go-sdk/pull/52) in [turbo-go-sdk](https://github.com/turbonomic/turbo-go-sdk/blob/771c5767564845eda68aa5e8a545c6810f85d0ea/pkg/probe/probe_builder.go#L104) about `pb.entityMetadataProvider`  
