### PR TITLE
Delete the old pod after the new one is ready

### DIFF
--- a/pkg/action/executor/move_util.go
+++ b/pkg/action/executor/move_util.go
@@ -63,7 +63,7 @@ func doCheckPodNode(client *kclient.Clientset, namespace, name, nodeName string)
 	}
 
 	phase := pod.Status.Phase
-	if phase == api.PodRunning {
+	if phase == api.PodRunning && podutil.PodIsReady(pod) {
 		if len(nodeName) > 0 {
 			if !strings.EqualFold(pod.Spec.NodeName, nodeName) {
 				return false, fmt.Errorf("Pod[%s] running on an unexpected node[%v].", name, pod.Spec.NodeName)
@@ -80,7 +80,7 @@ func doCheckPodNode(client *kclient.Clientset, namespace, name, nodeName string)
 		return false, fmt.Errorf("Pod %s is in phase %v", name, phase)
 	}
 
-	return true, fmt.Errorf("pod(%s) is not in running phase[%v] yet.", name, phase)
+	return true, fmt.Errorf("pod(%s) is not ready [phase: %v] yet.", name, phase)
 }
 
 func waitForReady(client *kclient.Clientset, namespace, name, nodeName string, retryNum int) error {

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -99,7 +99,7 @@ func GetReadyPods(pods []*api.Pod) []*api.Pod {
 	readyPods := []*api.Pod{}
 
 	for _, pod := range pods {
-		if podIsReady(pod) {
+		if PodIsReady(pod) {
 			readyPods = append(readyPods, pod)
 		} else {
 			glog.V(4).Infof("Pod %s is not ready", pod.Name)
@@ -110,7 +110,7 @@ func GetReadyPods(pods []*api.Pod) []*api.Pod {
 }
 
 // PodIsReady checks if a pod is in Ready status.
-func podIsReady(pod *api.Pod) bool {
+func PodIsReady(pod *api.Pod) bool {
 	for _, condition := range pod.Status.Conditions {
 		if condition.Type == api.PodReady {
 			return condition.Status == api.ConditionTrue


### PR DESCRIPTION
Delete the old pod after the new one is in ready status for resize/move actions. The change is to add the check of the readiness for the new pod before deleting the old one.