### PR TITLE
Set the VCPU peak value and patch it at server side.

### DIFF
--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -150,6 +150,9 @@ func (builder generalBuilder) getSoldResourceCommodityWithKey(entityType metrics
 
 	commSoldBuilder.Used(usedValue)
 
+	// set peak value as the used value
+	commSoldBuilder.Peak(usedValue)
+
 	// set capacity value
 	capacityValue, err := builder.metricValue(entityType, entityID,
 		resourceType, metrics.Capacity, converter)
@@ -216,6 +219,9 @@ func (builder generalBuilder) getResourceCommoditiesBought(entityType metrics.Di
 		}
 		commBoughtBuilder.Used(usedValue)
 
+		// set peak value as the used value
+		commBoughtBuilder.Peak(usedValue)
+
 		// set reservation value if any
 		reservedMetricUID := metrics.GenerateEntityResourceMetricUID(entityType, entityID,
 			rType, metrics.Reservation)
@@ -273,6 +279,9 @@ func (builder generalBuilder) getResourceCommodityBoughtWithKey(entityType metri
 	}
 
 	commBoughtBuilder.Used(usedValue)
+
+	// set peak value as the used value
+	commBoughtBuilder.Peak(usedValue)
 
 	// set reservation value if any
 	reservationValue, _ := builder.metricValue(entityType, entityID,

--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -207,10 +207,11 @@ func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_Re
 		return nil, fmt.Errorf("Stitching property type %s is not supported.", s.stitchType)
 	}
 	usedAndCapacityPropertyNames := []string{builder.PropertyCapacity, builder.PropertyUsed}
+	vcpuUsedAndCapacityPropertyNames := []string{builder.PropertyCapacity, builder.PropertyUsed, builder.PropertyPeak}
 	capacityOnlyPropertyNames := []string{builder.PropertyCapacity}
 	replacementEntityMetaDataBuilder.PatchSellingWithProperty(proto.CommodityDTO_CLUSTER, capacityOnlyPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_VMPM_ACCESS, capacityOnlyPropertyNames).
-		PatchSellingWithProperty(proto.CommodityDTO_VCPU, usedAndCapacityPropertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_VCPU, vcpuUsedAndCapacityPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_VMEM, usedAndCapacityPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_CPU_ALLOCATION, usedAndCapacityPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_MEM_ALLOCATION, usedAndCapacityPropertyNames)

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/commodity_dto_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/commodity_dto_builder.go
@@ -99,6 +99,14 @@ func (cb *CommodityDTOBuilder) Used(used float64) *CommodityDTOBuilder {
 	return cb
 }
 
+func (cb *CommodityDTOBuilder) Peak(peak float64) *CommodityDTOBuilder {
+	if cb.err != nil {
+		return cb
+	}
+	cb.peak = &peak
+	return cb
+}
+
 func (cb *CommodityDTOBuilder) Reservation(reservation float64) *CommodityDTOBuilder {
 	if cb.err != nil {
 		return cb


### PR DESCRIPTION
Currently, at server side, only VM VCPU capacity and used values are patched. However, it causes some inconsistent issue for the peak value. See OM-43641 for details. To avoid it, Kubeturbo needs also set peak value and patch it at server side.

This is the change at Kubeturbo side.