### PR TITLE
Add openshift scc flag to allow pod action execution

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -41,6 +41,8 @@ const (
 )
 
 var (
+	defaultSccSupport = []string{"restricted"}
+
 	//these variables will be deprecated. Keep it here for backward compatibility only
 	k8sVersion        = "1.8"
 	noneSchedulerName = "turbo-no-scheduler"
@@ -82,6 +84,9 @@ type VMTServer struct {
 	// The cluster processor related config
 	ValidationWorkers int
 	ValidationTimeout int
+
+	// The Openshift SCC list allowed for action execution
+	sccSupport []string
 }
 
 // NewVMTServer creates a new VMTServer with default parameters
@@ -112,6 +117,7 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.DiscoveryIntervalSec, "discovery-interval-sec", defaultDiscoveryIntervalSec, "The discovery interval in seconds")
 	fs.IntVar(&s.ValidationWorkers, "validation-workers", defaultValidationWorkers, "The validation workers")
 	fs.IntVar(&s.ValidationTimeout, "validation-timeout-sec", defaultValidationTimeout, "The validation timeout in seconds")
+	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=.* to allow all")
 }
 
 // create an eventRecorder to send events to Kubernetes APIserver
@@ -231,7 +237,8 @@ func (s *VMTServer) Run(_ []string) error {
 		UsingUUIDStitch(s.UseUUID).
 		WithDiscoveryInterval(s.DiscoveryIntervalSec).
 		WithValidationTimeout(s.ValidationTimeout).
-		WithValidationWorkers(s.ValidationWorkers)
+		WithValidationWorkers(s.ValidationWorkers).
+		WithSccSupport(s.sccSupport)
 	glog.V(3).Infof("Finished creating turbo configuration: %+v", vmtConfig)
 
 	// The KubeTurbo TAP service

--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -117,7 +117,7 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.DiscoveryIntervalSec, "discovery-interval-sec", defaultDiscoveryIntervalSec, "The discovery interval in seconds")
 	fs.IntVar(&s.ValidationWorkers, "validation-workers", defaultValidationWorkers, "The validation workers")
 	fs.IntVar(&s.ValidationTimeout, "validation-timeout-sec", defaultValidationTimeout, "The validation timeout in seconds")
-	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=.* to allow all")
+	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=* to allow all")
 }
 
 // create an eventRecorder to send events to Kubernetes APIserver

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
 	"github.com/turbonomic/kubeturbo/pkg/turbostore"
 	api "k8s.io/api/core/v1"
+	"strings"
 )
 
 const (
@@ -41,13 +42,21 @@ type ActionHandlerConfig struct {
 	kubeClient     *client.Clientset
 	kubeletClient  *kubeclient.KubeletClient
 	StopEverything chan struct{}
+	sccAllowedSet  map[string]struct{}
 }
 
-func NewActionHandlerConfig(kubeClient *client.Clientset, kubeletClient *kubeclient.KubeletClient) *ActionHandlerConfig {
+func NewActionHandlerConfig(kubeClient *client.Clientset, kubeletClient *kubeclient.KubeletClient, sccSupport []string) *ActionHandlerConfig {
+	sccAllowedSet := make(map[string]struct{})
+	for _, sccAllowed := range sccSupport {
+		sccAllowedSet[strings.TrimSpace(sccAllowed)] = struct{}{}
+	}
+	glog.V(4).Infof("SCC's allowed: %s", sccAllowedSet)
+
 	config := &ActionHandlerConfig{
 		kubeClient:     kubeClient,
 		kubeletClient:  kubeletClient,
 		StopEverything: make(chan struct{}),
+		sccAllowedSet:  sccAllowedSet,
 	}
 
 	return config
@@ -89,14 +98,14 @@ func (h *ActionHandler) registerActionExecutors() {
 	c := h.config
 	ae := executor.NewTurboK8sActionExecutor(c.kubeClient, h.podManager)
 
-	reScheduler := executor.NewReScheduler(ae)
+	reScheduler := executor.NewReScheduler(ae, c.sccAllowedSet)
 	h.actionExecutors[turboActionPodMove] = reScheduler
 
 	horizontalScaler := executor.NewHorizontalScaler(ae)
 	h.actionExecutors[turboActionPodProvision] = horizontalScaler
 	h.actionExecutors[turboActionContainerPodSuspend] = horizontalScaler
 
-	containerResizer := executor.NewContainerResizer(ae, c.kubeletClient)
+	containerResizer := executor.NewContainerResizer(ae, c.kubeletClient, c.sccAllowedSet)
 	h.actionExecutors[turboActionContainerResize] = containerResizer
 }
 

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -15,11 +15,13 @@ import (
 
 type ReScheduler struct {
 	TurboK8sActionExecutor
+	sccAllowedSet map[string]struct{}
 }
 
-func NewReScheduler(ae TurboK8sActionExecutor) *ReScheduler {
+func NewReScheduler(ae TurboK8sActionExecutor, sccAllowedSet map[string]struct{}) *ReScheduler {
 	return &ReScheduler{
 		TurboK8sActionExecutor: ae,
+		sccAllowedSet:          sccAllowedSet,
 	}
 }
 
@@ -164,7 +166,7 @@ func (r *ReScheduler) preActionCheck(pod *api.Pod, node *api.Node) error {
 	fullName := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 
 	// Check if the pod privilege is supported
-	if !util.SupportPrivilegePod(pod) {
+	if !util.SupportPrivilegePod(pod, r.sccAllowedSet) {
 		err := fmt.Errorf("The pod %s has privilege requirement unsupported", fullName)
 		glog.Error(err)
 		return err

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -167,7 +167,7 @@ func (r *ReScheduler) preActionCheck(pod *api.Pod, node *api.Node) error {
 
 	// Check if the pod privilege is supported
 	if !util.SupportPrivilegePod(pod, r.sccAllowedSet) {
-		err := fmt.Errorf("The pod %s has privilege requirement unsupported", fullName)
+		err := fmt.Errorf("Pod %s has unsupported SCC", fullName)
 		glog.Error(err)
 		return err
 	}

--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -375,7 +375,7 @@ func (r *ContainerResizer) preActionCheck(resizeSpec *containerResizeSpec, pod *
 
 	// Check if the pod privilege is supported
 	if !util.SupportPrivilegePod(pod, r.sccAllowedSet) {
-		err := fmt.Errorf("The pod %s has privilege requirement unsupported", fullName)
+		err := fmt.Errorf("Pod %s has unsupported SCC", fullName)
 		glog.Error(err)
 		return err
 	}

--- a/pkg/action/util/util.go
+++ b/pkg/action/util/util.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	osSccAnnotation = "openshift.io/scc"
-	osSccAllowAll   = ".*"
+	osSccAllowAll   = "*"
 )
 
 var (
@@ -150,7 +150,8 @@ func SupportPrivilegePod(pod *api.Pod, sccAllowedSet map[string]struct{}) bool {
 
 	podScc := pod.Annotations[osSccAnnotation]
 	if _, ok := sccAllowedSet[podScc]; !ok {
-		glog.Warningf("The pod %s has unsupported privilege %s", pod.Name, podScc)
+		glog.Warningf("Target pod %s has unsupported SCC %s. Please add the SCC to "+
+			"--scc-support argument in kubeturbo yaml to allow execution.", pod.Name, podScc)
 		return false
 	}
 

--- a/pkg/action/util/util_test.go
+++ b/pkg/action/util/util_test.go
@@ -103,7 +103,66 @@ func TestAddAnnotation_Overwrite(t *testing.T) {
 	}
 }
 
-func TestSupportPrivilegePod(t *testing.T) {
+func TestSupportPrivilegePodAllowNone(t *testing.T) {
+	sccAllowedSet := map[string]struct{}{}
+
+	wants := map[string]bool{
+		"restricted": false,
+		"anyuid":     false,
+		"privilege":  false,
+		"foo":        false,
+	}
+
+	testSupportPrivilegePod(t, sccAllowedSet, wants)
+}
+
+func TestSupportPrivilegePodAllowAll(t *testing.T) {
+	sccAllowedSet := map[string]struct{}{
+		".*": struct{}{},
+	}
+
+	wants := map[string]bool{
+		"restricted": true,
+		"anyuid":     true,
+		"privilege":  true,
+		"foo":        true,
+	}
+
+	testSupportPrivilegePod(t, sccAllowedSet, wants)
+}
+
+func TestSupportPrivilegePodAllowRestrictedOnly(t *testing.T) {
+	sccAllowedSet := map[string]struct{}{
+		"restricted": struct{}{},
+	}
+
+	wants := map[string]bool{
+		"restricted": true,
+		"anyuid":     false,
+		"privilege":  false,
+		"foo":        false,
+	}
+
+	testSupportPrivilegePod(t, sccAllowedSet, wants)
+}
+
+func TestSupportPrivilegePodAllowRestrictedAndFoo(t *testing.T) {
+	sccAllowedSet := map[string]struct{}{
+		"restricted": struct{}{},
+		"foo":        struct{}{},
+	}
+
+	wants := map[string]bool{
+		"restricted": true,
+		"anyuid":     false,
+		"privilege":  false,
+		"foo":        true,
+	}
+
+	testSupportPrivilegePod(t, sccAllowedSet, wants)
+}
+
+func testSupportPrivilegePod(t *testing.T, sccAllowedSet map[string]struct{}, wants map[string]bool) {
 	tests := []struct {
 		name string
 		pod  *api.Pod
@@ -112,15 +171,15 @@ func TestSupportPrivilegePod(t *testing.T) {
 		{name: "pod-without-annotations", pod: newPod("pod-1", nil), want: true},
 		{name: "pod-with-empty-annotations", pod: newPod("pod-2", make(map[string]string)), want: true},
 		{name: "pod-with-scc-empty", pod: podWithSccAnnotations("pod-3", ""), want: true},
-		{name: "pod-with-scc-restricted", pod: podWithSccAnnotations("pod-4", "restricted"), want: true},
-		{name: "pod-with-scc-anyuid", pod: podWithSccAnnotations("pod-5", "anyuid"), want: false},
-		{name: "pod-with-scc-privilege", pod: podWithSccAnnotations("pod-6", "privilege"), want: false},
-		{name: "pod-with-scc-foo", pod: podWithSccAnnotations("pod-7", "foo"), want: false},
+		{name: "pod-with-scc-restricted", pod: podWithSccAnnotations("pod-4", "restricted"), want: wants["restricted"]},
+		{name: "pod-with-scc-anyuid", pod: podWithSccAnnotations("pod-5", "anyuid"), want: wants["anyuid"]},
+		{name: "pod-with-scc-privilege", pod: podWithSccAnnotations("pod-6", "privilege"), want: wants["privilege"]},
+		{name: "pod-with-scc-foo", pod: podWithSccAnnotations("pod-7", "foo"), want: wants["foo"]},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SupportPrivilegePod(tt.pod); got != tt.want {
+			if got := SupportPrivilegePod(tt.pod, sccAllowedSet); got != tt.want {
 				t.Errorf("SupportPrivilegePod() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/action/util/util_test.go
+++ b/pkg/action/util/util_test.go
@@ -118,7 +118,7 @@ func TestSupportPrivilegePodAllowNone(t *testing.T) {
 
 func TestSupportPrivilegePodAllowAll(t *testing.T) {
 	sccAllowedSet := map[string]struct{}{
-		".*": struct{}{},
+		"*": struct{}{},
 	}
 
 	wants := map[string]bool{

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -109,7 +109,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	probeConfig := createProbeConfigOrDie(config)
 	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig, config.ValidationWorkers, config.ValidationTimeoutSec)
 
-	actionHandlerConfig := action.NewActionHandlerConfig(config.Client, config.KubeletClient)
+	actionHandlerConfig := action.NewActionHandlerConfig(config.Client, config.KubeletClient, config.SccSupport)
 
 	// Kubernetes Probe Registration Client
 	registrationClient := registration.NewK8sRegistrationClient(registrationClientConfig)

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -26,6 +26,8 @@ type Config struct {
 	DiscoveryIntervalSec int
 	ValidationWorkers    int
 	ValidationTimeoutSec int
+
+	SccSupport []string
 }
 
 func NewVMTConfig2() *Config {
@@ -83,5 +85,10 @@ func (c *Config) WithValidationTimeout(di int) *Config {
 
 func (c *Config) WithValidationWorkers(di int) *Config {
 	c.ValidationWorkers = di
+	return c
+}
+
+func (c *Config) WithSccSupport(sccSupport []string) *Config {
+	c.SccSupport = sccSupport
 	return c
 }


### PR DESCRIPTION
Currently for Openshift, kubeturbo will only execute actions for pods with scc="restricted".

The change here is to add a scc flag (scc-support) to allow users to specify which scc's to allow action executions for Openshift clusters.

For example, if no scc flag included, the default is to only allow "restricted". To specify the flag, the allowed scc's should be listed: scc-support=scc1,scc2,scc3. The following are some examples to specify the scc flag.

--scc-support=restricted,anyuid,foo (allow action execution if pod has scc as one of the three)
--scc-support=.* (allow all scc's)