### PR TITLE
Patching vmem and vcpu for node entities

### DIFF
--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -134,7 +134,7 @@ func (m *ClusterMonitor) genNodeResourceMetrics(node *api.Node) error {
 	glog.V(3).Infof("Now get resouce metrics for node %s", key)
 
 	//1. Capacity of cpu and memory
-	cpuCapacityCore, memoryCapacityKiloBytes := util.GetCpuAndMemoryValues(node.Status.Allocatable)
+	cpuCapacityCore, memoryCapacityKiloBytes := util.GetCpuAndMemoryValues(node.Status.Capacity)
 	glog.V(4).Infof("Cpu capacity of node %s is %f core", node.Name, cpuCapacityCore)
 	glog.V(4).Infof("Memory capacity of node %s is %f Kb", node.Name, memoryCapacityKiloBytes)
 	m.genCapacityMetrics(metrics.NodeType, key, cpuCapacityCore, memoryCapacityKiloBytes)

--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -206,12 +206,14 @@ func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_Re
 	default:
 		return nil, fmt.Errorf("Stitching property type %s is not supported.", s.stitchType)
 	}
-	propertyNames := []string{builder.PropertyCapacity, builder.PropertyUsed}
-	accessCommPropertyNames := []string{builder.PropertyCapacity}
-	replacementEntityMetaDataBuilder.PatchSellingWithProperty(proto.CommodityDTO_CLUSTER, accessCommPropertyNames).
-		PatchSellingWithProperty(proto.CommodityDTO_VMPM_ACCESS, accessCommPropertyNames).
-		PatchSellingWithProperty(proto.CommodityDTO_CPU_ALLOCATION, propertyNames).
-		PatchSellingWithProperty(proto.CommodityDTO_MEM_ALLOCATION, propertyNames)
+	usedAndCapacityPropertyNames := []string{builder.PropertyCapacity, builder.PropertyUsed}
+	capacityOnlyPropertyNames := []string{builder.PropertyCapacity}
+	replacementEntityMetaDataBuilder.PatchSellingWithProperty(proto.CommodityDTO_CLUSTER, capacityOnlyPropertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_VMPM_ACCESS, capacityOnlyPropertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_VCPU, usedAndCapacityPropertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_VMEM, usedAndCapacityPropertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_CPU_ALLOCATION, usedAndCapacityPropertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_MEM_ALLOCATION, usedAndCapacityPropertyNames)
 	meta := replacementEntityMetaDataBuilder.Build()
 	return meta, nil
 }


### PR DESCRIPTION
This pull request added code to patch vmem and vcpu for node entities.  This patching is beneficial for the following scenarios:
-  Some cloud VMs do not have vmem usage instrumented by default.  This patching (from Kubernetes) allows those cloud VMs to have vmem metrics.
- Some other cloud VMs have their CPU metrics scaled up according to the ECU (AWS) or the ACU (Azure).  These metrics are from the cloud probes.  Kubernetes doesn't know about this scaling.  That means all the metrics for pods/containers that come from Kubernetes are not similarly scaled.  This mismatch would result in inaccurate container/pod actions.  This patching will correct such an inaccuracy by bringing back the unscaled CPU metrics for VM node entities.

This pull request also changed to use the overall capacity instead of the allocatable capacity for both vmem and vcpu, because the used value already includes the non-allocatable portion.  This change applies to the CPUAllocation and the MemAllocation capacities too, as dictated by the existing design.  We should have further discussion to decide what's best to do for those allocation/quota metrics.

Finally, one note for the vmem used value from Kubernetes.  It comes from cgroup which includes "active" cache pages.  This is different and generally more conservative than what's normally retrieved from the guest OS using "free", which doesn't count those cache pages.  Also as a comparison, vSphere is even more different: it has its own version of "Active Memory", which is generally more aggressive (or less than "free", which is less than from cgroup).
