### PR TITLE
Enable docker image build and push in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,39 @@
 language: go
 
+env:
+  global:
+    - DOCKER_IMAGE_NAME=$TRAVIS_REPO_SLUG
+
+services:
+  - docker
+
 go:
-  - 1.11
-  - tip
+  - 1.12
 
 go_import_path: github.com/turbonomic/kubeturbo
 
 before_install:
   - go get -v github.com/mattn/goveralls
 
-matrix:
-  allow_failures:
-    - go: tip
-
 script:
-  - make fmtcheck 
+  - make fmtcheck
   - make vet
-  - make product
-  - if [ "$TRAVIS_GO_VERSION" == "tip" ] ; then make test ; else $HOME/gopath/bin/goveralls -v -race -service=travis-ci ; fi
+  - make build
+  - $HOME/gopath/bin/goveralls -v -race -service=travis-ci
+  - cp ./kubeturbo build
+  - cd build
+  - docker build -t $DOCKER_IMAGE_NAME --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" .
+
+after_success:
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      if [ -n "$TRAVIS_TAG" ]; then
+          # Push a release image triggered by a git tag
+          docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:$TRAVIS_TAG
+          docker push $DOCKER_IMAGE_NAME:$TRAVIS_TAG
+      elif [ "$TRAVIS_BRANCH" == "master" ]; then
+          # Push the latest image built from master branch
+          docker push $DOCKER_IMAGE_NAME
+      fi
+    fi


### PR DESCRIPTION
This pull request enables travis ci to build and push docker image. We want to keep things simple and also be conservative when pushing images:

* The image name will be the repository name, i.e., `turbonomic/kubeturbo`.
* The image will only be pushed under the following circumstances:
  - When a new PR is approved and merged in the `master` branch. The docker image tag in this case will be the default `latest`. In this way, we can always be sure that `turbonomic/kubeturbo:latest` refers to the latest image built from the unreleased development branch.
  - When a new release is created from a `git tag`. The docker image tag in this case will be picked up from the release tag in a SemVer format: `MAJOR.MINOR.PATCH`. 
  - Builds triggered by push/merge to a non-master branch will **NOT** cause any image to be pushed. As mentioned in the above, a new release with updated patch number needs to be created in order for a new docker image to be pushed to dockerhub.
* The git commit hash will be set as `GIT_COMMIT` environment variable and `git-version` label in the docker image.
* For travis build triggered by pull requests, docker image will be built, but not pushed.
* Dockerhub credentials for **turbonomic** has already been set in travis settings, and they are encrypted.

This travis yaml file should also work in a forked repository, as long as:
* The forked repo has a matching dockerhub repo, e.g., **github:ading1977/kubeturbo** -> **dockerhub:ading1977/kubeturbo**
* The forked repo has integration with travis under the same account, and has the `DOCKER_USERNAME` and `DOCKER_PASSWORD` configured in travis setting for that account:
![image](https://user-images.githubusercontent.com/10012486/60748103-8cd1aa00-9f58-11e9-8a36-119ad9c5dca7.png)
