### PR TITLE
switch to ubi8 baseimage

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/ubi8
 MAINTAINER Enlin Xu <enlin.xu@turbonomic.com>
 ARG GIT_COMMIT
 ENV GIT_COMMIT ${GIT_COMMIT}
@@ -6,7 +6,7 @@ ENV GIT_COMMIT ${GIT_COMMIT}
 ### Atomic/OpenShift Labels - https://github.com/projectatomic/ContainerApplicationGenericLabels
 LABEL name="Hybrid Cloud Container" \
       vendor="Turbonomic" \
-      version="6.0" \
+      version="6.4" \
       release="1" \
       summary="Performance assurance for the applications in Openshift" \
       description="Hybrid Cloud Container leverages Turbonomic control platform, to assure the performance of micro-services running in OpenShift, as well as the efficiency of underlying infrastructure." \
@@ -27,16 +27,17 @@ COPY licenses /licenses
 
 COPY Dockerfile /Dockerfile
 
-### Add necessary Red Hat repos here
-RUN REPOLIST=rhel-7-server-rpms,rhel-7-server-optional-rpms \
-### Add your package needs here
-    INSTALL_PKGS="golang-github-cpuguy83-go-md2man ca-certificates" && \
-    yum -y update-minimal --disablerepo "*" --enablerepo rhel-7-server-rpms --setopt=tsflags=nodocs \
-      --security --sec-severity=Important --sec-severity=Critical && \
-    yum -y install --disablerepo "*" --enablerepo ${REPOLIST} --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+### Add md2man package
+RUN echo "[epel]" > /etc/yum.repos.d/epel.repo && \
+    echo "name=Extra Packages for Enterprise Linux 7" >> /etc/yum.repos.d/epel.repo && \
+    echo "baseurl=http://download.fedoraproject.org/pub/epel/7/x86_64/" >> /etc/yum.repos.d/epel.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/epel.repo && \
+    echo "enabled=1" >> /etc/yum.repos.d/epel.repo && \
+    dnf install -y --nogpgcheck --setopt=tsflags=nodocs golang-github-cpuguy83-go-md2man && \
+    dnf clean all && \
+
 ### help file markdown to man conversion
-    go-md2man -in /tmp/help.md -out /help.1 && \
-    yum clean all
+    go-md2man -in /tmp/help.md -out /help.1
 
 ### Setup user for build execution and application runtime
 ENV APP_ROOT=/opt/turbonomic \
@@ -45,7 +46,6 @@ ENV APP_ROOT=/opt/turbonomic \
 ENV PATH=$PATH:${APP_ROOT}/bin
 
 RUN mkdir -p ${APP_ROOT}/bin
-#COPY kubeturbo.sh ${APP_ROOT}/bin/kubeturbo
 COPY kubeturbo ${APP_ROOT}/bin/kubeturbo
 RUN chmod -R ug+x ${APP_ROOT}/bin && sync && \
     useradd -l -u ${USER_UID} -r -g 0 -d ${APP_ROOT} -s /sbin/nologin -c "${USER_NAME} user" ${USER_NAME} && \


### PR DESCRIPTION
$ make docker
docker build -t esara/kubeturbo:6.4dev --build-arg GIT_COMMIT=f167afd build
Sending build context to Docker daemon   43.1MB
Step 1/17 : FROM registry.access.redhat.com/ubi8
 ---> 4a0518848c7a
Step 2/17 : MAINTAINER Enlin Xu <enlin.xu@turbonomic.com>
 ---> Using cache
 ---> ab259f930b4a
Step 3/17 : ARG GIT_COMMIT
 ---> Using cache
 ---> 3aad3c3dae7e
Step 4/17 : ENV GIT_COMMIT ${GIT_COMMIT}
 ---> Using cache
 ---> bc9d556483f6
Step 5/17 : LABEL name "Hybrid Cloud Container" vendor "Turbonomic" version "6.4" release "1" summary "Performance assurance for the applications in Openshift" description "Hybrid Cloud Container leverages Turbonomic control platform, to assure the performance of micro-services running in OpenShift, as well as the efficiency of underlying infrastructure." url "http://www.turbonomic.com" run 'docker run -tdi --name ${NAME} vmturbo/kubeturbo:latest' io.k8s.description "Hybrid Cloud Container will monitor and control the entire stack, from OpenShift down to your underlying infrastructure. " io.k8s.display-name "Hybrid Cloud Container" io.openshift.expose-services "" io.openshift.tags "turbonomic,Hybrid Cloud Container"
 ---> Using cache
 ---> 6951e542b945
Step 6/17 : COPY help.md /tmp/
 ---> Using cache
 ---> 93e454711171
Step 7/17 : COPY licenses /licenses
 ---> Using cache
 ---> ae584f05b7a3
Step 8/17 : COPY Dockerfile /Dockerfile
 ---> Using cache
 ---> b1eba6ed00f3
Step 9/17 : RUN echo "[epel]" > /etc/yum.repos.d/epel.repo &&     echo "name=Extra Packages for Enterprise Linux 7" >> /etc/yum.repos.d/epel.repo &&     echo "baseurl=http://download.fedoraproject.org/pub/epel/7/x86_64/" >> /etc/yum.repos.d/epel.repo &&     echo "gpgcheck=1" >> /etc/yum.repos.d/epel.repo &&     echo "enabled=1" >> /etc/yum.repos.d/epel.repo &&     dnf install -y --nogpgcheck --setopt=tsflags=nodocs golang-github-cpuguy83-go-md2man &&     dnf clean all &&     go-md2man -in /tmp/help.md -out /help.1
 ---> Using cache
 ---> 518b8b76c9c1
Step 10/17 : ENV APP_ROOT /opt/turbonomic USER_NAME default USER_UID 10001
 ---> Using cache
 ---> abcbc47039e2
Step 11/17 : ENV PATH $PATH:${APP_ROOT}/bin
 ---> Using cache
 ---> 4ffaacfc5ca6
Step 12/17 : RUN mkdir -p ${APP_ROOT}/bin
 ---> Using cache
 ---> f6d586ea6a89
Step 13/17 : COPY kubeturbo ${APP_ROOT}/bin/kubeturbo
 ---> a6e452a24944
Removing intermediate container ca43d8295ede
Step 14/17 : RUN chmod -R ug+x ${APP_ROOT}/bin && sync &&     useradd -l -u ${USER_UID} -r -g 0 -d ${APP_ROOT} -s /sbin/nologin -c "${USER_NAME} user" ${USER_NAME} &&     chown -R ${USER_UID}:0 ${APP_ROOT} &&     chmod -R g=u ${APP_ROOT}
 ---> Running in f8a95af0af78
 ---> 27e8ce60ff8d
Removing intermediate container f8a95af0af78
Step 15/17 : USER 10001
 ---> Running in 72099670911c
 ---> 8f28a2ab0ec2
Removing intermediate container 72099670911c
Step 16/17 : WORKDIR ${APP_ROOT}
 ---> 1a5c93c8a686
Removing intermediate container 10cd38db072c
Step 17/17 : ENTRYPOINT /opt/turbonomic/bin/kubeturbo
 ---> Running in 9b8d6c635a63
 ---> 0d77024a6653
Removing intermediate container 9b8d6c635a63
Successfully built 0d77024a6653
Successfully tagged esara/kubeturbo:6.4dev
[root@centos kubeturbo]# docker push esara/kubeturbo:6.4dev
The push refers to a repository [docker.io/esara/kubeturbo]
93ba1ae4eae8: Pushed 
21dc8762edd1: Pushed 
257eaff99274: Layer already exists 
f06a274b8ba7: Layer already exists 
2eb876e41fa3: Layer already exists 
0bd16d7225c7: Layer already exists 
b9520c000c15: Layer already exists 
c613b100be16: Layer already exists 
24d85c895b6b: Layer already exists 
6.4dev: digest: sha256:b901239a9de9c2540f6dc97e18e16418e85ce788ac8993a0501b001218e245e3 size: 2203
