### PR TITLE
Add git commit hash

### DIFF
--- a/redhat-img/Dockerfile
+++ b/redhat-img/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/rhel7
 MAINTAINER Enlin Xu <enlin.xu@turbonomic.com>
+ARG GIT_COMMIT
+ENV GIT_COMMIT ${GIT_COMMIT}
 
 
 ### Atomic/OpenShift Labels - https://github.com/projectatomic/ContainerApplicationGenericLabels


### PR DESCRIPTION
Add git commit hash in Dockerfile so we can log the git hash when kubeturbo starts.