### PR TITLE
Increase the default pod creation timeout to 10 min

### DIFF
--- a/pkg/action/executor/constants.go
+++ b/pkg/action/executor/constants.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	defaultRetryLess = 3
-	defaultRetryMore = 12
+	defaultRetryMore = 55
 
 	defaultWaitLockTimeOut = time.Second * 300
 	defaultWaitLockSleep   = time.Second * 10


### PR DESCRIPTION
This cherry-picks @ading1977's changes in the following PR into the master branch.
https://github.com/turbonomic/kubeturbo/pull/276