### PR TITLE
Update turbo-go-sdk version and automate RH CC release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: go
 
 env:
   global:
-    - DOCKER_IMAGE_NAME=$TRAVIS_REPO_SLUG
+    - DOCKER_IMAGE=$TRAVIS_REPO_SLUG
+    - DOCKER_TAG=$TRAVIS_TAG
 
 services:
   - docker
@@ -22,18 +23,24 @@ script:
   - $HOME/gopath/bin/goveralls -v -race -service=travis-ci
   - cp ./kubeturbo build
   - cd build
-  - docker build -t $DOCKER_IMAGE_NAME --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" .
+  - docker build -t $DOCKER_IMAGE --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" .
 
 after_success:
   - |
+    # Do not push images for builds triggered from pull requests
     if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       if [ -n "$TRAVIS_TAG" ]; then
-          # Push a release image triggered by a git tag
-          docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:$TRAVIS_TAG
-          docker push $DOCKER_IMAGE_NAME:$TRAVIS_TAG
+          # Push a release image triggered by a git tag to Docker Hub
+          docker tag $DOCKER_IMAGE $DOCKER_IMAGE:$DOCKER_TAG
+          docker push $DOCKER_IMAGE:$DOCKER_TAG
+          # Also push to RH CC
+          echo "$RHCC_PASSWORD" | docker login -u "$RHCC_USERNAME" "$RHCC_REGISTRY" --password-stdin
+          RHCC_IMAGE=$RHCC_REGISTRY/$RHCC_REPO/$(basename $DOCKER_IMAGE)
+          docker tag $DOCKER_IMAGE:$DOCKER_TAG $RHCC_IMAGE:$DOCKER_TAG
+          docker push $RHCC_IMAGE:$DOCKER_TAG
       elif [ "$TRAVIS_BRANCH" == "master" ]; then
           # Push the latest image built from master branch
-          docker push $DOCKER_IMAGE_NAME
+          docker push $DOCKER_IMAGE
       fi
     fi

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.2.2
 	github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 // indirect
-	github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190618175117-e8ebccf7d25d+incompatible
+	github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible
 	go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 // indirect
 	go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df // indirect
 	go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 h1:xfnOa96E4g6MRfLPSVyL4Aprmxf8NBjsUyqUoW0VnIs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190618175117-e8ebccf7d25d+incompatible h1:X/icPual8ZWiJdoK+QvjKZBJByDdkQi4y7ew0V8T5CU=
-github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190618175117-e8ebccf7d25d+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
+github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible h1:sL9P8YlheUU/Cn2o/3r9G2AVH24rtBvYd6EO9bOgh1E=
+github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 h1:nSQar3Y0E3VQF/VdZ8PTAilaXpER+d7ypdABCrpwMdg=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df h1:shvkWr0NAZkg4nPuE3XrKP0VuBPijjk3TfX6Y6acFNg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/stretchr/testify/assert
 # github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
-# github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190618175117-e8ebccf7d25d+incompatible
+# github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible
 github.com/turbonomic/turbo-go-sdk/pkg/probe
 github.com/turbonomic/turbo-go-sdk/pkg/service
 github.com/turbonomic/turbo-go-sdk/pkg/proto


### PR DESCRIPTION
This pull request:
- Update the `turbo-go-sdk` version in `go.mod`.
- Add automation in Travis to push the release image to RHCC once 6.4.0 is released.