### PR TITLE
Include NotReady Node into quota discovery, to prevent the removal of…

### DIFF
--- a/pkg/discovery/worker/quotas_discovery_worker.go
+++ b/pkg/discovery/worker/quotas_discovery_worker.go
@@ -85,10 +85,8 @@ func (worker *k8sResourceQuotasDiscoveryWorker) Do(quotaMetricsList []*repositor
 		for _, node := range kubeNodes {
 			//Do not include the node that is not ready
 			// We still want to include the scheduledisabled nodes in the relationship
-			if util.NodeIsReady(node.Node) {
-				nodeUID := node.UID
-				quotaEntity.AddNodeProvider(nodeUID, quotaMetrics.AllocationBoughtMap[nodeUID])
-			}
+			nodeUID := node.UID
+			quotaEntity.AddNodeProvider(nodeUID, quotaMetrics.AllocationBoughtMap[nodeUID])
 		}
 
 		// Create sold allocation commodity for the types that are not defined in the namespace quota objects


### PR DESCRIPTION
Without attaching the notready node with quota, seems like the node and corresponding pod will get deleted completely. With Michael's cache change earlier, we will create instance for not ready node now, so having not ready node attaching to the vdc is now working fine. 