### PR TITLE
OM-46976 Create cluster for a kubernetes cluster with group of VMs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.2.2
 	github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 // indirect
-	github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190618175117-e8ebccf7d25d+incompatible
+	github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190628213717-579ca3a8764e+incompatible
 	go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 // indirect
 	go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df // indirect
 	go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 h1:xfnOa96E4g6MRfLPSVyL4Aprmxf8NBjsUyqUoW0VnIs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190618175117-e8ebccf7d25d+incompatible h1:X/icPual8ZWiJdoK+QvjKZBJByDdkQi4y7ew0V8T5CU=
-github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190618175117-e8ebccf7d25d+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
+github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190628213717-579ca3a8764e+incompatible h1:c5P+Y9lU/tmjHURQemrkuaeU3HvX28FWIJ4WL3fcTok=
+github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190628213717-579ca3a8764e+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 h1:nSQar3Y0E3VQF/VdZ8PTAilaXpER+d7ypdABCrpwMdg=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df h1:shvkWr0NAZkg4nPuE3XrKP0VuBPijjk3TfX6Y6acFNg=

--- a/pkg/discovery/dtofactory/cluster_dto_builder.go
+++ b/pkg/discovery/dtofactory/cluster_dto_builder.go
@@ -1,0 +1,37 @@
+package dtofactory
+
+import (
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/turbo-go-sdk/pkg/builder/group"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+type clusterDTOBuilder struct {
+	cluster  *repository.ClusterSummary
+	targetId string
+}
+
+func NewClusterDTOBuilder(cluster *repository.ClusterSummary,
+	targetId string) *clusterDTOBuilder {
+	return &clusterDTOBuilder{
+		cluster:  cluster,
+		targetId: targetId,
+	}
+}
+
+func (builder *clusterDTOBuilder) Build() *proto.GroupDTO {
+	var members []string
+	for _, node := range builder.cluster.NodeList {
+		members = append(members, string(node.UID))
+	}
+	clusterDTO, err := group.Cluster(builder.targetId).
+		OfType(proto.EntityDTO_VIRTUAL_MACHINE).
+		WithEntities(members).
+		WithDisplayName(builder.targetId).
+		Build()
+	if err != nil {
+		glog.Errorf("Failed to build cluster DTO %v", err)
+	}
+	return clusterDTO
+}

--- a/pkg/discovery/dtofactory/group_dto_builder.go
+++ b/pkg/discovery/dtofactory/group_dto_builder.go
@@ -12,7 +12,6 @@ import (
 // Builds GroupDTOs given the map of EntityGroup structures for the kubeturbo probe.
 type groupDTOBuilder struct {
 	entityGroupMap map[string]*repository.EntityGroup
-	nodeNames      []string
 	targetId       string
 }
 
@@ -31,10 +30,10 @@ var (
 func NewGroupDTOBuilder(entityGroupMap map[string]*repository.EntityGroup,
 	targetId string) (*groupDTOBuilder, error) {
 	if entityGroupMap == nil || len(entityGroupMap) == 0 {
-		return nil, fmt.Errorf("Invalid entity group map")
+		return nil, fmt.Errorf("invalid entity group map")
 	}
 	if targetId == "" {
-		return nil, fmt.Errorf("Invalid kubeturbo target identifier [%s]", targetId)
+		return nil, fmt.Errorf("invalid kubeturbo target identifier [%s]", targetId)
 	}
 
 	return &groupDTOBuilder{
@@ -46,7 +45,7 @@ func NewGroupDTOBuilder(entityGroupMap map[string]*repository.EntityGroup,
 // Build groupDTOs for pod and containers that belong to parent group instances for
 // StatefulSets, DaemonSets, ReplicaSets.
 // In addition also builds pod groups per parent type.
-func (builder *groupDTOBuilder) BuildGroupDTOs() ([]*proto.GroupDTO, error) {
+func (builder *groupDTOBuilder) BuildGroupDTOs() []*proto.GroupDTO {
 	var result []*proto.GroupDTO
 
 	// Groups per parent instance
@@ -100,5 +99,5 @@ func (builder *groupDTOBuilder) BuildGroupDTOs() ([]*proto.GroupDTO, error) {
 		}
 	}
 
-	return result, nil
+	return result
 }

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -227,9 +227,9 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework() ([]*proto.EntityDTO, []
 	glog.V(2).Infof("There are totally %d groups DTOs", len(groupDTOs))
 	if glog.V(3) {
 		for _, groupDto := range groupDTOs {
-			glog.Infof("%s::%s contains %d members",
+			glog.Infof("%s %s members: %+v",
 				groupDto.GetDisplayName(), groupDto.GetGroupName(),
-				len(groupDto.GetMemberList().Member))
+				groupDto.GetMemberList().Member)
 		}
 	}
 

--- a/pkg/discovery/processor/service_processor.go
+++ b/pkg/discovery/processor/service_processor.go
@@ -72,7 +72,7 @@ func (p *ServiceProcessor) ProcessServices() {
 
 	for svc, podList := range svcPodMap {
 		serviceClusterID := util.GetServiceClusterID(svc)
-		glog.Infof("Service:%s --> %s\n", serviceClusterID, podList)
+		glog.V(4).Infof("Service:%s --> %s\n", serviceClusterID, podList)
 	}
 	p.KubeCluster.Services = svcPodMap
 }

--- a/pkg/discovery/repository/kube_policies.go
+++ b/pkg/discovery/repository/kube_policies.go
@@ -14,7 +14,7 @@ type EntityGroup struct {
 
 func NewEntityGroup(kind, name string) (*EntityGroup, error) {
 	if kind == "" {
-		return nil, fmt.Errorf("Invalid parent kind")
+		return nil, fmt.Errorf("invalid parent kind")
 	}
 	groupKey := kind
 	if name != "" {

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/cluster_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/cluster_builder.go
@@ -1,0 +1,37 @@
+package group
+
+import "github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
+type ClusterBuilder struct {
+	*AbstractConstraintGroupBuilder
+}
+
+// Cluster is the builder for a group with Cluster constraint
+func Cluster(id string) *ClusterBuilder {
+	return &ClusterBuilder{
+		&AbstractConstraintGroupBuilder{
+			StaticGroup(id),
+			newConstraintBuilder(proto.GroupDTO_CLUSTER, id),
+		},
+	}
+}
+
+func (c *ClusterBuilder) OfType(eType proto.EntityDTO_EntityType) *ClusterBuilder {
+	c.AbstractBuilder.OfType(eType)
+	return c
+}
+
+func (c *ClusterBuilder) WithEntities(entities []string) *ClusterBuilder {
+	c.AbstractBuilder.WithEntities(entities)
+	return c
+}
+
+func (c *ClusterBuilder) WithDisplayName(displayName string) *ClusterBuilder {
+	c.AbstractBuilder.WithDisplayName(displayName)
+	c.ConstraintInfoBuilder.WithDisplayName(displayName)
+	return c
+}
+
+func (c *ClusterBuilder) Build() (*proto.GroupDTO, error) {
+	return c.AbstractConstraintGroupBuilder.Build()
+}

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/constraint_group_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/constraint_group_builder.go
@@ -1,0 +1,121 @@
+package group
+
+import (
+	"fmt"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+// ConstraintInfoBuilder is the builder for the constraint info data in a Group DTO
+type ConstraintInfoBuilder struct {
+	constraintType        proto.GroupDTO_ConstraintType
+	constraintId          string
+	constraintName        string
+	constraintDisplayName string
+	providerTypePtr       *proto.EntityDTO_EntityType
+	isBuyer               bool
+
+	maxBuyers int32
+}
+
+func newConstraintBuilder(constraintType proto.GroupDTO_ConstraintType, constraintId string) *ConstraintInfoBuilder {
+
+	return &ConstraintInfoBuilder{
+		constraintName: constraintId,
+		constraintType: constraintType,
+	}
+}
+
+func (constraintInfoBuilder *ConstraintInfoBuilder) WithName(constraintName string) *ConstraintInfoBuilder {
+	constraintInfoBuilder.constraintName = constraintName
+	return constraintInfoBuilder
+}
+
+func (constraintInfoBuilder *ConstraintInfoBuilder) WithDisplayName(constraintDisplayName string) *ConstraintInfoBuilder {
+	constraintInfoBuilder.constraintDisplayName = constraintDisplayName
+	return constraintInfoBuilder
+}
+
+// Set the entity type of the seller group for the buyer entities
+func (constraintInfoBuilder *ConstraintInfoBuilder) WithSellerType(providerType proto.EntityDTO_EntityType) *ConstraintInfoBuilder {
+	constraintInfoBuilder.providerTypePtr = &providerType
+	return constraintInfoBuilder
+}
+
+// Set the maximum number of buyer entities allowed in the policy
+func (constraintInfoBuilder *ConstraintInfoBuilder) AtMostBuyers(maxBuyers int32) *ConstraintInfoBuilder {
+	constraintInfoBuilder.maxBuyers = maxBuyers
+	return constraintInfoBuilder
+}
+
+// Build the ConstraintInfo DTO
+func (constraintInfoBuilder *ConstraintInfoBuilder) Build() (*proto.GroupDTO_ConstraintInfo, error) {
+	constraintInfo := &proto.GroupDTO_ConstraintInfo{
+		ConstraintId:          &constraintInfoBuilder.constraintId,
+		ConstraintType:        &constraintInfoBuilder.constraintType,
+		ConstraintName:        &constraintInfoBuilder.constraintName,
+		ConstraintDisplayName: &constraintInfoBuilder.constraintDisplayName,
+	}
+
+	if constraintInfoBuilder.isBuyer {
+		// buyer group specific metadata
+		constraintInfo.BuyerMetaData = &proto.GroupDTO_BuyerMetaData{}
+		boolVal := true
+		constraintInfo.IsBuyer = &boolVal
+		// seller entity type should be provided for buyer seller policies
+		setProvider := (constraintInfoBuilder.constraintType == proto.GroupDTO_BUYER_SELLER_AFFINITY) ||
+			(constraintInfoBuilder.constraintType == proto.GroupDTO_BUYER_SELLER_ANTI_AFFINITY)
+		if setProvider && constraintInfoBuilder.providerTypePtr == nil {
+			return nil, fmt.Errorf("seller type required")
+		}
+		constraintInfo.BuyerMetaData.SellerType = constraintInfoBuilder.providerTypePtr
+		// max buyers allowed
+		if constraintInfoBuilder.maxBuyers > 0 {
+			constraintInfo.BuyerMetaData.AtMost = &constraintInfoBuilder.maxBuyers
+		}
+	}
+
+	// seller group specific metadata
+	needsComplementary := constraintInfoBuilder.constraintType == proto.GroupDTO_BUYER_SELLER_ANTI_AFFINITY
+	constraintInfo.NeedComplementary = &needsComplementary
+
+	return constraintInfo, nil
+}
+
+// AbstractConstraintGroupBuilder is the builder of a Group with constraint
+type AbstractConstraintGroupBuilder struct {
+	*AbstractBuilder
+	*ConstraintInfoBuilder
+}
+
+// Build policy group with Constraint Info
+func (groupBuilder *AbstractConstraintGroupBuilder) Build() (*proto.GroupDTO, error) {
+
+	groupDTO, err := groupBuilder.AbstractBuilder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build group: %v", err)
+	}
+
+	var constraintInfo *proto.GroupDTO_ConstraintInfo
+	constraintInfo, err = groupBuilder.ConstraintInfoBuilder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build group constraint: %v", err)
+	}
+
+	if groupBuilder.constraintType == proto.GroupDTO_CLUSTER {
+		entityType := *groupBuilder.entityTypePtr
+		if entityType != proto.EntityDTO_VIRTUAL_MACHINE &&
+			entityType != proto.EntityDTO_PHYSICAL_MACHINE &&
+			entityType != proto.EntityDTO_STORAGE {
+			return nil, fmt.Errorf("failed to build cluster: unsupported entity type %v", entityType)
+		}
+	}
+
+	// set constraint info in the group DTO
+	info := &proto.GroupDTO_ConstraintInfo_{
+		ConstraintInfo: constraintInfo,
+	}
+
+	groupDTO.Info = info
+
+	return groupDTO, nil
+}

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/group_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/group_builder.go
@@ -91,7 +91,7 @@ func (groupBuilder *AbstractBuilder) Build() (*proto.GroupDTO, error) {
 	groupDTO.IsConsistentResizing = &groupBuilder.consistentResize
 
 	if groupBuilder.ec.Count() > 0 {
-		glog.Errorf("GroupBuilder Error %s : %s\n", groupBuilder.groupId, groupBuilder.ec.Error())
+		glog.Errorf("%s : %s", groupBuilder.groupId, groupBuilder.ec.Error())
 		return nil, fmt.Errorf("%s: %s", groupBuilder.groupId, groupBuilder.ec.Error())
 	}
 
@@ -114,7 +114,7 @@ func (groupBuilder *AbstractBuilder) OfType(eType proto.EntityDTO_EntityType) *A
 
 	// Check entity type
 	if groupBuilder.entityTypePtr != nil && *groupBuilder.entityTypePtr != eType {
-		groupBuilder.ec.Collect(fmt.Errorf("Cannot add members, input EntityType - %s is not consistent with existing EntityType %s ",
+		groupBuilder.ec.Collect(fmt.Errorf("cannot add members, input entityType %v is not consistent with existing entityType %v",
 			eType, *groupBuilder.entityTypePtr))
 		return groupBuilder
 	}
@@ -127,14 +127,14 @@ func (groupBuilder *AbstractBuilder) OfType(eType proto.EntityDTO_EntityType) *A
 
 func (groupBuilder *AbstractBuilder) setupEntityType(groupDTO *proto.GroupDTO) error {
 	if groupBuilder.entityTypePtr == nil {
-		return fmt.Errorf("Entity type is not set")
+		return fmt.Errorf("entity type is not set")
 	}
 	// Validate entity type
 	entityType := *groupBuilder.entityTypePtr
 	_, valid := proto.EntityDTO_EntityType_name[int32(entityType)]
 
 	if !valid {
-		return fmt.Errorf("Invalid entity type %v\n", entityType)
+		return fmt.Errorf("invalid entity type %v", entityType)
 	}
 
 	// Setup entity type
@@ -147,7 +147,7 @@ func (groupBuilder *AbstractBuilder) WithEntities(entities []string) *AbstractBu
 
 	// Assert that the group is a static group
 	if groupBuilder.groupType != STATIC_GROUP {
-		groupBuilder.ec.Collect(fmt.Errorf("Cannot set member uuid list for dynamic group"))
+		groupBuilder.ec.Collect(fmt.Errorf("cannot set member uuid list for dynamic group"))
 		return groupBuilder
 	}
 	groupBuilder.memberList = entities
@@ -158,7 +158,7 @@ func (groupBuilder *AbstractBuilder) WithEntities(entities []string) *AbstractBu
 func (groupBuilder *AbstractBuilder) setUpStaticMembers(groupDTO *proto.GroupDTO) error {
 
 	if len(groupBuilder.memberList) == 0 {
-		return fmt.Errorf("Empty member list")
+		return fmt.Errorf("empty member list")
 	}
 
 	// Set the Group DTO member field
@@ -176,7 +176,7 @@ func (groupBuilder *AbstractBuilder) MatchingEntities(matching *Matching) *Abstr
 
 	// Assert that the group is a dynamci group
 	if groupBuilder.groupType != DYNAMIC_GROUP {
-		groupBuilder.ec.Collect(fmt.Errorf("Cannot set matching criteria for static group"))
+		groupBuilder.ec.Collect(fmt.Errorf("cannot set matching criteria for static group"))
 		return groupBuilder
 	}
 	groupBuilder.matching = matching
@@ -187,7 +187,7 @@ func (groupBuilder *AbstractBuilder) MatchingEntities(matching *Matching) *Abstr
 func (groupBuilder *AbstractBuilder) setUpDynamicGroup(groupDTO *proto.GroupDTO) error {
 
 	if groupBuilder.matching == nil {
-		return fmt.Errorf("Null matching criteria for member selection")
+		return fmt.Errorf("null matching criteria for member selection")
 	}
 
 	var selectionSpecList []*proto.GroupDTO_SelectionSpec

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/stretchr/testify/assert
 # github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
-# github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190618175117-e8ebccf7d25d+incompatible
+# github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190628213717-579ca3a8764e+incompatible
 github.com/turbonomic/turbo-go-sdk/pkg/probe
 github.com/turbonomic/turbo-go-sdk/pkg/service
 github.com/turbonomic/turbo-go-sdk/pkg/proto


### PR DESCRIPTION
This pull request creates a static group of virtual machines with cluster constraint in `kubeturbo`. This is needed for the server to create a new search category of Virtual Machine Clusters such that user can easily scope to a kubernetes cluster.

The following is a screenshot showing how these discovered groups look like in the UI. 

For example, when user clicks the **Virtual Machine Clusters** search category, three kubernetes clusters are listed. When expanding the 2nd cluster, the statistics and actions of that cluster are displayed.

![image](https://user-images.githubusercontent.com/10012486/60373217-70b89080-99cd-11e9-85c3-51399fe03fc0.png)
