### PR TITLE
Do not set capacities for Transaction and ResponseTime commodities.

### DIFF
--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -16,11 +16,6 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 )
 
-const (
-	defaultTransactionCapacity float64 = 1000.0
-	defaultRespTimeCapacity    float64 = 500.0
-)
-
 var (
 	applicationResourceCommoditySold = []metrics.ResourceType{
 		metrics.Transaction,
@@ -137,8 +132,7 @@ func getCommoditiesSold(pod *api.Pod, index int) ([]*proto.CommodityDTO, error) 
 
 	key := getAppStitchingProperty(pod, index)
 
-	ebuilder := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_TRANSACTION).Key(key).
-		Capacity(defaultTransactionCapacity)
+	ebuilder := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_TRANSACTION).Key(key)
 
 	tranCommodity, err := ebuilder.Create()
 	if err != nil {
@@ -147,8 +141,7 @@ func getCommoditiesSold(pod *api.Pod, index int) ([]*proto.CommodityDTO, error) 
 	}
 	result = append(result, tranCommodity)
 
-	ebuilder = sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_RESPONSE_TIME).Key(key).
-		Capacity(defaultRespTimeCapacity)
+	ebuilder = sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_RESPONSE_TIME).Key(key)
 
 	respCommodity, err := ebuilder.Create()
 	if err != nil {

--- a/pkg/discovery/dtofactory/application_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder_test.go
@@ -28,8 +28,8 @@ func Test_getCommoditiesSold(t *testing.T) {
 				index: 0,
 			},
 			want: []*proto.CommodityDTO{
-				createCommodity(proto.CommodityDTO_TRANSACTION, podIP, defaultTransactionCapacity),
-				createCommodity(proto.CommodityDTO_RESPONSE_TIME, podIP, defaultRespTimeCapacity),
+				createCommodity(proto.CommodityDTO_TRANSACTION, podIP),
+				createCommodity(proto.CommodityDTO_RESPONSE_TIME, podIP),
 			},
 		},
 		{
@@ -39,8 +39,8 @@ func Test_getCommoditiesSold(t *testing.T) {
 				index: 1,
 			},
 			want: []*proto.CommodityDTO{
-				createCommodity(proto.CommodityDTO_TRANSACTION, podIP+"-1", defaultTransactionCapacity),
-				createCommodity(proto.CommodityDTO_RESPONSE_TIME, podIP+"-1", defaultRespTimeCapacity),
+				createCommodity(proto.CommodityDTO_TRANSACTION, podIP+"-1"),
+				createCommodity(proto.CommodityDTO_RESPONSE_TIME, podIP+"-1"),
 			},
 		},
 	}
@@ -58,10 +58,9 @@ func Test_getCommoditiesSold(t *testing.T) {
 	}
 }
 
-func createCommodity(commType proto.CommodityDTO_CommodityType, key string, capacity float64) *proto.CommodityDTO {
+func createCommodity(commType proto.CommodityDTO_CommodityType, key string) *proto.CommodityDTO {
 	return &proto.CommodityDTO{
 		CommodityType: &commType,
 		Key:           &key,
-		Capacity:      &capacity,
 	}
 }


### PR DESCRIPTION
Kubeturbo doesn't have information about the capacities of Transaction and ResponseTime commodities so shouldn't set capacities in DTO's.

Instead, the capacities need to be set from users in Turbo UI policy/setting for different applications. To enable it, the capacity needs to be unset from probe side.