### PR TITLE
OM-46668 Resource quota usage value double counting

### DIFF
--- a/pkg/discovery/worker/quotas_discovery_worker.go
+++ b/pkg/discovery/worker/quotas_discovery_worker.go
@@ -40,17 +40,18 @@ func (worker *k8sResourceQuotasDiscoveryWorker) Do(quotaMetricsList []*repositor
 	for _, quotaMetrics := range quotaMetricsList {
 		glog.V(4).Infof("Merging metrics of %s for nodes %s",
 			quotaMetrics.QuotaName, quotaMetrics.NodeProviders)
-		_, exists := quotaMetricsMap[quotaMetrics.QuotaName]
+		existingMetric, exists := quotaMetricsMap[quotaMetrics.QuotaName]
 		if !exists {
+			// first time that this quota is seen
 			quotaMetricsMap[quotaMetrics.QuotaName] = quotaMetrics
+			continue
 		}
-		existingMetric := quotaMetricsMap[quotaMetrics.QuotaName]
 		// merge the provider node metrics into the existing quota metrics
 		for node, nodeMap := range quotaMetrics.AllocationBoughtMap {
 			existingMetric.UpdateAllocationBought(node, nodeMap)
 		}
 
-		//merge the pod usage from this quota metrics into the existing quota metrics
+		// merge the pod usage from this quota metrics into the existing quota metrics
 		existingMetric.UpdateAllocationSoldUsed(quotaMetrics.AllocationSoldUsed)
 	}
 


### PR DESCRIPTION
In `kubeturbo`, we handle discovery of metrics using multiple workers, and each worker is responsible for the discovery of metrics of one or several nodes (and pods/containers running on the node) in the cluster. After that, we launch a `k8sResourceQuotasDiscoveryWorker`, which merge the quota metrics discovered by the previous workers. This merge is needed because we need to properly create quota entities, where each quota entity can buy resource from multiple nodes, and sell to pods that run on multiple nodes.

During the merge in `k8sResourceQuotasDiscoveryWorker.Do()`, we first create a `quotaMetricsMap` to hold the merged metrics, where the key is the name of the quota, and the value is the `QuotaMetrics` object that holds the Bought and Sold quota resource for that quota, we then loop through the list of quota metrics discovered in the previous step to merge metrics for the same quota.

Inside the loop, if we see a new quota for the first time, we set the `QuotaMetrics` of that quota in the `quotaMetricsMap`. After this, we should skip the rest of this iteration and continue with the next iteration of the loop, however, we do not, we go ahead and do the merge for the same `QuotaMetrics`, where `UpdateAllocationSoldUsed` adds the same metric value twice.

This is how I recreated the issue:
* Deploy XL on a single node (4 CPU, 12GB memory) kubernetes cluster with helm
* Deploy kubeturbo in the same cluster
* After discovery, navigate to the **turbonomic** namespace (VDC). This is the namespace where all XL components are installed
* Look at the used value and capacity of MemAllocation and MemRequestAllocation, which are both more than 100%, which is clearly wrong
<img width="1400" alt="Screen Shot 2019-05-27 at 12 06 34 PM" src="https://user-images.githubusercontent.com/10012486/58435463-a72d8380-808e-11e9-8a86-e8f93511a64f.png">

After the fix, the allocation resource used value are correct:
<img width="1423" alt="Screen Shot 2019-05-27 at 12 08 55 PM" src="https://user-images.githubusercontent.com/10012486/58435516-d5ab5e80-808e-11e9-96da-8b631c8f9e6a.png">
