### PR TITLE
Do not create kubenode for notready node and notschedulable node, to …

### DIFF
--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -191,7 +191,7 @@ func (processor *ClusterProcessor) DiscoverCluster() (*repository.KubeCluster, e
 	for _, item := range nodeList {
 		nodeActive := util.NodeIsReady(item) && util.NodeIsSchedulable(item)
 		if !nodeActive {
-			glog.V(2).Info("Node status is NotReady or NotSchedulable, skip in Quota creation")
+			glog.V(2).Info("node status is NotReady or NotSchedulable, skip in Quota creation, the node is = %s\n", item.Name)
 		} else {
 			nodeEntity := repository.NewKubeNode(item, clusterName)
 			kubeCluster.SetNodeEntity(nodeEntity)

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -191,7 +191,7 @@ func (processor *ClusterProcessor) DiscoverCluster() (*repository.KubeCluster, e
 	for _, item := range nodeList {
 		nodeActive := util.NodeIsReady(item) && util.NodeIsSchedulable(item)
 		if !nodeActive {
-			glog.V(2).Info("node status is NotReady or NotSchedulable, skip in Quota creation, the node is = %s\n", item.Name)
+			glog.V(2).Infof("node status is NotReady or NotSchedulable, skip in Quota creation, the node is = %s", item.Name)
 		} else {
 			nodeEntity := repository.NewKubeNode(item, clusterName)
 			kubeCluster.SetNodeEntity(nodeEntity)

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -2,6 +2,9 @@ package processor
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
@@ -11,8 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/pkg/api/v1"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
-	"testing"
-	"time"
 )
 
 var (
@@ -25,7 +26,7 @@ var (
 		v1.ResourceCPU: resource.MustParse("4.0"),
 	}
 	schedulableNodeMap = map[string]bool{
-		"node1": true,
+		"node1": false,
 		"node2": true,
 		"node3": true,
 		"node4": true,
@@ -58,7 +59,7 @@ func createMockNodes(allocatableMap map[v1.ResourceName]resource.Quantity, sched
 	var nodeList []*v1.Node
 	for _, mockNode := range mockNodes {
 		nodeAddresses := []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: mockNode.ipAddress}}
-
+		conditions := []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionTrue}}
 		node := &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: mockNode.name,
@@ -67,9 +68,10 @@ func createMockNodes(allocatableMap map[v1.ResourceName]resource.Quantity, sched
 			Status: v1.NodeStatus{
 				Allocatable: allocatableMap,
 				Addresses:   nodeAddresses,
+				Conditions:  conditions,
 			},
 			Spec: v1.NodeSpec{
-				Unschedulable: !schedulableNodeMap[mockNode.name],
+				Unschedulable: schedulableNodeMap[mockNode.name],
 			},
 		}
 		nodeList = append(nodeList, node)
@@ -177,7 +179,7 @@ func TestDiscoverCluster(t *testing.T) {
 	testCluster, err := clusterProcessor.DiscoverCluster()
 	assert.Nil(t, err)
 	nodeMap := testCluster.Nodes
-	assert.Equal(t, len(nodeList), len(nodeMap))
+	assert.Equal(t, 1, len(nodeMap))
 	assert.Equal(t, 0, len(testCluster.Namespaces))
 }
 
@@ -198,12 +200,9 @@ func TestDiscoverClusterChangedSchedulableNodes(t *testing.T) {
 
 	testCluster1, _ := clusterProcessor.DiscoverCluster()
 	nodeMap := testCluster1.Nodes
-	assert.Equal(t, len(nodeList), len(nodeMap))
+	//Depends on the number of schedulable nodes
+	assert.Equal(t, 1, len(nodeMap))
 	assert.Equal(t, 0, len(testCluster1.Namespaces))
-
-	for _, node := range nodeMap {
-		assert.Equal(t, schedulableNodeMap[node.Name], !node.Node.Spec.Unschedulable)
-	}
 
 	newSchedulableNodeMap := map[string]bool{
 		"node1": true,
@@ -217,10 +216,8 @@ func TestDiscoverClusterChangedSchedulableNodes(t *testing.T) {
 	}
 	testCluster2, _ := clusterProcessor.DiscoverCluster()
 	nodeMap = testCluster2.Nodes
-	assert.Equal(t, len(nodeList), len(nodeMap))
-	for _, node := range nodeMap {
-		assert.Equal(t, newSchedulableNodeMap[node.Name], !node.Node.Spec.Unschedulable)
-	}
+	//Depends on the number of schedulable nodes
+	assert.Equal(t, 2, len(nodeMap))
 }
 
 func TestConnectCluster(t *testing.T) {


### PR DESCRIPTION
This is to fix OM-29813 and OM-36523. We don't want to count the capacity for VDC when the node is either not ready or not schedulable.
Updated the unit test as well.