### PR TITLE
Using working set as memory used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ actionexecutionsimulator
 _output/
 .idea/
 kubeturbo.iml
+kubeturbo
+kubeturbo.linux

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,6 @@
+### Simple Dockerfile for testing
+FROM alpine:3.3
+RUN apk --update upgrade && apk add ca-certificates && update-ca-certificates
+COPY ./kubeturbo.linux /bin/kubeturbo 
+RUN chmod +x /bin/kubeturbo
+ENTRYPOINT ["/bin/kubeturbo"]

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -142,12 +142,12 @@ func (m *KubeletMonitor) parseNodeInfo(node *api.Node, machineInfo *cadvisorapi.
 func (m *KubeletMonitor) parseNodeStats(nodeStats stats.NodeStats) {
 	// cpu
 	cpuUsageCore := float64(*nodeStats.CPU.UsageNanoCores) / util.NanoToUnit
-	memoryUsageKiloBytes := float64(*nodeStats.Memory.UsageBytes) / util.KilobytesToBytes
+	memoryWorkingSetKiloBytes := float64(*nodeStats.Memory.WorkingSetBytes) / util.KilobytesToBytes
 
 	key := util.NodeStatsKeyFunc(nodeStats)
 	glog.V(4).Infof("CPU usage of node %s is %.3f core", nodeStats.NodeName, cpuUsageCore)
-	glog.V(4).Infof("Memory usage of node %s is %.3f KB", nodeStats.NodeName, memoryUsageKiloBytes)
-	m.genUsedMetrics(metrics.NodeType, key, cpuUsageCore, memoryUsageKiloBytes)
+	glog.V(4).Infof("Memory working set of node %s is %.3f KB", nodeStats.NodeName, memoryWorkingSetKiloBytes)
+	m.genUsedMetrics(metrics.NodeType, key, cpuUsageCore, memoryWorkingSetKiloBytes)
 }
 
 // Parse pod stats for every pod and put them into sink.
@@ -178,12 +178,12 @@ func (m *KubeletMonitor) parseContainerStats(pod *stats.PodStats) (float64, floa
 		if container.CPU == nil || container.CPU.UsageNanoCores == nil {
 			continue
 		}
-		if container.Memory == nil || container.Memory.UsageBytes == nil {
+		if container.Memory == nil || container.Memory.WorkingSetBytes == nil {
 			continue
 		}
 
 		cpuUsed := float64(*(container.CPU.UsageNanoCores)) / util.NanoToUnit
-		memUsed := float64(*(container.Memory.UsageBytes)) / util.KilobytesToBytes
+		memUsed := float64(*(container.Memory.WorkingSetBytes)) / util.KilobytesToBytes
 
 		totalUsedCPU += cpuUsed
 		totalUsedMem += memUsed

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
@@ -27,7 +27,7 @@ func createContainerStat(name string, cpu, mem int) stats.ContainerStats {
 
 	usedbytes := uint64(mem)
 	memoryInfo := &stats.MemoryStats{
-		UsageBytes: &usedbytes,
+		WorkingSetBytes: &usedbytes,
 	}
 
 	container := stats.ContainerStats{
@@ -82,7 +82,7 @@ func checkPodMetrics(sink *metrics.EntityMetricSink, podMId string, pod *stats.P
 			expected = expected / util.NanoToUnit
 		} else {
 			for _, c := range pod.Containers {
-				expected += float64(*c.Memory.UsageBytes)
+				expected += float64(*c.Memory.WorkingSetBytes)
 			}
 			expected = expected / util.KilobytesToBytes
 		}
@@ -114,7 +114,7 @@ func checkContainerMetrics(sink *metrics.EntityMetricSink, containerMId string, 
 			expected += float64(*container.CPU.UsageNanoCores)
 			expected = expected / util.NanoToUnit
 		} else {
-			expected += float64(*container.Memory.UsageBytes)
+			expected += float64(*container.Memory.WorkingSetBytes)
 			expected = expected / util.KilobytesToBytes
 		}
 
@@ -144,7 +144,7 @@ func checkApplicationMetrics(sink *metrics.EntityMetricSink, appMId string, cont
 			expected += float64(*container.CPU.UsageNanoCores)
 			expected = expected / util.NanoToUnit
 		} else {
-			expected += float64(*container.Memory.UsageBytes)
+			expected += float64(*container.Memory.WorkingSetBytes)
 			expected = expected / util.KilobytesToBytes
 		}
 


### PR DESCRIPTION
Currently for memory used stats for both containers and nodes, we get it from [Kubelet's MemoryStats.UsagesBytes](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/stats/v1alpha1/types.go#L211), which includes "inactive" cache pages that are reclaimable by the OS when necessary.  In other words, that doesn't reflect the true memory pressure (in terms of OOM possibility).

To more properly reflect on the true memory pressure, this pull request changed to use [MemoryStats.WorkingSetBytes](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/stats/v1alpha1/types.go#L215) instead.  Loosely speaking, this is the memory that can't be reclaimed by the OS.  It does include the active cache pages, which are not claimable.

Here is a good article on this topic: https://blog.freshtracks.io/a-deep-dive-into-kubernetes-metrics-part-3-container-resource-metrics-361c5ee46e66.

The two attached screenshots are a comparison before and after this change on the memory used value of an AKS node.  As one can see the difference (66% vs 44%) could be quite significant.  Though there are cases where the difference is minimum if the apps aren't having a lot of cold page caches.

<img width="1424" alt="aks-node-memory-used-before-changes" src="https://user-images.githubusercontent.com/6045065/46922800-75bee680-cfdc-11e8-8c52-33f8541ea2cf.png">
<img width="1424" alt="aks-node-memory-used-after-changes" src="https://user-images.githubusercontent.com/6045065/46922841-f67de280-cfdc-11e8-94c7-6c12fff03af4.png">
