### PR TITLE
Append container index to the commodity keys sold by the application entities

### DIFF
--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -133,12 +133,20 @@ func (builder *applicationEntityDTOBuilder) getCommoditiesSold(pod *api.Pod, ind
 	svc := builder.podClusterIDToServiceMap[podClusterId]
 	// commodity key using service Id
 	var key string
+
 	// Service is associated with the pod, then the commodities key is the service Id,
 	// Else, it is computed using the container IP
 	if svc != nil {
 		key = util.GetServiceClusterID(svc)
 	} else {
-		key = getAppStitchingProperty(pod, index)
+		key = pod.Status.PodIP
+	}
+
+	// Sold commodity Key is appended with the container index,
+	// to distinguish between the main application serving the virtual application service
+	// and the sidecar application in the pod
+	if index > 0 {
+		key = fmt.Sprintf("%s-%d", key, index)
 	}
 
 	// Application Access Commodity in lieu of Transaction and ResponseTime commodities


### PR DESCRIPTION
This is to distinguish the commodities sold by the main application serving the virtual application and the sidecar application in the pod.
This change does not affect the stitching of the kubeturbo application/virtual application entities with that of the corresponding entities created by the prometurbo probe, as explained below -
- Kubeturbo creates applications for all containers in a pod. Application from the main container will have the IP address value to be the Pod IP address. Applications from other containers (sidecar) will have IP address value to be the PodIP-<index>.
- Virtual application will have the IP address property to be the list of IPs of all the pods serving the service.
- This IP property is used to merge the application and virtual application with the entities created by the prometurbo probe that collects the SLO metrics for the applications and services.

- Application and Virtual application entities are merged with the prometurbo entities using the primary IP address only. 