### PR TITLE
OM-50212: Create a static group for master nodes. 

### DIFF
--- a/pkg/discovery/dtofactory/group_dto_builder.go
+++ b/pkg/discovery/dtofactory/group_dto_builder.go
@@ -83,7 +83,7 @@ func (builder *groupDTOBuilder) BuildGroupDTOs() ([]*proto.GroupDTO, error) {
 			// group resize policy - currently only for stateful sets
 			_, exists := CONSISTENT_RESIZE_GROUPS[entityGroup.ParentKind]
 			if exists && entityGroup.ParentName != "" {
-				glog.V(3).Infof("%s: set group to resize consistently\n", entityGroup.GroupId)
+				glog.V(4).Infof("%s: set group to resize consistently\n", entityGroup.GroupId)
 				groupBuilder.ResizeConsistently()
 			}
 

--- a/pkg/discovery/dtofactory/master_nodes_group_dto_builder.go
+++ b/pkg/discovery/dtofactory/master_nodes_group_dto_builder.go
@@ -1,0 +1,60 @@
+package dtofactory
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/turbonomic/turbo-go-sdk/pkg/builder/group"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+type masterNodesGroupDTOBuilder struct {
+	cluster  *repository.ClusterSummary
+	targetId string
+}
+
+func NewMasterNodesGroupDTOBuilder(cluster *repository.ClusterSummary,
+	targetId string) *masterNodesGroupDTOBuilder {
+	return &masterNodesGroupDTOBuilder{
+		cluster:  cluster,
+		targetId: targetId,
+	}
+}
+
+func (builder *masterNodesGroupDTOBuilder) Build() *proto.GroupDTO {
+	var masterNodes []string
+
+	nodes := builder.cluster.NodeList
+	for _, node := range nodes {
+		if util.NodeIsMaster(node) {
+			nodeID := string(node.UID)
+			masterNodes = append(masterNodes, nodeID)
+		}
+	}
+
+	if len(masterNodes) == 0 {
+		glog.Errorf("Master nodes not detected, cannot create group")
+		return nil
+	}
+
+	// static group
+	// group id created using the parent type, name and target identifier
+	groupId := "MasterNodes"
+	id := fmt.Sprintf("%s-%s", groupId, builder.targetId)
+
+	displayName := fmt.Sprintf("%s[%s]", groupId, builder.targetId)
+
+	groupBuilder := group.StaticGroup(id).
+		WithDisplayName(displayName).
+		OfType(proto.EntityDTO_VIRTUAL_MACHINE).
+		WithEntities(masterNodes)
+	groupDTO, err := groupBuilder.Build()
+	if err != nil {
+		glog.Errorf("Error creating master nodes group dto  %s::%s", id, err)
+	}
+
+	glog.V(3).Infof("Master nodes group %++v\n", groupDTO)
+
+	return groupDTO
+}

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -89,7 +89,7 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) ([]*prot
 			nodeActive = false
 		}
 
-		controllable := util.NodeIsControllable(node)
+		controllable := true
 		entityDTOBuilder = entityDTOBuilder.ConsumerPolicy(&proto.EntityDTO_ConsumerPolicy{
 			Controllable: &controllable,
 		})

--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -61,5 +61,12 @@ func (worker *k8sEntityGroupDiscoveryWorker) Do(entityGroupList []*repository.En
 	}
 
 	groupDtos, _ = groupDtoBuilder.BuildGroupDTOs()
+
+	// Create a static group for Master Nodes
+	masterNodesGroupDTO := dtofactory.NewMasterNodesGroupDTOBuilder(worker.Cluster, worker.targetId).Build()
+	if masterNodesGroupDTO != nil {
+		groupDtos = append(groupDtos, masterNodesGroupDTO)
+	}
+
 	return groupDtos, nil
 }


### PR DESCRIPTION
Create a static group of master nodes in a kubernetes cluster.
Master nodes will be detected using node name patterns or role descriptors.
Group is identified using the target Id, since Turbonomic server can manage multiple kubernetes clusters.
In addition, Master nodes are marked controllable=true to permit move recommendations in turbo server.