### PR TITLE
Fix NPE when GetMachineInfo is called before GetSummary.

### DIFF
--- a/pkg/kubeclient/kubelet_client.go
+++ b/pkg/kubeclient/kubelet_client.go
@@ -131,11 +131,12 @@ func (client *KubeletClient) GetSummary(host string) (*stats.Summary, error) {
 	entry, entryPresent := client.cache[host]
 	if err != nil {
 		if entryPresent {
-			glog.V(2).Infof("unable to retrieve machine[%s] summary: %v. Using cached value", host, err)
 			entry.used = true
 			if entry.statsSummary == nil {
+				glog.V(2).Infof("unable to retrieve machine[%s] summary: %v. The cached value unavailable", host, err)
 				return nil, err
 			}
+			glog.V(2).Infof("unable to retrieve machine[%s] summary: %v. Using cached value", host, err)
 			return entry.statsSummary, nil
 		} else {
 			glog.Errorf("failed to get machine[%s] summary: %v. No cache available", host, err)
@@ -167,11 +168,12 @@ func (client *KubeletClient) GetMachineInfo(host string) (*cadvisorapi.MachineIn
 	entry, entryPresent := client.cache[host]
 	if err != nil {
 		if entryPresent {
-			glog.V(2).Infof("unable to retrieve machine[%s] machine info: %v. Using cached value", host, err)
 			entry.used = true
 			if entry.machineInfo == nil {
+				glog.V(2).Infof("unable to retrieve machine[%s] machine info: %v. The cached value unavailable", host, err)
 				return nil, err
 			}
+			glog.V(2).Infof("unable to retrieve machine[%s] machine info: %v. Using cached value", host, err)
 			return entry.machineInfo, nil
 		} else {
 			glog.Errorf("failed to get machine[%s] machine info: %v. No cache available", host, err)

--- a/pkg/kubeclient/kubelet_client.go
+++ b/pkg/kubeclient/kubelet_client.go
@@ -133,6 +133,9 @@ func (client *KubeletClient) GetSummary(host string) (*stats.Summary, error) {
 		if entryPresent {
 			glog.V(2).Infof("unable to retrieve machine[%s] summary: %v. Using cached value", host, err)
 			entry.used = true
+			if entry.statsSummary == nil {
+				return nil, err
+			}
 			return entry.statsSummary, nil
 		} else {
 			glog.Errorf("failed to get machine[%s] summary: %v. No cache available", host, err)
@@ -166,6 +169,9 @@ func (client *KubeletClient) GetMachineInfo(host string) (*cadvisorapi.MachineIn
 		if entryPresent {
 			glog.V(2).Infof("unable to retrieve machine[%s] machine info: %v. Using cached value", host, err)
 			entry.used = true
+			if entry.machineInfo == nil {
+				return nil, err
+			}
 			return entry.machineInfo, nil
 		} else {
 			glog.Errorf("failed to get machine[%s] machine info: %v. No cache available", host, err)

--- a/pkg/kubeclient/kubelet_client_test.go
+++ b/pkg/kubeclient/kubelet_client_test.go
@@ -64,8 +64,7 @@ func TestKubeletClientCachebeenUsed(t *testing.T) {
 }
 
 func TestKubeletClientCacheNil(t *testing.T) {
-	kubeConf := &rest.Config{
-	}
+	kubeConf := &rest.Config{}
 	conf := NewKubeletConfig(kubeConf)
 
 	kc, _ := conf.Create()

--- a/pkg/kubeclient/kubelet_client_test.go
+++ b/pkg/kubeclient/kubelet_client_test.go
@@ -3,6 +3,7 @@ package kubeclient
 import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
 	"testing"
 )
 
@@ -60,4 +61,20 @@ func TestKubeletClientCachebeenUsed(t *testing.T) {
 	assert.False(t, kc.HasCacheBeenUsed("host_3"))
 	kc.cache["host_2"].used = true
 	assert.True(t, kc.HasCacheBeenUsed("host_2"))
+}
+
+func TestKubeletClientCacheNil(t *testing.T) {
+	kubeConf := &rest.Config{
+	}
+	conf := NewKubeletConfig(kubeConf)
+
+	kc, _ := conf.Create()
+	entry := &CacheEntry{}
+	kc.cache["host_1"] = entry
+	assert.False(t, kc.HasCacheBeenUsed("host_1"))
+	_, err := kc.GetSummary("host_1")
+	assert.NotNil(t, err)
+
+	_, err2 := kc.GetMachineInfo("host_1")
+	assert.NotNil(t, err2)
 }


### PR DESCRIPTION
Return err when using the cache in case machine info or summary hasn't been set yet.