### PR TITLE
Set controllable flag for Containers and Applications

### DIFF
--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultTransactionCapacity float64 = 20.0
+	defaultTransactionCapacity float64 = 1000.0
 	defaultRespTimeCapacity    float64 = 500.0
 )
 
@@ -104,8 +104,10 @@ func (builder *applicationEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod) ([]
 			ebuilder.WithProperties(properties)
 
 			truep := true
+			controllable := util.Controllable(pod)
 			ebuilder.ConsumerPolicy(&proto.EntityDTO_ConsumerPolicy{
 				ProviderMustClone: &truep,
+				Controllable:      &controllable,
 			})
 
 			appType := util.GetAppType(pod)

--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -111,8 +111,10 @@ func (builder *containerDTOBuilder) BuildDTOs(pods []*api.Pod) ([]*proto.EntityD
 			ebuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
 
 			truep := true
+			controllable := util.Controllable(pod)
 			ebuilder.ConsumerPolicy(&proto.EntityDTO_ConsumerPolicy{
 				ProviderMustClone: &truep,
+				Controllable:      &controllable,
 			})
 
 			//4. build entityDTO


### PR DESCRIPTION
- Explicitly set controllable flag for Containers and Applications since kubeturbo knows exactly how to set the values. It avoids the dependency on the default value defined at server side.

- Set default transaction capacity to a lager number (20 -> 1000) to avoid pod provision actions triggered by high transaction utilization.