### PR TITLE
Do not set Move action capability for VIRTUAL_MACHINE entity type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.2.2
 	github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 // indirect
-	github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190628213717-579ca3a8764e+incompatible
+	github.com/turbonomic/turbo-go-sdk v6.4.1-0.20190628213717-579ca3a8764e+incompatible
 	go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 // indirect
 	go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df // indirect
 	go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 h1:xfnOa96E4g6MRfLPSVyL4Aprmxf8NBjsUyqUoW0VnIs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190628213717-579ca3a8764e+incompatible h1:c5P+Y9lU/tmjHURQemrkuaeU3HvX28FWIJ4WL3fcTok=
-github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190628213717-579ca3a8764e+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
+github.com/turbonomic/turbo-go-sdk v6.4.1-0.20190628213717-579ca3a8764e+incompatible h1:dcCVM4F2bqNYvC9zjxanlNoPzCYutQCgY6IKzKsmVkc=
+github.com/turbonomic/turbo-go-sdk v6.4.1-0.20190628213717-579ca3a8764e+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 h1:nSQar3Y0E3VQF/VdZ8PTAilaXpER+d7ypdABCrpwMdg=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df h1:shvkWr0NAZkg4nPuE3XrKP0VuBPijjk3TfX6Y6acFNg=

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -82,7 +82,7 @@ func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO
 	recommend := proto.ActionPolicyDTO_NOT_EXECUTABLE
 	notSupported := proto.ActionPolicyDTO_NOT_SUPPORTED
 
-	// 1. containerPod: move, provision; not resize;
+	// 1. containerPod: support move, provision and suspend; not resize;
 	pod := proto.EntityDTO_CONTAINER_POD
 	podPolicy := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
 	podPolicy[proto.ActionItemDTO_MOVE] = supported
@@ -92,7 +92,7 @@ func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO
 
 	rClient.addActionPolicy(ab, pod, podPolicy)
 
-	// 2. container: support resize; recommend provision; not move;
+	// 2. container: support resize; recommend provision and suspend; not move;
 	container := proto.EntityDTO_CONTAINER
 	containerPolicy := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
 	containerPolicy[proto.ActionItemDTO_RIGHT_SIZE] = supported
@@ -102,7 +102,7 @@ func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO
 
 	rClient.addActionPolicy(ab, container, containerPolicy)
 
-	// 3. application: only recommend provision; all else are not supported
+	// 3. application: only recommend provision and suspend; all else are not supported
 	app := proto.EntityDTO_APPLICATION
 	appPolicy := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
 	appPolicy[proto.ActionItemDTO_PROVISION] = recommend
@@ -112,10 +112,9 @@ func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO
 
 	rClient.addActionPolicy(ab, app, appPolicy)
 
-	// 4. node: move, provision; not resize;
+	// 4. node: support provision and suspend; not resize; do not set move
 	node := proto.EntityDTO_VIRTUAL_MACHINE
 	nodePolicy := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
-	nodePolicy[proto.ActionItemDTO_MOVE] = notSupported
 	nodePolicy[proto.ActionItemDTO_PROVISION] = supported
 	nodePolicy[proto.ActionItemDTO_RIGHT_SIZE] = notSupported
 	nodePolicy[proto.ActionItemDTO_SUSPEND] = supported

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -67,7 +67,6 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 	expected_app[suspend] = recommend
 
 	expected_node := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
-	expected_node[move] = notSupported
 	expected_node[resize] = notSupported
 	expected_node[provision] = supported
 	expected_node[suspend] = supported

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/stretchr/testify/assert
 # github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
-# github.com/turbonomic/turbo-go-sdk v6.3.1-0.20190628213717-579ca3a8764e+incompatible
+# github.com/turbonomic/turbo-go-sdk v6.4.1-0.20190628213717-579ca3a8764e+incompatible
 github.com/turbonomic/turbo-go-sdk/pkg/probe
 github.com/turbonomic/turbo-go-sdk/pkg/service
 github.com/turbonomic/turbo-go-sdk/pkg/proto


### PR DESCRIPTION
This pull request
* Remove the `NOT_SUPPORTED` settings of Move action capability for `VIRTUAL_MACHINE` entity type. Otherwise, VM move will be disabled in a vCenter stitched environment with the current implementation of action capability resolution in XL Platform. In any case, there is no need for `kubeturbo` to set Move action capability for VM, and it should definitely not be set to `NOT_SUPPORTED`
* Update `turbo-go-sdk` version