### PR TITLE
Support the horizontal scale in of application execution in k8s

### DIFF
--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -29,9 +29,11 @@ type turboActionType struct {
 }
 
 var (
-	turboActionPodProvision    turboActionType = turboActionType{proto.ActionItemDTO_PROVISION, proto.EntityDTO_CONTAINER_POD}
-	turboActionPodMove         turboActionType = turboActionType{proto.ActionItemDTO_MOVE, proto.EntityDTO_CONTAINER_POD}
-	turboActionContainerResize turboActionType = turboActionType{proto.ActionItemDTO_RIGHT_SIZE, proto.EntityDTO_CONTAINER}
+	turboActionPodProvision        turboActionType = turboActionType{proto.ActionItemDTO_PROVISION, proto.EntityDTO_CONTAINER_POD}
+	turboActionPodMove             turboActionType = turboActionType{proto.ActionItemDTO_MOVE, proto.EntityDTO_CONTAINER_POD}
+	turboActionContainerResize     turboActionType = turboActionType{proto.ActionItemDTO_RIGHT_SIZE, proto.EntityDTO_CONTAINER}
+	turboActionContainerPodSuspend turboActionType = turboActionType{proto.ActionItemDTO_SUSPEND, proto.EntityDTO_CONTAINER_POD}
+
 	//turboActionUnbind          turboActionType = "unbind"
 )
 
@@ -92,7 +94,7 @@ func (h *ActionHandler) registerActionExecutors() {
 
 	horizontalScaler := executor.NewHorizontalScaler(ae)
 	h.actionExecutors[turboActionPodProvision] = horizontalScaler
-	//h.actionExecutors[turboActionUnbind] = horizontalScaler
+	h.actionExecutors[turboActionContainerPodSuspend] = horizontalScaler
 
 	containerResizer := executor.NewContainerResizer(ae, c.kubeletClient)
 	h.actionExecutors[turboActionContainerResize] = containerResizer
@@ -187,6 +189,8 @@ func (h *ActionHandler) getRelatedPod(actionItem *proto.ActionItemDTO) *api.Pod 
 	case turboActionPodMove:
 		podEntity = se
 	case turboActionPodProvision:
+		podEntity = se
+	case turboActionContainerPodSuspend:
 		podEntity = se
 	default:
 		return nil

--- a/pkg/action/action_handler_test.go
+++ b/pkg/action/action_handler_test.go
@@ -30,7 +30,7 @@ func TestActionHandler_registerActionExecutors(t *testing.T) {
 
 	h.registerActionExecutors()
 
-	supportedActions := [...]turboActionType{turboActionPodProvision, turboActionPodMove, turboActionContainerResize}
+	supportedActions := [...]turboActionType{turboActionPodProvision, turboActionPodMove, turboActionContainerResize, turboActionContainerPodSuspend}
 	m := h.actionExecutors
 	if len(m) != len(supportedActions) {
 		t.Errorf("Action handler supports %d action types but got %d", len(supportedActions), len(m))

--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -86,8 +86,7 @@ func (h *HorizontalScaler) getReplicaDiff(action *proto.ActionItemDTO) (int32, e
 	if atype == proto.ActionItemDTO_PROVISION {
 		// Scale out, increase the replica. diff = 1.
 		return 1, nil
-	} else if atype == proto.ActionItemDTO_MOVE {
-		// TODO, unbind action is send as MOVE. This requires server side change.
+	} else if atype == proto.ActionItemDTO_SUSPEND {
 		// Scale in, decrease the replica. diff = -1.
 		return -1, nil
 	} else {

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -88,6 +88,8 @@ func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO
 	podPolicy[proto.ActionItemDTO_MOVE] = supported
 	podPolicy[proto.ActionItemDTO_PROVISION] = supported
 	podPolicy[proto.ActionItemDTO_RIGHT_SIZE] = notSupported
+	podPolicy[proto.ActionItemDTO_SUSPEND] = supported
+
 	rClient.addActionPolicy(ab, pod, podPolicy)
 
 	//2. container: support resize; recommend provision; not move;
@@ -96,6 +98,8 @@ func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO
 	containerPolicy[proto.ActionItemDTO_RIGHT_SIZE] = supported
 	containerPolicy[proto.ActionItemDTO_PROVISION] = recommend
 	containerPolicy[proto.ActionItemDTO_MOVE] = notSupported
+	containerPolicy[proto.ActionItemDTO_SUSPEND] = recommend
+
 	rClient.addActionPolicy(ab, container, containerPolicy)
 
 	//3. application: only recommend provision; all else are not supported
@@ -104,6 +108,8 @@ func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO
 	appPolicy[proto.ActionItemDTO_PROVISION] = recommend
 	appPolicy[proto.ActionItemDTO_RIGHT_SIZE] = notSupported
 	appPolicy[proto.ActionItemDTO_MOVE] = notSupported
+	appPolicy[proto.ActionItemDTO_SUSPEND] = recommend
+
 	rClient.addActionPolicy(ab, app, appPolicy)
 
 	return ab.Create()

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -45,21 +45,25 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 	move := proto.ActionItemDTO_MOVE
 	resize := proto.ActionItemDTO_RIGHT_SIZE
 	provision := proto.ActionItemDTO_PROVISION
+	suspend := proto.ActionItemDTO_SUSPEND
 
 	expected_pod := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
 	expected_pod[move] = supported
 	expected_pod[resize] = notSupported
 	expected_pod[provision] = supported
+	expected_pod[suspend] = supported
 
 	expected_container := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
 	expected_container[move] = notSupported
 	expected_container[resize] = supported
 	expected_container[provision] = recommend
+	expected_container[suspend] = recommend
 
 	expected_app := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
 	expected_app[move] = notSupported
 	expected_app[resize] = notSupported
 	expected_app[provision] = recommend
+	expected_app[suspend] = recommend
 
 	policies := reg.GetActionPolicy()
 


### PR DESCRIPTION
Tested in Openshift 3.7, execution succeeded. 

I0827 13:59:40.880404    3882 remote_mediation_client.go:423] Received: action SUSPEND request for probe type: Kubernetes-867813526
 
I0827 13:59:40.880438    3882 turbo_probe.go:238] Execute Action for Target: [key:"targetIdentifier" stringValue:"Kubernetes-Streched cluster"  key:"password" stringValue:"defaultPassword"  key:"username" stringValue:"defaultUser" ]
I0827 13:59:40.880572    3882 action_handler.go:302] Receive a action request of type: {actionType:3 targetEntityType:41}
I0827 13:59:40.880593    3882 action_handler.go:125] Now wait for action result
I0827 13:59:40.880628    3882 remote_mediation_client.go:487] Sent action progress for 69.
I0827 14:00:07.218029    3882 remote_mediation_client.go:487] Sent action progress for 69.
I0827 14:00:13.702810    3882 remote_mediation_client.go:487] Sent action progress for 69.
I0827 14:01:41.702742    3882 horizontal_scaler.go:45] Begin to check action resulf of HorizontalScale for pod[default/max-ui-dbssd]
I0827 14:01:41.702751    3882 client_websocket_transport.go:153] begin to send Ping message
I0827 14:01:44.474069    3882 horizontal_scaler.go:50] Action HorizontalScale for pod[default/max-ui-dbssd] succeeded.
I0827 14:01:41.702751    3882 remote_mediation_client.go:487] Sent action progress for 69.
I0827 14:01:41.702772    3882 client_websocket_transport.go:198] Received websocket message of type 2 and size 131
I0827 14:01:46.061602    3882 client_websocket_transport.go:224] [ListenForMessages] received message on websocket of size 131
I0827 14:01:46.061615    3882 remote_mediation_client.go:468] Sent action response for 69.
I0827 14:01:46.061649    3882 action_handler.go:277] action keepAlive goroutine exit.
