### PR TITLE
Create access commodities for taint and toleration rules

### DIFF
--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -190,6 +190,16 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework() ([]*proto.EntityDTO, er
 		entityDTOs = affinityProcessor.ProcessAffinityRules(entityDTOs)
 	}
 
+	// Taint-toleration process to create access commodities
+	glog.V(2).Infof("Begin to process taints and tolerations")
+	taintTolerationProcessor, err := compliance.NewTaintTolerationProcessor(dc.k8sClusterScraper)
+	if err != nil {
+		glog.Errorf("Failed during process taints and tolerations: %s", err)
+	} else {
+		// Add access commodiites to entity DOTs based on the taint-toleration rules
+		taintTolerationProcessor.Process(entityDTOs)
+	}
+
 	glog.V(2).Infof("begin to generate service EntityDTOs.")
 	svcWorkerConfig := worker.NewK8sServiceDiscoveryWorkerConfig(dc.k8sClusterScraper)
 	svcDiscWorker, err := worker.NewK8sServiceDiscoveryWorker(svcWorkerConfig)

--- a/pkg/discovery/worker/compliance/taint_toleration_processor.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor.go
@@ -1,0 +1,239 @@
+package compliance
+
+import (
+	api "k8s.io/client-go/pkg/api/v1"
+
+	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
+	"github.com/golang/glog"
+)
+
+type NodeAndPodGetter interface {
+	GetAllNodes() ([]*api.Node, error)
+	GetAllPods() ([]*api.Pod, error)
+}
+
+// TaintTolerationProcessor parses taints defined in nodes and tolerations defined in pods and creates access commodity DTOs,
+// sold by VMs and bought by Container Pods.
+// See the detail in: https://vmturbo.atlassian.net/wiki/spaces/AE/pages/668598357/Taints+and+Tolerations+in+Kubernetes
+type TaintTolerationProcessor struct {
+	// Map of nodes indexed by node uid
+	nodes map[string]*api.Node
+
+	// Map of pods indexed by pod uid
+	pods map[string]*api.Pod
+
+	// Map of node uid indexed by node name
+	nodeNameToUID map[string]string
+}
+
+func NewTaintTolerationProcessor(nodeAndPodGetter NodeAndPodGetter) (*TaintTolerationProcessor, error) {
+	nodes, err := nodeAndPodGetter.GetAllNodes()
+	if err != nil {
+		return nil, err
+	}
+	pods, err := nodeAndPodGetter.GetAllPods()
+	if err != nil {
+		return nil, err
+	}
+
+	nodeMap := make(map[string]*api.Node)
+	nodeNameToUID := make(map[string]string)
+	for _, node := range nodes {
+		nodeMap[string(node.UID)] = node
+		nodeNameToUID[node.Name] = string(node.UID)
+	}
+
+	podMap := make(map[string]*api.Pod)
+	for _, pod := range pods {
+		podMap[string(pod.UID)] = pod
+	}
+
+	return &TaintTolerationProcessor{
+		nodes:         nodeMap,
+		pods:          podMap,
+		nodeNameToUID: nodeNameToUID,
+	}, nil
+}
+
+// Process takes entityDTOs and add access commodities for VMs and ContainerPods
+// based on the taints and tolerations, respectively, in nodes and pods.
+func (t *TaintTolerationProcessor) Process(entityDTOs []*proto.EntityDTO) {
+	// Preprocess for node taints to create access commodities for each node later.
+	taintCollection := getTaintCollection(t.nodes)
+
+	nodeDTOs, podDTOs := retrieveNodeAndPodDTOs(entityDTOs)
+
+	createAccessCommoditiesSold(nodeDTOs, t.nodes, taintCollection)
+
+	createAccessCommoditiesBought(podDTOs, t.pods, t.nodeNameToUID, taintCollection)
+}
+
+// Creates access commodities sold by VMs.
+func createAccessCommoditiesSold(nodeDTOs []*proto.EntityDTO, nodes map[string]*api.Node, taintCollection map[api.Taint]string) {
+	for _, nodeDTO := range nodeDTOs {
+		node, ok := nodes[*nodeDTO.Id]
+		if !ok {
+			glog.Errorf("Unable to find node object with uid %s", *nodeDTO.Id)
+			continue
+		}
+
+		taintAccessComms, err := createTaintAccessComms(node, taintCollection)
+		if err != nil {
+			glog.Errorf("Error while process taints for node %s", node.GetName())
+			continue
+		}
+
+		nodeDTO.CommoditiesSold = append(nodeDTO.CommoditiesSold, taintAccessComms...)
+	}
+}
+
+// Creates access commodities bought by ContainerPods.
+func createAccessCommoditiesBought(podDTOs []*proto.EntityDTO, pods map[string]*api.Pod, nodeNameToUID map[string]string, taintCollection map[api.Taint]string) {
+	for _, podDTO := range podDTOs {
+		pod, ok := pods[*podDTO.Id]
+		if !ok {
+			glog.Errorf("Unable to find pod object with uid %s", *podDTO.Id)
+			continue
+		}
+
+		providerId, ok := nodeNameToUID[pod.Spec.NodeName]
+		if !ok {
+			glog.Errorf("Unable to find hosting node %s for pod %s", pod.Spec.NodeName, *podDTO.DisplayName)
+			continue
+		}
+
+		tolerateAccessComms, err := createTolerationAccessComms(pod, taintCollection)
+		if err != nil {
+			glog.Errorf("Error while process tolerations for pod %s", pod.GetName())
+			continue
+		}
+
+		podBuysCommodities(podDTO, tolerateAccessComms, providerId)
+	}
+}
+
+// Appends accesss commodities to the CommodityBought list in the ContainerPod DTO.
+func podBuysCommodities(podDTO *proto.EntityDTO, comms []*proto.CommodityDTO, providerId string) {
+	if len(comms) == 0 {
+		return
+	}
+
+	for _, commBought := range podDTO.GetCommoditiesBought() {
+		if commBought.GetProviderId() == providerId {
+			glog.V(2).Infof("Found provider %s for pod %s to buy %d commodities", providerId, podDTO.DisplayName, len(comms))
+			commBought.Bought = append(commBought.GetBought(), comms...)
+			return
+		}
+	}
+
+	glog.Errorf("Unable to find commodity bought with provider %s for pod %s", providerId, *podDTO.DisplayName)
+}
+
+// Retrives VM and ContainerPod DTOs from the DTO list.
+func retrieveNodeAndPodDTOs(entityDTOs []*proto.EntityDTO) ([]*proto.EntityDTO, []*proto.EntityDTO) {
+	nodes := []*proto.EntityDTO{}
+	pods := []*proto.EntityDTO{}
+
+	for _, dto := range entityDTOs {
+		if *dto.EntityType == proto.EntityDTO_VIRTUAL_MACHINE {
+			nodes = append(nodes, dto)
+		} else if *dto.EntityType == proto.EntityDTO_CONTAINER_POD {
+			pods = append(pods, dto)
+		}
+	}
+
+	return nodes, pods
+}
+
+// Generates taint collection from taints in the node spec.
+func getTaintCollection(nodes map[string]*api.Node) map[api.Taint]string {
+	taintCollection := make(map[api.Taint]string)
+
+	for _, node := range nodes {
+		taints := node.Spec.Taints
+
+		for _, taint := range taints {
+			if taint.Effect == api.TaintEffectNoExecute || taint.Effect == api.TaintEffectNoSchedule {
+				taintCollection[taint] = taint.Key + "=" + taint.Value + ":" + string(taint.Effect)
+				glog.V(4).Infof("Found taint (comm key = %s): %+v)", taintCollection[taint], taint)
+			}
+		}
+	}
+
+	glog.V(2).Infof("Created taint collection with %d taints found", len(taintCollection))
+
+	return taintCollection
+}
+
+// Creates access commodities sold by VMs based on the taint collection.
+func createTaintAccessComms(node *api.Node, taintCollection map[api.Taint]string) ([]*proto.CommodityDTO, error) {
+	accessComms := []*proto.CommodityDTO{}
+
+	taints := node.Spec.Taints
+	nodeTaints := make(map[api.Taint]struct{})
+
+	for _, taint := range taints {
+		nodeTaints[taint] = struct{}{}
+	}
+
+	for taint, key := range taintCollection {
+		// If the node doesn't contain the taint, create access commodity
+		if _, ok := nodeTaints[taint]; !ok {
+			accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
+				Key(key).
+				Capacity(accessCommodityDefaultCapacity).
+				Create()
+
+			if err != nil {
+				return nil, err
+			}
+
+			glog.V(4).Infof("Created access commodity with key %s for node %s", key, node.GetName())
+
+			accessComms = append(accessComms, accessComm)
+		}
+	}
+
+	glog.V(4).Infof("Created %d access commodities for node %s", len(accessComms), node.GetName())
+
+	return accessComms, nil
+}
+
+// Creates access commodities bought by ContainerPods based on the taint collection and pod tolerations.
+func createTolerationAccessComms(pod *api.Pod, taintCollection map[api.Taint]string) ([]*proto.CommodityDTO, error) {
+	accessComms := []*proto.CommodityDTO{}
+
+	for taint, key := range taintCollection {
+		// If the pod doesn't have the proper toleration, create access commodity to buy
+		if !TolerationsTolerateTaint(pod.Spec.Tolerations, &taint) {
+			accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
+				Key(key).
+				Capacity(accessCommodityDefaultCapacity).
+				Create()
+
+			if err != nil {
+				return nil, err
+			}
+
+			glog.V(4).Infof("Created access commodity with key %s for pod %s", key, pod.GetName())
+
+			accessComms = append(accessComms, accessComm)
+		}
+	}
+
+	glog.V(4).Infof("Created %d access commodities for pod %s", len(accessComms), pod.GetName())
+
+	return accessComms, nil
+}
+
+// Checks if taint is tolerated by any of the tolerations.
+func TolerationsTolerateTaint(tolerations []api.Toleration, taint *api.Taint) bool {
+	for i := range tolerations {
+		if tolerations[i].ToleratesTaint(taint) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
@@ -1,0 +1,274 @@
+package compliance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	api "k8s.io/client-go/pkg/api/v1"
+)
+
+var (
+	t1    = newTaint("k1", "v1", api.TaintEffectNoExecute)
+	t2    = newTaint("k2", "v2", api.TaintEffectNoSchedule)
+	t3    = newTaint("k3", "v3", api.TaintEffectPreferNoSchedule)
+	key1  = "k1=v1:NoExecute"
+	key2  = "k2=v2:NoSchedule"
+	n1    = newNodeWithTaints("node-1", []api.Taint{t1})
+	n2    = newNodeWithTaints("node-2", []api.Taint{t2})
+	n3    = newNodeWithTaints("node-3", []api.Taint{t3})
+	nodes = map[string]*api.Node{
+		string(n1.UID): n1,
+		string(n2.UID): n2,
+		string(n3.UID): n3,
+	}
+
+	tole1 = newToleration("k1", "v1", api.TaintEffectNoExecute, api.TolerationOpEqual)
+	tole2 = newToleration("k2", "v2", api.TaintEffectNoSchedule, api.TolerationOpEqual)
+
+	pod1 = newPodWithTolerations("pod-1", "node-1", []api.Toleration{})
+	pod2 = newPodWithTolerations("pod-2", "node-2", []api.Toleration{tole1})
+	pod3 = newPodWithTolerations("pod-3", "node-3", []api.Toleration{tole1, tole2})
+
+	podDTO1 = newEntityDTO("pod-1", proto.EntityDTO_CONTAINER_POD, createCommBoughtForPod("node-1"))
+	podDTO2 = newEntityDTO("pod-2", proto.EntityDTO_CONTAINER_POD, createCommBoughtForPod("node-2"))
+	podDTO3 = newEntityDTO("pod-3", proto.EntityDTO_CONTAINER_POD, createCommBoughtForPod("node-3"))
+
+	nodeDTO1 = newEntityDTO("node-1", proto.EntityDTO_VIRTUAL_MACHINE, []*proto.EntityDTO_CommodityBought{})
+	nodeDTO2 = newEntityDTO("node-2", proto.EntityDTO_VIRTUAL_MACHINE, []*proto.EntityDTO_CommodityBought{})
+	nodeDTO3 = newEntityDTO("node-3", proto.EntityDTO_VIRTUAL_MACHINE, []*proto.EntityDTO_CommodityBought{})
+
+	otherDTO1 = newEntityDTO("foo-1", proto.EntityDTO_PHYSICAL_MACHINE, []*proto.EntityDTO_CommodityBought{})
+)
+
+func TestProcess(t *testing.T) {
+	nodeAndPodGetter := &mockNodeAndPodGetter{
+		nodes: []*api.Node{n1, n2, n3},
+		pods:  []*api.Pod{pod1, pod2, pod3},
+	}
+
+	taintTolerationProcessor, err := NewTaintTolerationProcessor(nodeAndPodGetter)
+
+	if err != nil {
+		t.Errorf("Failed to create TaintTolerationProcessor: %v", err)
+		return
+	}
+
+	dto1 := *podDTO1
+	dto2 := *podDTO2
+	dto3 := *podDTO3
+	dto4 := *nodeDTO1
+	dto5 := *nodeDTO2
+	dto6 := *nodeDTO3
+	dto7 := *otherDTO1
+
+	entityDTOs := []*proto.EntityDTO{&dto1, &dto2, &dto3, &dto4, &dto5, &dto6, &dto7}
+	taintTolerationProcessor.Process(entityDTOs)
+
+	// Check entity DTOs for access commodities created from tatins and tolerations
+	checkPodEntity(t, &dto1, "node-1")
+	checkPodEntity(t, &dto2, "node-2")
+	checkPodEntity(t, &dto3, "node-3")
+
+	checkNodeEntity(t, &dto4, 1)
+	checkNodeEntity(t, &dto5, 1)
+	checkNodeEntity(t, &dto6, 2)
+
+}
+
+func checkPodEntity(t *testing.T, dto1 *proto.EntityDTO, providerId string) {
+	if len(dto1.CommoditiesBought) != 1 {
+		t.Errorf("Expected 2 CommoditiesBought but got %d", len(dto1.CommoditiesBought))
+		return
+	}
+
+	if *(dto1.CommoditiesBought[0].ProviderId) != providerId {
+		t.Errorf("Wrong provider ID %s", *(dto1.CommoditiesBought[0].ProviderId))
+	}
+}
+
+func checkNodeEntity(t *testing.T, dto1 *proto.EntityDTO, numComms int) {
+	if len(dto1.CommoditiesSold) != numComms {
+		t.Errorf("Expected %d Commodities sold but got %d", numComms, len(dto1.CommoditiesSold))
+	}
+}
+
+type mockNodeAndPodGetter struct {
+	nodes []*api.Node
+	pods  []*api.Pod
+}
+
+func (m *mockNodeAndPodGetter) GetAllNodes() ([]*api.Node, error) {
+	return m.nodes, nil
+}
+func (m *mockNodeAndPodGetter) GetAllPods() ([]*api.Pod, error) {
+	return m.pods, nil
+}
+
+func TestGetTaintCollection(t *testing.T) {
+	taintCollection := getTaintCollection(nodes)
+
+	fmt.Printf("taintCollection: %++v", taintCollection)
+
+	if len(taintCollection) != 2 {
+		t.Errorf("Expected 2 taints but got %d", len(taintCollection))
+	}
+
+	if value, ok := taintCollection[t1]; !ok {
+		t.Errorf("Taint %+v not found", t1)
+	} else if value != key1 {
+		t.Errorf("Taint %+v has wrong key %s", t1, value)
+	}
+
+	if value, ok := taintCollection[t2]; !ok {
+		t.Errorf("Taint %+v not found", t2)
+	} else if value != key2 {
+		t.Errorf("Taint %+v has wrong key %s", t2, value)
+	}
+}
+
+func TestCreateTaintAccessComms(t *testing.T) {
+	taintCollection := getTaintCollection(nodes)
+
+	comms, err := createTaintAccessComms(n1, taintCollection)
+
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+
+	if len(comms) != 1 {
+		t.Errorf("Expected 1 commodity but got %d", len(comms))
+	}
+
+	if *(comms[0].Key) != key2 {
+		t.Errorf("Comm %+v has wrong key %s", comms[0], *(comms[0].Key))
+	}
+
+	comms2, err := createTaintAccessComms(n2, taintCollection)
+
+	if len(comms2) != 1 {
+		t.Errorf("Expected 1 commodity but got %d", len(comms2))
+	}
+
+	if *(comms2[0].Key) != key1 {
+		t.Errorf("Comm %+v has wrong key %s", comms2[0], *(comms2[0].Key))
+	}
+
+	comms3, err := createTaintAccessComms(n3, taintCollection)
+
+	if len(comms3) != 2 {
+		t.Errorf("Expected 2 commodities but got %d", len(comms3))
+	}
+
+	if *(comms3[0].Key) != key1 || *(comms3[1].Key) != key2 {
+		if *(comms3[1].Key) == key1 && *(comms3[0].Key) == key2 {
+
+		} else {
+			t.Errorf("Wrong comms3 %+v", comms3)
+		}
+	}
+}
+
+func TestCreateTolerationAccessComms(t *testing.T) {
+	taintCollection := getTaintCollection(nodes)
+
+	testTolerationAccessComms(t, pod1, taintCollection, []string{key1, key2})
+
+	testTolerationAccessComms(t, pod2, taintCollection, []string{key2})
+
+	testTolerationAccessComms(t, pod3, taintCollection, []string{})
+}
+
+func newNodeWithTaints(id string, taints []api.Taint) *api.Node {
+	node := &api.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: id,
+			UID:  types.UID(id),
+		},
+
+		Spec: api.NodeSpec{
+			Taints: taints,
+		},
+	}
+
+	return node
+}
+
+func newTaint(key, value string, effect api.TaintEffect) api.Taint {
+	taint := api.Taint{
+		Key:    key,
+		Value:  value,
+		Effect: effect,
+	}
+
+	return taint
+}
+
+func newPodWithTolerations(id, nodeName string, tolerations []api.Toleration) *api.Pod {
+	return &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: id,
+			UID:  types.UID(id),
+		},
+
+		Spec: api.PodSpec{
+			NodeName:    nodeName,
+			Tolerations: tolerations,
+		},
+	}
+}
+
+func newToleration(key, value string, effect api.TaintEffect, tolerationOp api.TolerationOperator) api.Toleration {
+	toleration := api.Toleration{
+		Key:      key,
+		Value:    value,
+		Effect:   effect,
+		Operator: tolerationOp,
+	}
+
+	return toleration
+}
+
+func testTolerationAccessComms(t *testing.T, pod *api.Pod, taintCollection map[api.Taint]string, keys []string) {
+	comms, err := createTolerationAccessComms(pod, taintCollection)
+
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+
+	if len(comms) != len(keys) {
+		t.Errorf("Expected to get %d commodities but got %d", len(keys), len(comms))
+	}
+
+	// Don't care the order
+	commsMap := make(map[string]struct{})
+	for i := range comms {
+		commsMap[comms[i].GetKey()] = struct{}{}
+	}
+
+	for _, key := range keys {
+		if _, ok := commsMap[key]; !ok {
+			t.Errorf("The commodity with key %s not found", key)
+		}
+	}
+}
+
+func newEntityDTO(id string, entityType proto.EntityDTO_EntityType, commBought []*proto.EntityDTO_CommodityBought) *proto.EntityDTO {
+	return &proto.EntityDTO{
+		Id:                &id,
+		DisplayName:       &id,
+		EntityType:        &entityType,
+		CommoditiesBought: commBought,
+	}
+}
+
+func createCommBoughtForPod(providerId string) []*proto.EntityDTO_CommodityBought {
+	return []*proto.EntityDTO_CommodityBought{
+		{
+			ProviderId: &providerId,
+			Bought:     []*proto.CommodityDTO{{}},
+		},
+	}
+}


### PR DESCRIPTION
This code change is to support the taint and toleration rules in k8s by using access commodities in turbonomic model. VMPM access commodities will be created for container pods to buy and for nodes to sell according to the rules of node taints and pod tolerations. See details in:

https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
https://docs.openshift.org/latest/admin_guide/scheduling/taints_tolerations.html

See the design for access commodities in:

https://vmturbo.atlassian.net/wiki/spaces/AE/pages/668598357/Taints+and+Tolerations+in+Kubernetes