### PR TITLE
OM-50212: Create a static group for master nodes

### DIFF
--- a/pkg/discovery/dtofactory/group_dto_builder.go
+++ b/pkg/discovery/dtofactory/group_dto_builder.go
@@ -82,7 +82,7 @@ func (builder *groupDTOBuilder) BuildGroupDTOs() []*proto.GroupDTO {
 			// group resize policy - currently only for stateful sets
 			_, exists := CONSISTENT_RESIZE_GROUPS[entityGroup.ParentKind]
 			if exists && entityGroup.ParentName != "" {
-				glog.V(3).Infof("%s: set group to resize consistently\n", entityGroup.GroupId)
+				glog.V(4).Infof("%s: set group to resize consistently\n", entityGroup.GroupId)
 				groupBuilder.ResizeConsistently()
 			}
 

--- a/pkg/discovery/dtofactory/master_nodes_group_dto_builder.go
+++ b/pkg/discovery/dtofactory/master_nodes_group_dto_builder.go
@@ -1,0 +1,61 @@
+package dtofactory
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/turbonomic/turbo-go-sdk/pkg/builder/group"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+type masterNodesGroupDTOBuilder struct {
+	cluster  *repository.ClusterSummary
+	targetId string
+}
+
+func NewMasterNodesGroupDTOBuilder(cluster *repository.ClusterSummary,
+	targetId string) *masterNodesGroupDTOBuilder {
+	return &masterNodesGroupDTOBuilder{
+		cluster:  cluster,
+		targetId: targetId,
+	}
+}
+
+func (builder *masterNodesGroupDTOBuilder) Build() *proto.GroupDTO {
+	var masterNodes []string
+
+	nodes := builder.cluster.NodeList
+	for _, node := range nodes {
+		if util.NodeIsMaster(node) {
+			nodeID := string(node.UID)
+			masterNodes = append(masterNodes, nodeID)
+		}
+	}
+
+	if len(masterNodes) == 0 {
+		glog.Errorf("Master nodes not detected, cannot create group")
+		return nil
+	}
+
+	// static group
+	// group id created using the parent type, name and target identifier
+	groupId := "KubeMasterNodes"
+	id := fmt.Sprintf("%s-%s", groupId, builder.targetId)
+
+	displayName := fmt.Sprintf("%s[%s]",
+		groupId, builder.targetId)
+
+	groupBuilder := group.StaticGroup(id).
+		WithDisplayName(displayName).
+		OfType(proto.EntityDTO_VIRTUAL_MACHINE).
+		WithEntities(masterNodes)
+	groupDTO, err := groupBuilder.Build()
+	if err != nil {
+		glog.Errorf("Error creating master nodes group dto  %s::%s", id, err)
+	}
+
+	glog.V(3).Infof("Master nodes group %++v\n", groupDTO)
+
+	return groupDTO
+}

--- a/pkg/discovery/dtofactory/master_nodes_group_dto_builder.go
+++ b/pkg/discovery/dtofactory/master_nodes_group_dto_builder.go
@@ -43,8 +43,7 @@ func (builder *masterNodesGroupDTOBuilder) Build() *proto.GroupDTO {
 	groupId := "KubeMasterNodes"
 	id := fmt.Sprintf("%s-%s", groupId, builder.targetId)
 
-	displayName := fmt.Sprintf("%s[%s]",
-		groupId, builder.targetId)
+	displayName := fmt.Sprintf("%s[%s]", groupId, builder.targetId)
 
 	groupBuilder := group.StaticGroup(id).
 		WithDisplayName(displayName).

--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -26,9 +26,9 @@ func Newk8sEntityGroupDiscoveryWorker(cluster *repository.ClusterSummary,
 	}
 }
 
-// Group discovery worker collects groups discovered by different discovery workers.
-// It merges the group members belonging to the same group but discovered by different workers.
-// Then it creates DTOs for the groups to be sent to the server.
+// Group discovery worker collects pod and container groups discovered by different discovery workers.
+// It merges the group members belonging to the same group but discovered by different discovery workers.
+// Then it creates DTOs for the pod/container groups to be sent to the server.
 func (worker *k8sEntityGroupDiscoveryWorker) Do(entityGroupList []*repository.EntityGroup,
 ) ([]*proto.GroupDTO, error) {
 	var groupDTOs []*proto.GroupDTO
@@ -60,10 +60,18 @@ func (worker *k8sEntityGroupDiscoveryWorker) Do(entityGroupList []*repository.En
 		return nil, err
 	}
 	groupDTOs = groupDtoBuilder.BuildGroupDTOs()
+
 	// Create DTO for cluster
 	clusterDTO := dtofactory.NewClusterDTOBuilder(worker.cluster, worker.targetId).Build()
 	if clusterDTO != nil {
 		groupDTOs = append(groupDTOs, clusterDTO)
 	}
+
+	// Create a static group for Master Nodes
+	masterNodesGroupDTO := dtofactory.NewMasterNodesGroupDTOBuilder(worker.cluster, worker.targetId).Build()
+	if masterNodesGroupDTO != nil {
+		groupDTOs = append(groupDTOs, masterNodesGroupDTO)
+	}
+
 	return groupDTOs, nil
 }


### PR DESCRIPTION
Create a static group of master nodes in a kubernetes cluster.
Master nodes will be detected using node name patterns or role descriptors.
Group is identified using the target Id, since Turbonomic server can manage multiple kubernetes clusters.