### PR TITLE
Do not set the used attribute of commodities bought by vapp if app unset

### DIFF
--- a/pkg/discovery/dtofactory/service_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/service_entity_dto_builder.go
@@ -113,10 +113,12 @@ func (svcEntityDTOBuilder *ServiceEntityDTOBuilder) getCommoditiesBought(appDTO 
 	var commoditiesBoughtFromApp []*proto.CommodityDTO
 	for _, commSold := range commoditiesSoldByApp {
 		if _, exist := commodityTypeBetweenAppAndService[commSold.GetCommodityType()]; exist {
-			commBoughtByService, err := sdkbuilder.NewCommodityDTOBuilder(commSold.GetCommodityType()).
-				Key(commSold.GetKey()).
-				Used(commSold.GetUsed()).
-				Create()
+			commBuilder := sdkbuilder.NewCommodityDTOBuilder(commSold.GetCommodityType()).
+				Key(commSold.GetKey())
+			if commSold.Used != nil {
+				commBuilder.Used(commSold.GetUsed())
+			}
+			commBoughtByService, err := commBuilder.Create()
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Add logic to check if the used value is set at app side when creating commodities bought by vapp. So, if app doesn't set the used value, the corresponding vapp should have it unset.