### PR TITLE
Fixed the uuid for container entity used for group membership

### DIFF
--- a/pkg/discovery/worker/group_metrics_collector.go
+++ b/pkg/discovery/worker/group_metrics_collector.go
@@ -54,17 +54,15 @@ func (collector *GroupMetricsCollector) CollectGroupMetrics() ([]*repository.Ent
 		podByParentMembers[ownerTypeString] = append(podByParentMembers[ownerTypeString], podId)
 
 		// Container group membership - same as pod group
-		podMId := util.PodMetricIdAPI(pod)
 		for i := range pod.Spec.Containers { //
-			container := &(pod.Spec.Containers[i])
-			containerMId := util.ContainerMetricId(podMId, container.Name)
+			containerId := util.ContainerIdFunc(podId, i)
 
 			cOwnerTypeMap, cOwnerTypeExists := containerMembers[ownerTypeString]
 			if !cOwnerTypeExists {
 				containerMembers[ownerTypeString] = make(map[string][]string)
 				cOwnerTypeMap = containerMembers[ownerTypeString]
 			}
-			cOwnerTypeMap[ownerString] = append(cOwnerTypeMap[ownerString], containerMId)
+			cOwnerTypeMap[ownerString] = append(cOwnerTypeMap[ownerString], containerId)
 		}
 	}
 


### PR DESCRIPTION
Groups with containers entities do not show any members in the UI. That is because the container entity UUIDs used in the group DTOs was incorrect.
The util method used to generate the container uuid used for group membership was changed to the one used for generating uuid for container DTOs.