### PR TITLE
Propagate action errors

### DIFF
--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -173,8 +173,8 @@ func (h *ActionHandler) execute(actionItem *proto.ActionItemDTO) error {
 	output, err := worker.Execute(input)
 
 	if err != nil {
-		msg := fmt.Errorf("Action %v on %s failed.", actionType, actionItem.GetTargetSE().GetEntityType())
-		glog.Errorf(msg.Error())
+		glog.Errorf("Failed to execute action %v on %s: %+v.",
+			actionType, actionItem.GetTargetSE().GetEntityType(), actionItem)
 		return err
 	}
 

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -12,11 +12,12 @@ import (
 	sdkprobe "github.com/turbonomic/turbo-go-sdk/pkg/probe"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 
+	"strings"
+
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
 	"github.com/turbonomic/kubeturbo/pkg/turbostore"
 	api "k8s.io/api/core/v1"
-	"strings"
 )
 
 const (
@@ -252,7 +253,7 @@ func (h *ActionHandler) failedResult(msg string) *proto.ActionResult {
 
 	state := proto.ActionResponseState_FAILED
 	progress := int32(0)
-	msg = "Failed"
+	msg = "Action failed, " + msg
 
 	res := &proto.ActionResponse{
 		ActionResponseState: &state,

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -2,14 +2,13 @@ package executor
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
-	"time"
 
 	"github.com/turbonomic/kubeturbo/pkg/action/util"
 	api "k8s.io/api/core/v1"
 
 	podutil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
-	goutil "github.com/turbonomic/kubeturbo/pkg/util"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
@@ -25,7 +24,7 @@ func NewReScheduler(ae TurboK8sActionExecutor, sccAllowedSet map[string]struct{}
 	}
 }
 
-//Note: the error info will be shown in UI
+// Execute executes the move action. The error message will be shown in UI.
 func (r *ReScheduler) Execute(input *TurboActionExecutorInput) (*TurboActionExecutorOutput, error) {
 	actionItem := input.ActionItem
 	pod := input.Pod
@@ -33,26 +32,16 @@ func (r *ReScheduler) Execute(input *TurboActionExecutorInput) (*TurboActionExec
 	//1. get target Pod and new hosting Node
 	node, err := r.getPodNode(actionItem)
 	if err != nil {
-		glog.Errorf("Failed to execute pod move: failed to get target pod or new hosting node: %v", err)
-		return &TurboActionExecutorOutput{}, fmt.Errorf("Failed")
-	}
-
-	//2. move pod to the node
-	npod, err := r.reSchedule(pod, node)
-	if err != nil {
-		glog.Errorf("Failed to execute pod move: %v\n %++v", err, actionItem)
+		glog.Errorf("Failed to execute pod move: %v.", err)
 		return &TurboActionExecutorOutput{}, err
 	}
 
-	//3. check Pod
-	fullName := util.BuildIdentifier(npod.Namespace, npod.Name)
-	nodeName := npod.Spec.NodeName
-	glog.V(2).Infof("Begin to check pod move for pod[%v]", fullName)
-	if err = r.checkPod(npod, nodeName); err != nil {
-		glog.Errorf("Checking pod move failed: pod[%v] failed: %v", fullName, err)
-		return &TurboActionExecutorOutput{}, fmt.Errorf("Check Failed")
+	//2. move pod to the node and check move status
+	npod, err := r.reSchedule(pod, node)
+	if err != nil {
+		glog.Errorf("Failed to execute pod move: %v.", err)
+		return &TurboActionExecutorOutput{}, err
 	}
-	glog.V(2).Infof("Checking pod move succeeded: pod[%v] is on node[%v].", fullName, nodeName)
 
 	return &TurboActionExecutorOutput{
 		Succeeded: true,
@@ -61,103 +50,71 @@ func (r *ReScheduler) Execute(input *TurboActionExecutorInput) (*TurboActionExec
 	}, nil
 }
 
-func (r *ReScheduler) checkActionItem(action *proto.ActionItemDTO) error {
-	// check new hosting node
-	destSE := action.GetNewSE()
-	if destSE == nil {
-		err := fmt.Errorf("new hosting node is empty: %++v", action)
-		glog.Error(err.Error())
-		return err
-	}
-
-	nodeType := destSE.GetEntityType()
-	if nodeType != proto.EntityDTO_VIRTUAL_MACHINE && nodeType != proto.EntityDTO_PHYSICAL_MACHINE {
-		err := fmt.Errorf("hosting node type[%v] is not a virtual machine, nor a phsical machine.", nodeType.String())
-		glog.Error(err.Error())
-		return err
-	}
-
-	return nil
-}
-
 // get k8s.node of the new hosting node
 func (r *ReScheduler) getNode(action *proto.ActionItemDTO) (*api.Node, error) {
+	//1. check host entity
 	hostSE := action.GetNewSE()
 	if hostSE == nil {
-		err := fmt.Errorf("new host pod entity is empty")
-		glog.Error(err.Error())
+		err := fmt.Errorf("New host entity is empty")
+		glog.Errorf("%v.", err)
 		return nil, err
 	}
 
-	var err error = nil
-	var node *api.Node = nil
-
-	//0. check entity type
+	//2. check entity type
 	etype := hostSE.GetEntityType()
 	if etype != proto.EntityDTO_VIRTUAL_MACHINE && etype != proto.EntityDTO_PHYSICAL_MACHINE {
-		err = fmt.Errorf("The target entity(%v) for move destiantion is neither a VM nor a PM.", etype)
-		glog.Error(err.Error())
+		err := fmt.Errorf("The move destination [%v] is neither a VM nor a PM", etype)
+		glog.Errorf("%v.", err)
 		return nil, err
 	}
 
-	//1. get node from properties
+	var err error
+	var node *api.Node
+
+	//3. get node from properties
 	node, err = util.GetNodeFromProperties(r.kubeClient, hostSE.GetEntityProperties())
 	if err == nil {
 		glog.V(2).Infof("Get node(%v) from properties.", node.Name)
 		return node, nil
 	}
 
-	//2. get node by displayName
+	//4. get node by displayName
 	node, err = util.GetNodebyName(r.kubeClient, hostSE.GetDisplayName())
 	if err == nil {
 		glog.V(2).Infof("Get node(%v) by displayName.", node.Name)
 		return node, nil
 	}
 
-	//3. get node by UUID
+	//5. get node by UUID
 	node, err = util.GetNodebyUUID(r.kubeClient, hostSE.GetId())
 	if err == nil {
 		glog.V(2).Infof("Get node(%v) by UUID(%v).", node.Name, hostSE.GetId())
 		return node, nil
 	}
 
-	//4. get node by IP
+	//6. get node by IP
 	vmIPs := getVMIps(hostSE)
 	if len(vmIPs) > 0 {
 		node, err = util.GetNodebyIP(r.kubeClient, vmIPs)
 		if err == nil {
 			glog.V(2).Infof("Get node(%v) by IP.", hostSE.GetDisplayName())
 			return node, nil
-		} else {
-			glog.Errorf("Failed to get node by IP(%+v): %v", vmIPs, err)
 		}
+		err = fmt.Errorf("Failed to get node %s by IP %+v: %v",
+			hostSE.GetDisplayName(), vmIPs, err)
 	} else {
-		glog.Warningf("VMIPs are empty: %++v", hostSE)
+		err = fmt.Errorf("Failed to get node %s: IPs are empty",
+			hostSE.GetDisplayName())
 	}
-
-	glog.Errorf("Failed to get node(%v) %++v", hostSE.GetDisplayName(), hostSE)
-	err = fmt.Errorf("Failed to get node(%v)", hostSE.GetDisplayName())
+	glog.Errorf("%v.", err)
 	return nil, err
 }
 
 // get kubernetes pod, and the new hosting kubernetes node
 func (r *ReScheduler) getPodNode(action *proto.ActionItemDTO) (*api.Node, error) {
-	//1. check
 	glog.V(4).Infof("MoveActionItem: %++v", action)
-	if err := r.checkActionItem(action); err != nil {
-		err = fmt.Errorf("Move Action aborted: check action item failed: %v", err)
-		glog.Errorf(err.Error())
-		return nil, err
-	}
-	//2. find the new hosting node for the pod.
-	node, err := r.getNode(action)
-	if err != nil {
-		err = fmt.Errorf("Move action aborted: failed to get new hosting node: %v", err)
-		glog.Error(err.Error())
-		return nil, err
-	}
-
-	return node, nil
+	// Check and find the new hosting node for the pod.
+	return r.getNode(action)
 }
 
 // Check whether the action should be executed.
@@ -168,7 +125,7 @@ func (r *ReScheduler) preActionCheck(pod *api.Pod, node *api.Node) error {
 	// Check if the pod privilege is supported
 	if !util.SupportPrivilegePod(pod, r.sccAllowedSet) {
 		err := fmt.Errorf("Pod %s has unsupported SCC", fullName)
-		glog.Error(err)
+		glog.Errorf("%v.", err)
 		return err
 	}
 
@@ -197,98 +154,53 @@ func (r *ReScheduler) preActionCheck(pod *api.Pod, node *api.Node) error {
 func (r *ReScheduler) reSchedule(pod *api.Pod, node *api.Node) (*api.Pod, error) {
 	//1. do some check
 	if err := r.preActionCheck(pod, node); err != nil {
-		glog.Errorf("Move action aborted: %v", err)
-		return nil, fmt.Errorf("Failed")
+		glog.Errorf("Move action aborted: %v.", err)
+		return nil, err
 	}
 
 	nodeName := node.Name
 	fullName := util.BuildIdentifier(pod.Namespace, pod.Name)
 	// if the pod is already on the target node, then simply return success.
 	if pod.Spec.NodeName == nodeName {
-		glog.V(2).Infof("Move action aborted: pod[%v] is already on host[%v].", fullName, nodeName)
-		return nil, fmt.Errorf("Aborted")
+		err := fmt.Errorf("Pod [%v] is already on host [%v]", fullName, nodeName)
+		glog.V(2).Infof("Move action aborted: %v.", err)
+		return nil, err
 	}
 
-	//2. move
 	parentKind, parentName, err := podutil.GetPodParentInfo(pod)
 	if err != nil {
-		glog.Errorf("Move action aborted: cannot get pod-%v parent info: %v", fullName, err)
-		return nil, fmt.Errorf("Failed")
+		err = fmt.Errorf("Cannot get parent info of pod [%v]: %v", fullName, err)
+		glog.Errorf("Move action aborted: %v.", err)
+		return nil, err
 	}
 
 	if !util.SupportedParent(parentKind) {
-		glog.Errorf("Move action aborted: parent kind(%v) is not supported.", parentKind)
-		return nil, fmt.Errorf("Unsupported")
+		err = fmt.Errorf("The object kind [%v] of [%s] is not supported", parentKind, parentName)
+		glog.Errorf("Move action aborted: %v.", err)
+		return nil, err
 	}
 
-	var npod *api.Pod
-	if parentKind == "" {
-		npod, err = r.moveBarePod(pod, nodeName)
-	} else {
-		npod, err = r.moveControllerPod(pod, parentKind, parentName, nodeName)
-	}
-
-	if err != nil {
-		glog.Errorf("Move Pod(%v) action failed: %v", fullName, err)
-		return nil, fmt.Errorf("Failed")
-	}
-	return npod, nil
-}
-
-// move the pods controlled by ReplicationController/ReplicaSet
-func (r *ReScheduler) moveControllerPod(pod *api.Pod, parentKind, parentName, nodeName string) (*api.Pod, error) {
-	npod, err := movePod(r.kubeClient, pod, nodeName, defaultRetryMore)
-	if err != nil {
-		glog.Errorf("Move contorller pod(%s) failed: %v", pod.Name, err)
-	}
-
-	return npod, err
-}
-
-// as there may be concurrent actions on the same bare pod:
-//   for example, one action is to move Pod, and the other is to Resize Pod.container;
-// thus, concurrent control should also be applied to bare pods.
-func (r *ReScheduler) moveBarePod(pod *api.Pod, nodeName string) (*api.Pod, error) {
-	npod, err := movePod(r.kubeClient, pod, nodeName, defaultRetryMore)
-	if err != nil {
-		glog.Errorf("Move contorller pod(%s) failed: %v", pod.Name, err)
-	}
-
-	return npod, err
-}
-
-func (r *ReScheduler) checkPod(pod *api.Pod, nodeName string) error {
-	retryNum := defaultRetryLess
-	interval := defaultPodCheckSleep
-	timeout := time.Duration(retryNum+1) * interval
-	err := goutil.RetrySimple(retryNum, timeout, interval, func() (bool, error) {
-		return doCheckPodNode(r.kubeClient, pod.Namespace, pod.Name, nodeName)
-	})
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	//2. move
+	return movePod(r.kubeClient, pod, nodeName, defaultRetryMore)
 }
 
 func getVMIps(entity *proto.EntityDTO) []string {
 	result := []string{}
 
 	if entity.GetEntityType() != proto.EntityDTO_VIRTUAL_MACHINE {
-		glog.Errorf("hosting node is a not virtual machine: %++v", entity.GetEntityType())
+		glog.Errorf("Hosting node is a not virtual machine: %++v", entity.GetEntityType())
 		return result
 	}
 
 	vmData := entity.GetVirtualMachineData()
 	if vmData == nil {
-		err := fmt.Errorf("Missing virtualMachineData[%v] in targetSE.", entity.GetDisplayName())
+		err := fmt.Errorf("Missing virtualMachineData[%v] in targetSE", entity.GetDisplayName())
 		glog.Error(err.Error())
 		return result
 	}
 
 	if len(vmData.GetIpAddress()) < 1 {
-		glog.Warningf("machine IPs are empty: %++v", vmData)
+		glog.Warningf("Machine IPs are empty: %++v", vmData)
 	}
 
 	return vmData.GetIpAddress()

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -68,11 +68,8 @@ func (r *ReScheduler) getNode(action *proto.ActionItemDTO) (*api.Node, error) {
 		return nil, err
 	}
 
-	var err error
-	var node *api.Node
-
 	//3. get node from properties
-	node, err = util.GetNodeFromProperties(r.kubeClient, hostSE.GetEntityProperties())
+	node, err := util.GetNodeFromProperties(r.kubeClient, hostSE.GetEntityProperties())
 	if err == nil {
 		glog.V(2).Infof("Get node(%v) from properties.", node.Name)
 		return node, nil

--- a/pkg/action/util/util.go
+++ b/pkg/action/util/util.go
@@ -12,8 +12,9 @@ import (
 
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 
-	"github.com/golang/glog"
 	"strings"
+
+	"github.com/golang/glog"
 )
 
 const (

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -1,12 +1,14 @@
 package util
 
 import (
-	"github.com/golang/glog"
-	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
+	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+
 	"fmt"
+
 	api "k8s.io/api/core/v1"
 )
 
@@ -49,7 +51,7 @@ func ParseContainerId(containerId string) (string, int, error) {
 	}
 
 	if i < 1 {
-		err := fmt.Errorf("failed to parse containerId: %s.", containerId)
+		err := fmt.Errorf("failed to parse containerId: %s", containerId)
 		glog.Error(err)
 		return "", -1, err
 	}

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -324,6 +324,8 @@ func WaitForPodReady(client *client.Clientset, namespace, podName, nodeName stri
 	return err
 }
 
+// checkPodNode checks the readiness of a given pod
+// The boolean return value indicates if this function needs to be retried
 func checkPodNode(kubeClient *client.Clientset, namespace, podName, nodeName string) (bool, error) {
 	pod, err := kubeClient.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -399,17 +399,17 @@ func getPodEvents(kubeClient *client.Clientset, namespace, name string) (podEven
 	if err != nil {
 		return
 	}
-	// Get all events
-	events, err := kubeClient.CoreV1().Events(namespace).List(metav1.ListOptions{})
+	// Get events that belong to the given pod
+	events, err := kubeClient.CoreV1().Events(namespace).List(metav1.ListOptions{
+		FieldSelector: "involvedObject.uid=" + string(pod.UID),
+	})
 	if err != nil {
 		return
 	}
-	// Filter out the events that belong to the given pod and remove duplicates
+	// Remove duplicates and create podEvents
 	visited := make(map[string]bool, 0)
 	for _, item := range events.Items {
-		if namespace != item.ObjectMeta.Namespace ||
-			pod.UID != item.InvolvedObject.UID ||
-			visited[item.Reason] {
+		if visited[item.Reason] {
 			continue
 		}
 		visited[item.Reason] = true

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -3,17 +3,18 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
-
-	api "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"strings"
+	"time"
 
 	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
+	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/typed/core/v1"
-	"strings"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
+
+	goutil "github.com/turbonomic/kubeturbo/pkg/util"
 )
 
 const (
@@ -29,7 +30,13 @@ const (
 	TurboControllableAnnotation string = "kubeturbo.io/controllable"
 )
 
-// check whether a Kubernetes object is controllable or not by its annotation.
+type podEvent struct {
+	eType   string
+	reason  string
+	message string
+}
+
+// IsControllableFromAnnotation checks whether a Kubernetes object is controllable or not by its annotation.
 // The annotation can be either "kubeturbo.io/controllable" or "kubeturbo.io/monitored".
 // the object can be: Pod, Service, Namespace, or others.  If no annotation
 // exists, the default value is true.
@@ -89,6 +96,7 @@ func isPodCreatedBy(pod *api.Pod, kind string) bool {
 	return parentKind == kind
 }
 
+// GroupPodsByNode groups all pods based on their hosting node
 func GroupPodsByNode(pods []*api.Pod) map[string][]*api.Pod {
 	podsNodeMap := make(map[string][]*api.Pod)
 	if pods == nil {
@@ -136,7 +144,7 @@ func PodIsReady(pod *api.Pod) bool {
 // GetPodInPhase finds the pod with the specific name in the specific phase (e.g., Running).
 // If pod not found, nil pod pointer will be returned without error.
 func GetPodInPhase(podClient v1.PodInterface, name string, phase api.PodPhase) (*api.Pod, error) {
-	pod, err := podClient.Get(name, meta_v1.GetOptions{})
+	pod, err := podClient.Get(name, metav1.GetOptions{})
 	if err != nil {
 		glog.Errorf("Error while getting pod %s in phase %v: %v", name, phase, err.Error())
 		return nil, err
@@ -158,7 +166,7 @@ func GetPodInPhase(podClient v1.PodInterface, name string, phase api.PodPhase) (
 // GetPodInPhaseByUid finds the pod with the specific uid in the specific phase (e.g., Running).
 // If pod not found, nil pod pointer will be returned without error.
 func GetPodInPhaseByUid(podClient v1.PodInterface, uid string, phase api.PodPhase) (*api.Pod, error) {
-	podList, err := podClient.List(meta_v1.ListOptions{
+	podList, err := podClient.List(metav1.ListOptions{
 		FieldSelector: "status.phase=" + string(phase) + ",metadata.uid=" + uid,
 	})
 
@@ -176,7 +184,7 @@ func GetPodInPhaseByUid(podClient v1.PodInterface, uid string, phase api.PodPhas
 	return &podList.Items[0], nil
 }
 
-// Parses the pod entity display name to retrieve the namespace and name of the pod.
+// ParsePodDisplayName parses the pod entity display name to retrieve the namespace and name of the pod.
 func ParsePodDisplayName(displayName string) (string, string, error) {
 	sep := "/"
 	items := strings.Split(displayName, sep)
@@ -205,10 +213,6 @@ func ParsePodDisplayName(displayName string) (string, string, error) {
 	return namespace, name, nil
 }
 
-func GetPod(kubeClient *client.Clientset, namespace, name string) (*api.Pod, error) {
-	return kubeClient.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
-}
-
 func parseOwnerReferences(owners []metav1.OwnerReference) (string, string) {
 	for i := range owners {
 		owner := &owners[i]
@@ -226,6 +230,7 @@ func parseOwnerReferences(owners []metav1.OwnerReference) (string, string) {
 	return "", ""
 }
 
+// GetPodParentInfo gets parent information of a pod
 func GetPodParentInfo(pod *api.Pod) (string, string, error) {
 	//1. check ownerReferences:
 
@@ -246,7 +251,7 @@ func GetPodParentInfo(pod *api.Pod) (string, string, error) {
 			var ref api.SerializedReference
 
 			if err := json.Unmarshal([]byte(value), &ref); err != nil {
-				err = fmt.Errorf("failed to decode parent annoation:%v", err)
+				err = fmt.Errorf("failed to decode parent annoation: %v", err)
 				glog.Errorf("%v\n%v", err, value)
 				return "", "", err
 			}
@@ -260,7 +265,7 @@ func GetPodParentInfo(pod *api.Pod) (string, string, error) {
 	return "", "", nil
 }
 
-// get grandParent(parent's parent) information of a pod: kind, name
+// GetPodGrandInfo gets grandParent (parent's parent) information of a pod: kind, name
 // If parent does not have parent, then return parent info.
 // Note: if parent kind is "ReplicaSet", then its parent's parent can be a "Deployment"
 func GetPodGrandInfo(kclient *client.Clientset, pod *api.Pod) (string, string, error) {
@@ -291,4 +296,128 @@ func GetPodGrandInfo(kclient *client.Clientset, pod *api.Pod) (string, string, e
 	}
 
 	return kind, name, nil
+}
+
+// WaitForPodReady checks the readiness of a given pod with a retry limit and a timeout, whichever
+// comes first. If a nodeName is provided, also checks that the hosting node matches that in the
+// pod specification
+//
+// TODO:
+// Use k8s watch API to eliminate the need for polling and improve efficiency
+func WaitForPodReady(client *client.Clientset, namespace, podName, nodeName string,
+	retry int, interval time.Duration) error {
+	// check pod readiness with retries
+	timeout := time.Duration(retry+1) * interval
+	err := goutil.RetrySimple(retry, timeout, interval, func() (bool, error) {
+		return checkPodNode(client, namespace, podName, nodeName)
+	})
+	// log a list of unique events that belong to the pod
+	// warning events are logged in Error level, other events are logged in Info level
+	podEvents := getPodEvents(client, namespace, podName)
+	for _, pe := range podEvents {
+		if pe.eType == api.EventTypeWarning {
+			glog.Errorf("Pod %s: %s", podName, pe.message)
+		} else {
+			glog.V(2).Infof("Pod %s: %s", podName, pe.message)
+		}
+	}
+	return err
+}
+
+func checkPodNode(kubeClient *client.Clientset, namespace, podName, nodeName string) (bool, error) {
+	pod, err := kubeClient.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+	if err != nil {
+		return true, err
+	}
+	if pod.Status.Phase == api.PodRunning && PodIsReady(pod) {
+		if len(nodeName) > 0 {
+			if !strings.EqualFold(pod.Spec.NodeName, nodeName) {
+				return false, fmt.Errorf("pod %s is running on an unexpected node %v", podName, pod.Spec.NodeName)
+			}
+		}
+		return false, nil
+	}
+	warnings := getPodWarnings(pod, podName)
+	return true, fmt.Errorf("%s", strings.Join(warnings, ", "))
+}
+
+// getPodWarnings gets a list of short warning messages that belong to the given pod
+// These messages will be concatenated and sent to the UI
+// The warning messages are logged in the following order:
+//   - Pod states and reasons
+//   - Pod conditions and reasons (false conditions only)
+//   - Container states and reasons (abnormal states only)
+// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status
+func getPodWarnings(pod *api.Pod, podName string) (warnings []string) {
+	warnings = []string{}
+	// pod statuses
+	podState := ""
+	if pod.DeletionTimestamp != nil {
+		podState = fmt.Sprintf("pod %s is being deleted", podName)
+	} else {
+		podState = fmt.Sprintf("pod %s is in %s state", podName, pod.Status.Phase)
+	}
+	if pod.Status.Reason != "" {
+		podState = podState + " due to " + pod.Status.Reason
+	}
+	warnings = append(warnings, podState)
+	// pod conditions
+	visited := make(map[string]bool, 0)
+	for _, condition := range pod.Status.Conditions {
+		// skip true conditions
+		if condition.Status == api.ConditionTrue ||
+			visited[condition.Reason] {
+			continue
+		}
+		visited[condition.Reason] = true
+		warnings = append(warnings, condition.Reason)
+	}
+	// container statuses
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		name := containerStatus.Name
+		state := containerStatus.State
+		if state.Waiting != nil {
+			warnings = append(warnings,
+				fmt.Sprintf("container %s is waiting due to %s",
+					name, state.Waiting.Reason))
+		}
+		if state.Terminated != nil {
+			warnings = append(warnings,
+				fmt.Sprintf("container %s has terminated due to %s",
+					name, state.Terminated.Reason))
+		}
+	}
+	return
+}
+
+// getPodEvents gets a list of unique events that belong to the given pod
+// These events can be very long, and will only be written to the log file
+func getPodEvents(kubeClient *client.Clientset, namespace, name string) (podEvents []podEvent) {
+	podEvents = []podEvent{}
+	// Get the pod
+	pod, err := kubeClient.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+	// Get all events
+	events, err := kubeClient.CoreV1().Events(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+	// Filter out the events that belong to the given pod and remove duplicates
+	visited := make(map[string]bool, 0)
+	for _, item := range events.Items {
+		if namespace != item.ObjectMeta.Namespace ||
+			pod.UID != item.InvolvedObject.UID ||
+			visited[item.Reason] {
+			continue
+		}
+		visited[item.Reason] = true
+		podEvents = append(podEvents, podEvent{
+			eType:   item.Type,
+			reason:  item.Reason,
+			message: item.Message,
+		})
+	}
+	return
 }

--- a/pkg/util/go_util.go
+++ b/pkg/util/go_util.go
@@ -2,13 +2,14 @@ package util
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/golang/glog"
 )
 
-//compare two version strings, for example:
+// CompareVersion compares two version strings, for example:
 // v1: "1.4.9",  v2: "1.5", then return -1
 // v1: "1.5.0", v2: "1.5", then return 0
 func CompareVersion(version1, version2 string) int {
@@ -45,7 +46,7 @@ func CompareVersion(version1, version2 string) int {
 	return 0
 }
 
-//retry to execute a function with a timeout
+// RetryDuring executes a function with retries and a timeout
 func RetryDuring(attempts int, timeout time.Duration, sleep time.Duration, myfunc func() error) error {
 	t0 := time.Now()
 
@@ -79,7 +80,7 @@ func RetryDuring(attempts int, timeout time.Duration, sleep time.Duration, myfun
 	return err
 }
 
-//retry to execute a function with a timeout
+//RetrySimple executes a function with retries and a timeout
 func RetrySimple(attempts int, timeout, sleep time.Duration, myfunc func() (bool, error)) error {
 	t0 := time.Now()
 
@@ -97,8 +98,7 @@ func RetrySimple(attempts int, timeout, sleep time.Duration, myfunc func() (bool
 
 		if timeout > 0 {
 			if delta := time.Now().Sub(t0); delta > timeout {
-				err = fmt.Errorf("failed after %d attepmts (during %v) last error: %v", i+1, delta, err)
-				glog.Error(err)
+				glog.Errorf("Failed after %d attepmts (during %v) last error: %v", i+1, delta, err)
 				return err
 			}
 		}
@@ -108,7 +108,6 @@ func RetrySimple(attempts int, timeout, sleep time.Duration, myfunc func() (bool
 		}
 	}
 
-	err = fmt.Errorf("failed after %d attepmts, last error: %v", attempts, err)
-	glog.Error(err)
+	glog.Errorf("Failed after %d attepmts, last error: %v", attempts, err)
 	return err
 }


### PR DESCRIPTION
### Problem
Kubeturbo action errors are not propagated to the UI. What's worse, the detailed error messages are not logged in the kubeturbo log either. Today when kubeturbo move/resize a pod, it clones a pod first on the desired node, or to the desired size on the same node. If the clone fails for whatever reasons, kubeturbo deletes the cloned pod, and all errors related to the deleted pod cannot be retrieved any more.

### Solution
Detailed error messages can be obtained from k8s events API, however, some of the error messages can be long, and not suitable to be displayed on the GUI. These messages should only be logged in kubeturbo log.
For example:
```
I0225 16:17:46.113839       1 pod_util.go:305] Pod task-pv-pod-1b1l7hjatjl31: pulling image "nginx"
I0225 16:17:46.113853       1 pod_util.go:305] Pod task-pv-pod-1b1l7hjatjl31: Successfully pulled image "nginx"
I0225 16:17:46.113857       1 pod_util.go:305] Pod task-pv-pod-1b1l7hjatjl31: Created container
E0225 16:17:46.113861       1 pod_util.go:303] Pod task-pv-pod-1b1l7hjatjl31: Error: failed to start container "task-pv-container": Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "process_linux.go:402: container init caused \"rootfs_linux.go:58: mounting \\\"/mnt/data\\\" to rootfs \\\"/var/lib/docker/overlay2/3d3bb4345288eda3e55560ec47479df91cb85be9b17ed4b5176d005d4258c6fd/merged\\\" at \\\"/var/lib/docker/overlay2/3d3bb4345288eda3e55560ec47479df91cb85be9b17ed4b5176d005d4258c6fd/merged/usr/share/nginx/html\\\" caused \\\"not a directory\\\"\"": unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
E0225 16:17:46.113868       1 pod_util.go:303] Pod task-pv-pod-1b1l7hjatjl31: Back-off restarting failed container

```

For error messages displayed on GUI, propose the following format:
```
// getPodWarnings gets a list of short warning messages that belong to the given pod
// These messages will be concatenated and sent to the UI
// The warning messages are logged in the following order:
//   - Pod states and reasons
//   - Pod conditions and reasons (false conditions only)
//   - Container states and reasons (abnormal states only)
// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status
```
The **states** and **reasons** message from k8s API already have high level descriptions of the problems, and is short in general, so propose to use them for displaying. 

For example:
<img width="1216" alt="screen shot 2019-02-24 at 8 17 54 pm" src="https://user-images.githubusercontent.com/10012486/53352899-ad765d00-38f1-11e9-87e4-a18ca8621327.png">
![screen shot 2019-02-25 at 11 17 08 am](https://user-images.githubusercontent.com/10012486/53352907-b0714d80-38f1-11e9-95ad-3a1cb76c0aec.png)

### Changes
* Consolidate ``waitForReady`` and ``checkPod`` into a single function ``WaitForPodReady`` and move it into ``pod_util.go``
* Remove unnecessary pod status checking in move and resize (step 3 in ``Execute`` function)
* Remove ``moveControllerPod`` and ``moveBarePod``, just use ``movePod`` as the logic is the same
* Remove ``resizeControllerContainer`` and ``resizeBarePodContainer``, just use ``resizeContainer`` as the logic is the same
* Enhance error message format according to [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments#error-strings)
* Remove duplicated log messages
* Add the logic to get pod warning messages (for UI display) and pod events (for logging)
* Modify the code to propagate the messages