### PR TITLE
OM-43684 Create request commodity in kubeturbo

### DIFF
--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -2,6 +2,7 @@ package dtofactory
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	api "k8s.io/api/core/v1"
 
@@ -137,7 +138,7 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 	var result []*proto.CommodityDTO
 
 	//1a. vCPU
-	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU, metrics.CPUProvisioned)
+	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU)
 
 	cpuAttrSetter := NewCommodityAttrSetter()
 	cpuAttrSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(isCpuLimitSet) }, metrics.CPU)
@@ -183,7 +184,7 @@ func (builder *containerDTOBuilder) getCommoditiesBought(podId, containerName, c
 	var result []*proto.CommodityDTO
 
 	//1. vCPU & vMem
-	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU, metrics.CPUProvisioned)
+	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU)
 
 	attributeSetter := NewCommodityAttrSetter()
 	attributeSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(true) }, metrics.CPU, metrics.Memory)

--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 
 	"fmt"
+
 	"github.com/golang/glog"
 )
 
@@ -15,6 +16,8 @@ var (
 	rTypeMapping = map[metrics.ResourceType]proto.CommodityDTO_CommodityType{
 		metrics.CPU:               proto.CommodityDTO_VCPU,
 		metrics.Memory:            proto.CommodityDTO_VMEM,
+		metrics.CPURequest:        proto.CommodityDTO_VCPU_REQUEST,
+		metrics.MemoryRequest:     proto.CommodityDTO_VMEM_REQUEST,
 		metrics.CPUProvisioned:    proto.CommodityDTO_CPU_PROVISIONED,
 		metrics.MemoryProvisioned: proto.CommodityDTO_MEM_PROVISIONED,
 		metrics.Transaction:       proto.CommodityDTO_TRANSACTION,

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -27,8 +27,9 @@ var (
 	nodeResourceCommoditiesSold = []metrics.ResourceType{
 		metrics.CPU,
 		metrics.Memory,
-		//metrics.CPUProvisioned,
-		//metrics.MemoryProvisioned,
+		metrics.CPURequest,
+		metrics.MemoryRequest,
+		// TODO, add back provisioned commodity later
 	}
 
 	allocationResourceCommoditiesSold = []metrics.ResourceType{
@@ -133,8 +134,8 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) ([]*prot
 	return result, nil
 }
 
-// Build the sold commodityDTO by each node. They are include:
-// VCPU, VMem, CPUProvisioned, MemProvisioned;
+// Build the sold commodityDTO by each node. They include:
+// VCPU, VMem, CPURequest, MemRequest;
 // VMPMAccessCommodity, ApplicationCommodity, ClusterCommodity.
 func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node) ([]*proto.CommodityDTO, error) {
 	var commoditiesSold []*proto.CommodityDTO
@@ -148,12 +149,12 @@ func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node) ([]*
 	}
 	cpuFrequency := cpuFrequencyMetric.GetValue().(float64)
 	glog.V(4).Infof("Frequency is %f", cpuFrequency)
-	// cpu and cpu provisioned needs to be converted from number of cores to frequency.
+	// cpu and cpu request needs to be converted from number of cores to frequency.
 	converter := NewConverter().Set(
 		func(input float64) float64 {
 			return input * cpuFrequency
 		},
-		metrics.CPU, metrics.CPUProvisioned)
+		metrics.CPU, metrics.CPURequest)
 
 	// Resource Commodities
 	resourceCommoditiesSold, err := builder.getResourceCommoditiesSold(metrics.NodeType, key, nodeResourceCommoditiesSold, converter, nil)

--- a/pkg/discovery/dtofactory/node_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder_test.go
@@ -2,8 +2,9 @@ package dtofactory
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"testing"
+
+	"github.com/golang/glog"
 
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -29,9 +29,9 @@ var (
 	podResourceCommodityBoughtFromNode = []metrics.ResourceType{
 		metrics.CPU,
 		metrics.Memory,
-		// TODO, add back provisioned commodity later.
-		//metrics.CPUProvisioned,
-		//metrics.MemoryProvisioned,
+		metrics.CPURequest,
+		metrics.MemoryRequest,
+		// TODO, add back provisioned commodity later
 	}
 
 	podResourceCommodityBoughtFromQuota = []metrics.ResourceType{
@@ -169,7 +169,7 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesSold(pod *api.Pod, cpuFrequ
 	var commoditiesSold []*proto.CommodityDTO
 
 	// cpu and cpu provisioned needs to be converted from number of cores to frequency.
-	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU, metrics.CPUProvisioned)
+	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU)
 
 	attributeSetter := NewCommodityAttrSetter()
 	attributeSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(false) }, metrics.CPU, metrics.Memory)
@@ -206,7 +206,7 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBought(pod *api.Pod, cpuFre
 	var commoditiesBought []*proto.CommodityDTO
 
 	// cpu and cpu provisioned needs to be converted from number of cores to frequency.
-	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU, metrics.CPUProvisioned)
+	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU, metrics.CPURequest)
 
 	// Resource Commodities.
 	podMId := util.PodMetricIdAPI(pod)

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 type DiscoveredEntityType string
@@ -67,7 +67,7 @@ var (
 	ComputeResources = []ResourceType{CPU, Memory}
 
 	// List of Allocation resources
-	ComputeAllocationResources = []ResourceType{CPULimit, MemoryLimit, CPURequest, MemoryRequest}
+	ComputeAllocationResources = []ResourceType{CPULimit, MemoryLimit}
 
 	// List of cpu related metrics
 	CPUResources = []ResourceType{CPULimit, CPURequest, CPU}

--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -1,0 +1,157 @@
+package master
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/glog"
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var expectedMetrics = map[string]float64{
+	// Node metrics
+	"Node-mynode-CPU-Capacity":           2,
+	"Node-mynode-Memory-Capacity":        8.388608e+06,
+	"Node-mynode-CPURequest-Capacity":    1.9,
+	"Node-mynode-MemoryRequest-Capacity": 7.340032e+06,
+	"Node-mynode-CPURequest-Used":        0.26,
+	"Node-mynode-MemoryRequest-Used":     262144,
+
+	// Pod metrics
+	"Pod-default/mypod-CPU-Capacity":       2,
+	"Pod-default/mypod-Memory-Capacity":    8.388608e+06,
+	"Pod-default/mypod-CPU-Reservation":    0.26,
+	"Pod-default/mypod-Memory-Reservation": 262144,
+	"Pod-default/mypod-CPURequest-Used":    0.26,
+	"Pod-default/mypod-MemoryRequest-Used": 262144,
+
+	// Container metrics
+	"Container-default/mypod/twitter-cass-tweet-CPU-Capacity":       0.25,
+	"Container-default/mypod/twitter-cass-tweet-Memory-Capacity":    262144,
+	"Container-default/mypod/twitter-cass-tweet-CPU-Reservation":    0.25,
+	"Container-default/mypod/twitter-cass-tweet-Memory-Reservation": 262144,
+	"Container-default/mypod/istio-proxy-CPU-Capacity":              2,
+	"Container-default/mypod/istio-proxy-Memory-Capacity":           8.388608e+06,
+	"Container-default/mypod/istio-proxy-CPU-Reservation":           0.01,
+	"Container-default/mypod/istio-proxy-Memory-Reservation":        0,
+}
+
+func genCPUQuantity(cores float32) resource.Quantity {
+	cpuTime := int(cores * 1000)
+	result, _ := resource.ParseQuantity(fmt.Sprintf("%dm", cpuTime))
+	glog.V(3).Infof("result = %+v", result)
+	return result
+}
+
+func genMemQuantity(numKB int64) resource.Quantity {
+	result, _ := resource.ParseQuantity(fmt.Sprintf("%dKi", numKB))
+	glog.V(3).Infof("result = %+v", result)
+	return result
+}
+
+func buildResource(cores float32, numMB int64) api.ResourceList {
+	resource := make(api.ResourceList)
+	resource[api.ResourceCPU] = genCPUQuantity(cores)
+	resource[api.ResourceMemory] = genMemQuantity(numMB * 1024)
+	return resource
+}
+
+func mockContainer(name string, requestCores, limitCores float32,
+	requestMB, limitMB int64) api.Container {
+	container := api.Container{
+		Name: name,
+		Resources: api.ResourceRequirements{
+			Limits:   buildResource(limitCores, limitMB),
+			Requests: buildResource(requestCores, requestMB),
+		},
+	}
+	return container
+}
+
+func mockOwnerReference() (r metav1.OwnerReference) {
+	r = metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       "twitter-cass-tweet",
+		UID:        "e2b4720e-1b59-11e9-a464-0e8e22e09e66",
+	}
+	return
+}
+
+func mockPod(name string) *api.Pod {
+	return &api.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				mockOwnerReference(),
+			},
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				mockContainer("twitter-cass-tweet", 0.25, 0.25, 256, 256),
+				mockContainer("istio-proxy", 0.01, 2.0, 0, 8192),
+			},
+		},
+	}
+}
+
+func mockNode(name string, capacity, allocatable api.ResourceList) *api.Node {
+	labels := make(map[string]string)
+	labels["l1"] = "v1"
+	labels["l2"] = "v2"
+	node := &api.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: api.NodeStatus{
+			Capacity:    capacity,
+			Allocatable: allocatable,
+		},
+	}
+	return node
+}
+
+func TestGenNodeResourceMetrics(t *testing.T) {
+	// Build a node
+	node := mockNode(
+		"mynode",
+		buildResource(2.0, 8192), // node capacity: 2.0 cores, 8 GiB mem
+		buildResource(1.9, 7168), // node allocatable: 1.9 cores, 7 GiB mem
+	)
+	// Build pods in the node
+	pods := []*api.Pod{mockPod("mypod")}
+	config := &ClusterMonitorConfig{}
+	clusterMonitor, err := NewClusterMonitor(config)
+	if err != nil {
+		t.Errorf("Failed to create clusterMonitor: %v", err)
+	}
+	clusterMonitor.clusterClient = &cluster.ClusterScraper{}
+	clusterMonitor.sink = metrics.NewEntityMetricSink()
+	clusterMonitor.nodeList = []*api.Node{node}
+	clusterMonitor.nodePodMap = make(map[string][]*api.Pod)
+	clusterMonitor.nodePodMap["mynode"] = pods
+	// Collect node/pod/container metrics
+	clusterMonitor.findNodeStates()
+	for name, value := range expectedMetrics {
+		metric, err := clusterMonitor.sink.GetMetric(name)
+		if err != nil {
+			t.Errorf("Failed to validate metric: %v", err)
+		}
+		assert.EqualValues(t, value, metric.GetValue())
+	}
+}

--- a/pkg/discovery/util/resource.go
+++ b/pkg/discovery/util/resource.go
@@ -2,27 +2,9 @@ package util
 
 import (
 	"errors"
-	"fmt"
 
 	api "k8s.io/api/core/v1"
 )
-
-func GetNodeResourceRequestConsumption(pods []*api.Pod) (nodeCpuProvisionedUsedCore, nodeMemoryProvisionedUsedKiloBytes float64, err error) {
-	if pods == nil {
-		err = errors.New("pod list passed in is nil")
-		return
-	}
-	for _, pod := range pods {
-		podCpuRequest, podMemoryRequest, getErr := GetPodResourceRequest(pod)
-		if getErr != nil {
-			err = fmt.Errorf("failed to get resource requests: %s", getErr)
-			return
-		}
-		nodeCpuProvisionedUsedCore += podCpuRequest
-		nodeMemoryProvisionedUsedKiloBytes += podMemoryRequest
-	}
-	return
-}
 
 // CPU returned is in KHz; Mem is in Kb
 func GetPodResourceLimits(pod *api.Pod) (cpuCapacity float64, memCapacity float64, err error) {
@@ -36,22 +18,6 @@ func GetPodResourceLimits(pod *api.Pod) (cpuCapacity float64, memCapacity float6
 		ctnCpuCap, ctnMemoryCap := GetCpuAndMemoryValues(limits)
 		cpuCapacity += ctnCpuCap
 		memCapacity += ctnMemoryCap
-	}
-	return
-}
-
-// CPU returned is in KHz; Mem is in Kb
-func GetPodResourceRequest(pod *api.Pod) (cpuRequest float64, memRequest float64, err error) {
-	if pod == nil {
-		err = errors.New("pod passed in is nil.")
-		return
-	}
-
-	for _, container := range pod.Spec.Containers {
-		request := container.Resources.Requests
-		ctnCpuRequest, ctnMemoryRequest := GetCpuAndMemoryValues(request)
-		cpuRequest += ctnCpuRequest
-		memRequest += ctnMemoryRequest
 	}
 	return
 }

--- a/pkg/discovery/worker/metrics_collector_test.go
+++ b/pkg/discovery/worker/metrics_collector_test.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
@@ -9,7 +11,6 @@ import (
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
 )
 
 var (
@@ -257,8 +258,6 @@ func TestPodMetricsListAllocationUsage(t *testing.T) {
 	memUsed := 0.0
 	assert.Equal(t, cpuUsed, resourceMap[metrics.CPULimit])
 	assert.Equal(t, memUsed, resourceMap[metrics.MemoryLimit])
-	assert.Equal(t, cpuUsed, resourceMap[metrics.CPURequest])
-	assert.Equal(t, memUsed, resourceMap[metrics.MemoryRequest])
 }
 
 func TestSumPodMetricsMissingComputeUsage(t *testing.T) {
@@ -283,9 +282,7 @@ func TestPodMetrics(t *testing.T) {
 	pm := createPodMetrics(pod_ns1_n1, ns1, metricsSink)
 
 	assert.Equal(t, pm.AllocationBought[metrics.CPULimit], cpuUsed_pod_n1_ns1)
-	assert.Equal(t, pm.AllocationBought[metrics.CPURequest], cpuUsed_pod_n1_ns1)
 	assert.Equal(t, pm.AllocationBought[metrics.MemoryLimit], 0.0)
-	assert.Equal(t, pm.AllocationBought[metrics.MemoryRequest], 0.0)
 }
 
 func TestPodMetricsCollectionNullCluster(t *testing.T) {
@@ -431,9 +428,7 @@ func TestCreateMetricsMapForNodeWithEmptyPodList(t *testing.T) {
 
 	// allocation used map is not created
 	assert.Equal(t, nm.AllocationUsed[metrics.CPULimit], 0.0)
-	assert.Equal(t, nm.AllocationUsed[metrics.CPURequest], 0.0)
 	assert.Equal(t, nm.AllocationUsed[metrics.MemoryLimit], 0.0)
-	assert.Equal(t, nm.AllocationUsed[metrics.MemoryRequest], 0.0)
 
 	// allocation capacity map is created
 	assertNodeAllocationCapacity(t, nm)
@@ -470,22 +465,17 @@ func TestNodeMetricsCollectionMultipleNodes(t *testing.T) {
 
 	// Assert the node allocation usage values for nodes with pods
 	assertNodeAllocationUsage(t, n1Metrics, node1)
-	assert.Equal(t, n2Metrics.AllocationUsed[metrics.CPULimit], 0.0)   // no pods on n2
-	assert.Equal(t, n2Metrics.AllocationUsed[metrics.CPURequest], 0.0) // no pods on n2
+	assert.Equal(t, n2Metrics.AllocationUsed[metrics.CPULimit], 0.0) // no pods on n2
 }
 
 func assertNodeAllocationCapacity(t *testing.T, nm *repository.NodeMetrics) {
-	assert.Equal(t, nm.AllocationCap[metrics.CPULimit], nodeCpuCap) // node allocation capacity is equal to the node's compute resources
-	assert.Equal(t, nm.AllocationCap[metrics.CPURequest], nodeCpuCap)
+	assert.Equal(t, nm.AllocationCap[metrics.CPULimit], nodeCpuCap)    // node allocation capacity is equal to the node's compute resources
 	assert.Equal(t, nm.AllocationCap[metrics.MemoryLimit], nodeMemCap) // node allocation capacity is equal to the node's compute resources
-	assert.Equal(t, nm.AllocationCap[metrics.MemoryRequest], nodeMemCap)
 }
 
 func assertNodeAllocationUsage(t *testing.T, nm *repository.NodeMetrics, node string) {
 	assert.Equal(t, nm.AllocationUsed[metrics.CPULimit], nodeToPodCpuUsageMap[node]) // node allocation capacity is equal to the node's compute resources
-	assert.Equal(t, nm.AllocationUsed[metrics.CPURequest], nodeToPodCpuUsageMap[node])
-	assert.Equal(t, nm.AllocationUsed[metrics.MemoryLimit], 0.0) // node allocation capacity is equal to the node's compute resources
-	assert.Equal(t, nm.AllocationUsed[metrics.MemoryRequest], 0.0)
+	assert.Equal(t, nm.AllocationUsed[metrics.MemoryLimit], 0.0)                     // node allocation capacity is equal to the node's compute resources
 }
 
 func TestQuotaMetricsMapAllNodes(t *testing.T) {


### PR DESCRIPTION
This pull request creates request commodities in kubeturbo. The following changes are made:

* Collect CPURequest and MemoryRequest in ``ClusterMonitor``
* Refactor the code that calculates the total request used, and remove unnecessary function calls ``GetNodeResourceRequestConsumption`` and ``GetPodResourceRequest``
* Add CPURequest and MemoryRequest to sold commodities (used and capacity) in ``nodeEntityDTOBuilder``
* Add CPURequest and MemoryRequest to bought commodities (used) in ``podEntityDTOBuilder``
* Remove unnecessary test cases related to request in Allocation. These tests will be properly handled in OM-44460 - Add request commodity into Resource Quota (VDC)
* Add proper test for ``ClusterMonitor``