### PR TITLE
No schedulable commodity for not controllable pods

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -77,7 +77,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeturbo.io/monitored: "false"
+        kubeturbo.io/controllable: "false"
       labels:
         app: kubeturbo
     spec:

--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -103,10 +103,6 @@ func (builder *applicationEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod) ([]
 			properties := builder.getApplicationProperties(pod, i)
 			ebuilder.WithProperties(properties)
 
-			if !util.Monitored(pod) {
-				ebuilder.Monitored(false)
-			}
-
 			truep := true
 			ebuilder.ConsumerPolicy(&proto.EntityDTO_ConsumerPolicy{
 				ProviderMustClone: &truep,

--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -92,7 +92,7 @@ func (builder *containerDTOBuilder) BuildDTOs(pods []*api.Pod) ([]*proto.EntityD
 			properties := builder.addPodProperties(pod, i)
 			ebuilder.WithProperties(properties)
 
-			ebuilder.Monitored(util.Monitored(pod))
+			//ebuilder.Monitored(util.Monitored(pod))
 			ebuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
 
 			truep := true

--- a/pkg/discovery/dtofactory/container_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_dto_builder_test.go
@@ -20,7 +20,7 @@ func TestPodFlags(t *testing.T) {
 	 * Pod 2: controllable = true, monitored = true, parentKind = ReplicaSet
 	 * (controllable should be true, monitored should be true)
 	 *
-	 * Pod 3: controllable = true, monitored = false, parentKind = ReplicaSet
+	 * Pod 3: controllable = false, monitored = true, parentKind = ReplicaSet
 	 * This pod has the "kubeturbo.io/monitored" attribute set to false.
 	 * (controllable should be true, monitored should be false)
 	 */
@@ -31,7 +31,7 @@ func TestPodFlags(t *testing.T) {
 		{true, true},
 		{false, true},
 		{true, true},
-		{true, false},
+		{false, true},
 	}
 
 	pods, err := LoadCannedTopology()
@@ -45,14 +45,9 @@ func TestPodFlags(t *testing.T) {
 
 	for i, pod := range pods {
 		controllable := podutil.Controllable(pod)
-		monitored := podutil.Monitored(pod)
 		if controllable != expectedResult[i].Controllable {
 			t.Errorf("Pod %d Controllable: expected %v, got %v", i,
 				expectedResult[i].Controllable, controllable)
-		}
-		if monitored != expectedResult[i].Monitored {
-			t.Errorf("Pod %d Monitored: expected %v, got %v", i,
-				expectedResult[i].Monitored, monitored)
 		}
 	}
 }
@@ -61,9 +56,8 @@ func dumpPodFlags(pods []*api.Pod) {
 	// This code dumps the attributes of the saved topology
 	for i, pod := range pods {
 		parentKind, _, _ := podutil.GetPodParentInfo(pod)
-		fmt.Printf("Pod %d: controllable = %v, monitored = %v, parentKind = %s\n", i,
+		fmt.Printf("Pod %d: controllable = %v, parentKind = %s\n", i,
 			podutil.Controllable(pod),
-			podutil.Monitored(pod),
 			parentKind)
 	}
 }

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -120,11 +120,6 @@ func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod) ([]*proto.E
 		}
 		entityDTOBuilder = entityDTOBuilder.WithProperties(properties)
 
-		if !util.Monitored(pod) {
-			entityDTOBuilder.Monitored(false)
-			glog.V(3).Infof("Pod %v is not monitored.", displayName)
-		}
-
 		controllable := util.Controllable(pod)
 		if !controllable {
 			glog.V(3).Infof("Pod %v is not controllable.", displayName)
@@ -237,7 +232,7 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBought(pod *api.Pod, cpuFre
 	}
 
 	// Access commodity: schedulable
-	if util.Monitored(pod) {
+	if util.Controllable(pod) {
 		schedAccessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
 			Key(schedAccessCommodityKey).
 			Create()

--- a/pkg/discovery/dtofactory/service_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/service_entity_dto_builder.go
@@ -53,15 +53,9 @@ func (builder *ServiceEntityDTOBuilder) BuildSvcEntityDTO(servicePodMap map[*api
 		// set the ip property for stitching
 		ebuilder.WithProperty(getIPProperty(pods))
 
-		//3. check whether it is monitored
-		if !util.IsMonitoredFromAnnotation(service.GetAnnotations()) {
-			glog.V(3).Infof("Service %v is not monitored.", displayName)
-			ebuilder.Monitored(false)
-		}
-
 		ebuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
 
-		//4. create it
+		//3. create it
 		entityDto, err := ebuilder.Create()
 		if err != nil {
 			glog.Errorf("failed to create service[%s] EntityDTO: %v", displayName, err)

--- a/pkg/discovery/util/pod_util_test.go
+++ b/pkg/discovery/util/pod_util_test.go
@@ -73,26 +73,26 @@ func checkObject(obj interface{}, t *testing.T) {
 		return
 	}
 
-	if len(annotation) == 0 && !IsMonitoredFromAnnotation(acc.GetAnnotations()) {
-		t.Errorf("Object %v with empty annotation should be monitored.", acc.GetName())
+	if len(annotation) == 0 && !IsControllableFromAnnotation(acc.GetAnnotations()) {
+		t.Errorf("Object %v with empty annotation should be controllable.", acc.GetName())
 	}
 
 	setMonitorFlag(annotation, true)
-	if !IsMonitoredFromAnnotation(acc.GetAnnotations()) {
-		t.Errorf("Object %v should be monitored.", acc.GetName())
+	if !IsControllableFromAnnotation(acc.GetAnnotations()) {
+		t.Errorf("Object %v should be controllable.", acc.GetName())
 	}
 
 	setMonitorFlag(annotation, false)
-	if IsMonitoredFromAnnotation(acc.GetAnnotations()) {
-		t.Errorf("Object %v should be monitored.", acc.GetName())
+	if IsControllableFromAnnotation(acc.GetAnnotations()) {
+		t.Errorf("Object %v should be controllable.", acc.GetName())
 	}
 }
 
 func TestIsMonitoredFromAnnotation_Pod(t *testing.T) {
 	pod := createPod()
 
-	if !IsMonitoredFromAnnotation(pod.GetAnnotations()) {
-		t.Error("Pod without annotation should be monitored.")
+	if !IsControllableFromAnnotation(pod.GetAnnotations()) {
+		t.Error("Pod without annotation should be controllable.")
 	}
 
 	pod.Annotations = make(map[string]string)
@@ -102,8 +102,8 @@ func TestIsMonitoredFromAnnotation_Pod(t *testing.T) {
 func TestIsMonitoredFromAnnotation_Service(t *testing.T) {
 	svc := createService()
 
-	if !IsMonitoredFromAnnotation(svc.GetAnnotations()) {
-		t.Error("Service without annotation should be monitored")
+	if !IsControllableFromAnnotation(svc.GetAnnotations()) {
+		t.Error("Service without annotation should be controllable")
 	}
 
 	svc.Annotations = make(map[string]string)
@@ -113,8 +113,8 @@ func TestIsMonitoredFromAnnotation_Service(t *testing.T) {
 func TestIsMonitoredFromAnnotation_Namespace(t *testing.T) {
 	ns := createNamespace()
 
-	if !IsMonitoredFromAnnotation(ns.GetAnnotations()) {
-		t.Error("Service without annotation should be monitored")
+	if !IsControllableFromAnnotation(ns.GetAnnotations()) {
+		t.Error("Service without annotation should be controllable")
 	}
 
 	ns.Annotations = make(map[string]string)
@@ -187,24 +187,6 @@ func TestGetReadyPods(t *testing.T) {
 				t.Errorf("Test %s: GetReadyPods() = %++v, want %++v", tt.name, got, tt.want)
 			}
 		})
-	}
-}
-
-func TestMonitored_DaemonSet(t *testing.T) {
-	// With annotation
-	pod := newPod("pod-foo")
-	pod.Annotations = map[string]string{
-		"kubernetes.io/created-by": `{"reference":{"kind":"DaemonSet","name":"daemon-set-foo"}}`,
-	}
-
-	if !Monitored(pod) {
-		t.Errorf("The pod in DaemonSet must be monitored")
-	}
-
-	// With Owner reference
-	podWithOwnerRef := makePodInDaemonSet()
-	if !Monitored(podWithOwnerRef) {
-		t.Errorf("The pod (with owner reference) in DaemonSet must be monitored")
 	}
 }
 


### PR DESCRIPTION
If pods are not controllable (e.g., daemonSet pods), creating schedulable access commodities will cause issues when running plans as those pods might not have any valid VM providers.

The change includes:

1. All entities are monitored;
2. Add annotation "kubeturbo.io/controllable" to replace "kubeturbo.io/monitored"; 
3. Pods those are not controllable don't buy schedulable access commodities.