### PR TITLE
OM-43900 Prevent creating access commodity with duplicate key

### DIFF
--- a/pkg/discovery/worker/compliance/taint_toleration_processor.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor.go
@@ -177,8 +177,12 @@ func createTaintAccessComms(node *api.Node, taintCollection map[api.Taint]string
 	for _, taint := range taints {
 		nodeTaints[taint] = struct{}{}
 	}
-
+	visited := make(map[string]bool, 0)
 	for taint, key := range taintCollection {
+		if visited[key] {
+			glog.V(4).Infof("Commodity with key %s for taint %v has already been created", key, taint)
+			continue
+		}
 		// If the node doesn't contain the taint, create access commodity
 		if _, ok := nodeTaints[taint]; !ok {
 			accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
@@ -189,7 +193,7 @@ func createTaintAccessComms(node *api.Node, taintCollection map[api.Taint]string
 			if err != nil {
 				return nil, err
 			}
-
+			visited[key] = true
 			glog.V(4).Infof("Created access commodity with key %s for node %s", key, node.GetName())
 
 			accessComms = append(accessComms, accessComm)
@@ -205,7 +209,12 @@ func createTaintAccessComms(node *api.Node, taintCollection map[api.Taint]string
 func createTolerationAccessComms(pod *api.Pod, taintCollection map[api.Taint]string) ([]*proto.CommodityDTO, error) {
 	accessComms := []*proto.CommodityDTO{}
 
+	visited := make(map[string]bool, 0)
 	for taint, key := range taintCollection {
+		if visited[key] {
+			glog.V(4).Infof("Commodity with key %s for taint %v has already been created", key, taint)
+			continue
+		}
 		// If the pod doesn't have the proper toleration, create access commodity to buy
 		if !TolerationsTolerateTaint(pod.Spec.Tolerations, &taint) {
 			accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
@@ -216,7 +225,7 @@ func createTolerationAccessComms(pod *api.Pod, taintCollection map[api.Taint]str
 			if err != nil {
 				return nil, err
 			}
-
+			visited[key] = true
 			glog.V(4).Infof("Created access commodity with key %s for pod %s", key, pod.GetName())
 
 			accessComms = append(accessComms, accessComm)


### PR DESCRIPTION
# Recreate
This problem can be reproduced by running the following command on two different nodes:

```kubectl cordon <node>```

Then k8s will automatically taint the node with NoSchedule, *AND* a timestamp!

Kubeturbo log:
```
I0315 16:28:13.887063       1 taint_toleration_processor.go:160] Found taint (comm key = node.kubernetes.io/unschedulable=:NoSchedule): {Key:node.kubernetes.io/unschedulable Value: Effect:NoSchedule TimeAdded:2019-03-15 16:25:11 +0000 UTC})
I0315 16:28:13.887109       1 taint_toleration_processor.go:160] Found taint (comm key = node.kubernetes.io/unschedulable=:NoSchedule): {Key:node.kubernetes.io/unschedulable Value: Effect:NoSchedule TimeAdded:2019-03-15 16:26:11 +0000 UTC})
I0315 16:28:13.887118       1 taint_toleration_processor.go:160] Found taint (comm key = key=value:NoSchedule): {Key:key Value:value Effect:NoSchedule TimeAdded:<nil>})
I0315 16:28:13.887134       1 taint_toleration_processor.go:160] Found taint (comm key = node-role.kubernetes.io/master=:NoSchedule): {Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>})
I0315 16:28:13.887141       1 taint_toleration_processor.go:165] Created taint collection with 4 taints found
```

Turbo server log:
```
2019-03-15 16:28:14,211 ERROR [Discovery Thread Pool #5] [VMTExternalProbeImpl]	: Kubernetes-spc-smalltest : Discovery exception: 
java.lang.IllegalArgumentException: Multiple entries with same key: VMPMAccessCommodity-node.kubernetes.io/unschedulable=:NoSchedule=VMPM_ACCESS/node.kubernetes.io/unschedulable=:NoSchedule and VMPMAccessCommodity-node.kubernetes.io/unschedulable=:NoSchedule=VMPM_ACCESS/node.kubernetes.io/unschedulable=:NoSchedule. To index multiple values under a key, use Multimaps.index.
	at com.google.common.collect.Maps.uniqueIndex(Maps.java:1380) ~[guava-23.0.jar:?]
	at com.google.common.collect.Maps.uniqueIndex(Maps.java:1336) ~[guava-23.0.jar:?]
	at com.vmturbo.platform.VMTRoot.ManagedEntities.Abstraction.FluentAPI.ExternalProbeEntityParser.unsetSold(ExternalProbeEntityParser.java:93) ~[com.vmturbo.platform-6.4.0-SNAPSHOT.jar:?]
	at com.vmturbo.platform.VMTRoot.ManagedEntities.Abstraction.FluentAPI.ExternalProbeEntityParser.parse(ExternalProbeEntityParser.java:73) ~[com.vmturbo.platform-6.4.0-SNAPSHOT.jar:?]
	at com.vmturbo.platform.VMTRoot.ManagedEntities.Abstraction.FluentAPI.EntityParser.parse(EntityParser.java:165) ~[com.vmturbo.platform-6.4.0-SNAPSHOT.jar:?]
	at com.vmturbo.platform.VMTRoot.OperationalEntities.Mediation.Discovery.Generic.impl.VMTDiscoveryProbeImpl.parseEntities(VMTDiscoveryProbeImpl.java:4856) ~[com.vmturbo.platform-6.4.0-SNAPSHOT.jar:?]
```

# Propose fix:
* Check and prevent duplicated keys when creating access commodity
* Log a V4 message when duplicated key is found

# Test
* Perform the same test as described in **Recreate**, kubeturbo will not create access commodities with duplicated keys, and will log error message like:
```
I0315 20:06:52.537819       1 taint_toleration_processor.go:183] Commodity with key node.kubernetes.io/unschedulable=:NoSchedule for taint {node.kubernetes.io/unschedulable  NoSchedule 2019-03-15 16:26:11 +0000 UTC} has already been created
```
* Turbo server does not throw exception any more, and verify the correct compliance actions are generated in Turbo UI