### PR TITLE
Use timestamp to generate the new pod name after action execution. (6.2.0)

### DIFF
--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -263,7 +263,7 @@ func createResizePod(client *kclient.Clientset, pod *k8sapi.Pod, spec *container
 	npod := &k8sapi.Pod{}
 	copyPodWithoutLabel(pod, npod)
 	npod.Spec.NodeName = pod.Spec.NodeName
-	npod.Name = genNewPodName(pod.Name)
+	npod.Name = genNewPodName(pod)
 	// this annotation can be used for future garbage collection if action is interrupted
 	util.AddAnnotation(npod, TurboActionAnnotationKey, TurboResizeAnnotationValue)
 


### PR DESCRIPTION
6.2.0 version for https://github.com/turbonomic/kubeturbo/pull/224