### PR TITLE
Fix the uuid stitching schema selection by evaluate per node

### DIFF
--- a/pkg/discovery/dtofactory/quota_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/quota_entity_dto_builder.go
@@ -44,21 +44,14 @@ func (builder *quotaEntityDTOBuilder) setUpStitchManager() {
 	//1. set UUID getter by one k8s.Node.providerID
 	if m.GetStitchType() == stitching.UUID {
 		glog.V(3).Info("Begin to setup stitchManager UUID getter.")
-		for _, node := range builder.nodeMapByUID {
-			if node.Node == nil {
-				glog.Errorf("node.K8sNode is nil: %++v", node)
-				continue
-			}
-			providerId := node.Node.Spec.ProviderID
-			m.SetNodeUuidGetterByProvider(providerId)
-			break
-		}
 	}
 
 	//2. store the stitching values
 	builder.nodeNames = []string{}
 	for _, node := range builder.nodeMapByUID {
 		if node != nil {
+			providerId := node.Node.Spec.ProviderID
+			m.SetNodeUuidGetterByProvider(providerId)
 			m.StoreStitchingValue(node.Node)
 			builder.nodeNames = append(builder.nodeNames, node.Node.Name)
 		}

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -283,6 +283,7 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 
 	// Node providers
 	nodes := currTask.NodeList()
+	cluster := currTask.Cluster()
 
 	for _, node := range nodes {
 		if node != nil {

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -283,13 +283,6 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 
 	// Node providers
 	nodes := currTask.NodeList()
-	cluster := currTask.Cluster()
-
-/*	//if len(nodes) > 0 && worker.config.stitchingPropertyType == stitching.UUID {
-	if len(nodes) > 0 {
-		providerId := nodes[0].Spec.ProviderID
-		stitchingManager.SetNodeUuidGetterByProvider(providerId)
-	}*/
 
 	for _, node := range nodes {
 		if node != nil {

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -285,13 +285,16 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 	nodes := currTask.NodeList()
 	cluster := currTask.Cluster()
 
-	//if len(nodes) > 0 && worker.config.stitchingPropertyType == stitching.UUID {
+/*	//if len(nodes) > 0 && worker.config.stitchingPropertyType == stitching.UUID {
 	if len(nodes) > 0 {
 		providerId := nodes[0].Spec.ProviderID
 		stitchingManager.SetNodeUuidGetterByProvider(providerId)
-	}
+	}*/
 
 	for _, node := range nodes {
+		glog.V(3).Infof("The node we are parsing is : %v", node.Name)
+		providerId := node.Spec.ProviderID
+		stitchingManager.SetNodeUuidGetterByProvider(providerId)
 		stitchingManager.StoreStitchingValue(node)
 	}
 

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -292,10 +292,12 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 	}*/
 
 	for _, node := range nodes {
-		glog.V(3).Infof("The node we are parsing is : %v", node.Name)
-		providerId := node.Spec.ProviderID
-		stitchingManager.SetNodeUuidGetterByProvider(providerId)
-		stitchingManager.StoreStitchingValue(node)
+		if node != nil {
+			glog.V(3).Infof("The node we are parsing is : %v", node.Name)
+			providerId := node.Spec.ProviderID
+			stitchingManager.SetNodeUuidGetterByProvider(providerId)
+			stitchingManager.StoreStitchingValue(node)
+		}
 	}
 
 	//1. build entityDTOs for nodes


### PR DESCRIPTION
This is for https://vmturbo.atlassian.net/browse/OM-36658.

Instead of using a global uuid stitching schema by checking the node[0], we should check each node.