### PR TITLE
Log git version info and add port in ContainerPodData

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-# Set the base image
-FROM alpine:3.3
+FROM alpine:3.7
 
-# Set the file maintainer
-MAINTAINER Dongyi Yang <dongyi.yang@vmturbo.com>
+ARG GIT_COMMIT
+ENV GIT_COMMIT ${GIT_COMMIT}
 
 RUN apk --update upgrade && apk add ca-certificates && update-ca-certificates
-COPY ./_output/kubeturbo.linux /bin/kubeturbo 
+COPY ./kubeturbo.linux /bin/kubeturbo 
 
 ENTRYPOINT ["/bin/kubeturbo"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OUTPUT_DIR=./_output
+OUTPUT_DIR=./
 
 SOURCE_DIRS = cmd pkg
 PACKAGES := go list ./... | grep -v /vendor | grep -v /out
@@ -9,6 +9,9 @@ product: clean
 
 build: clean
 	go build -o ${OUTPUT_DIR}/kubeturbo ./cmd/kubeturbo
+
+docker: clean
+	docker build -t vmturbo/kubeturbo:6.2dev --build-arg GIT_COMMIT=$(shell git rev-parse --short HEAD) .
 
 test: clean
 	@go test -v -race ./pkg/...

--- a/cmd/kubeturbo/kubeturbo.go
+++ b/cmd/kubeturbo/kubeturbo.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
+	"os"
 )
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
-	glog.V(2).Infof("*** Run Kubeturbo service ***")
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
@@ -45,6 +45,8 @@ func main() {
 	s := app.NewVMTServer()
 	s.AddFlags(pflag.CommandLine)
 	flag.InitFlags()
+
+	glog.Infof("Run Kubeturbo service (GIT_COMMIT: %s)", os.Getenv("GIT_COMMIT"))
 
 	s.Run(pflag.CommandLine.Args())
 }

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -318,10 +318,12 @@ func (builder *podEntityDTOBuilder) createContainerPodData(pod *api.Pod) *proto.
 	// in which case the IP address will not be unique (in the k8s cluster) and hence not populated in ContainerPodData.
 	fullName := pod.Name
 	ns := pod.Namespace
+	port := "na"
 	if pod.Status.PodIP != "" && pod.Status.PodIP != pod.Status.HostIP {
 		return &proto.EntityDTO_ContainerPodData{
 			// Note the port needs to be set if needed
 			IpAddress: &(pod.Status.PodIP),
+			Port:      &port,
 			FullName:  &fullName,
 			Namespace: &ns,
 		}

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -318,7 +318,7 @@ func (builder *podEntityDTOBuilder) createContainerPodData(pod *api.Pod) *proto.
 	// in which case the IP address will not be unique (in the k8s cluster) and hence not populated in ContainerPodData.
 	fullName := pod.Name
 	ns := pod.Namespace
-	port := "na"
+	port := "not-set"
 	if pod.Status.PodIP != "" && pod.Status.PodIP != pod.Status.HostIP {
 		return &proto.EntityDTO_ContainerPodData{
 			// Note the port needs to be set if needed

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -33,6 +33,7 @@ func Test_podEntityDTOBuilder_createContainerPodData(t *testing.T) {
 	hostIP := "2.2.2.2"
 	namespace := "foo"
 	podName := "bar"
+	port := "na"
 
 	tests := []struct {
 		name string
@@ -56,6 +57,7 @@ func Test_podEntityDTOBuilder_createContainerPodData(t *testing.T) {
 				IpAddress: &podIP,
 				FullName:  &podName,
 				Namespace: &namespace,
+				Port:      &port,
 			},
 		},
 	}

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -33,7 +33,7 @@ func Test_podEntityDTOBuilder_createContainerPodData(t *testing.T) {
 	hostIP := "2.2.2.2"
 	namespace := "foo"
 	podName := "bar"
-	port := "na"
+	port := "not-set"
 
 	tests := []struct {
 		name string


### PR DESCRIPTION
Add git version info when kubeturbo starts.

Add port property in ContainerPodData.