### PR TITLE
Fix incorrect logging

### DIFF
--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -89,7 +89,7 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) ([]*prot
 		cacheUsedMetric := metrics.GenerateEntityStateMetricUID(metrics.NodeType, util.NodeKeyFunc(node), "NodeCacheUsed")
 		present, _ := builder.metricsSink.GetMetric(cacheUsedMetric)
 		if present != nil {
-			glog.Errorf("We have used the cached data, so the node %s appeared to be flaky", node)
+			glog.Errorf("We have used the cached data, so the node %s appeared to be flaky", displayName)
 			nodeActive = false
 		}
 


### PR DESCRIPTION
Error log is incorrect:
`W0913 17:02:08.321060       1 node_entity_dto_builder.go:62] the NodeIsReady marked node as-kube-node-4 as inactive
E0913 17:02:08.321170       1 node_entity_dto_builder.go:92] We have used the cached data, so the node &Node{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:as-kube-node-4,GenerateName:,Namespace:,SelfLink:/api/v1/nodes/as-kube-node-4,UID:d5929e1a-5d5b-11e8-b715-005056b8146c,ResourceVersion:60479784,Generation:0,CreationTimestamp:2018-05-22 01:02:44 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{beta.kubernetes.io/arch: amd64,beta.kubernetes.io/os: linux,kubernetes.io/hostname: as-kube-node-4,},Annotations:map[string]string{csi.volume.kubernetes.io/nodeid: {"storageos":"95034360-5f3f-d5f8-8223-021e583c596a"},node.alpha.kubernetes.io/ttl: 0,volumes.kubernetes.io/controller-managed-attach-detach: true,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:NodeSpec{PodCIDR:,DoNotUse_ExternalID:as-kube-node-4,ProviderID:,Unschedulable:true,Taints:[{node.kubernetes.io/unschedulable  NoSchedule 2019-09-12 18:54:20 +0000 UTC} {node.kubernetes.io/unreachable  NoSchedule 2019-09-13 17:01:56 +0000 UTC} {node.kubernetes.io/unreachable  NoExecute 2019-09-13 17:02:02 +0000 UTC}],ConfigSource:nil,},Status:NodeStatus{Capacity:ResourceList{attachable-volumes-azure-disk: {{16 0} {<nil>} 16 DecimalSI},cpu: {{2 0} {<nil>} 2 DecimalSI},ephemeral-storage: {{30810906624 0} {<nil>}  BinarySI},hugepages-2Mi: {{0 0} {<nil>} 0 DecimalSI},memory: {{16823046144 0} {<nil>} 16428756Ki BinarySI},pods: {{110 0} {<nil>} 110 DecimalSI},},Allocatable:ResourceList{attachable-volumes-azure-disk: {{16 0} {<nil>} 16 DecimalSI},cpu: {{2 0} {<nil>} 2 DecimalSI},ephemeral-storage: {{27729815916 0} {<nil>} 27729815916 DecimalSI},hugepages-2Mi: {{0 0} {<nil>} 0 DecimalSI},memory: {{16718188544 0} {<nil>} 16326356Ki BinarySI},pods: {{110 0} {<nil>} 110 DecimalSI},},Phase:,Conditions:[{MemoryPressure Unknown 2019-09-13 17:01:16 +0000 UTC 2019-09-13 17:01:56 +0000 UTC NodeStatusUnknown Kubelet stopped posting node status.} {DiskPressure Unknown 2019-09-13 17:01:16 +0000 UTC 2019-09-13 17:01:56 +0000 UTC NodeStatusUnknown Kubelet stopped posting node status.} {PIDPressure Unknown 2019-09-13 17:01:16 +0000 UTC 2019-09-13 17:01:56 +0000 UTC NodeStatusUnknown Kubelet stopped posting node status.} {Ready Unknown 2019-09-13 17:01:16 +0000 UTC 2019-09-13 17:01:56 +0000 UTC NodeStatusUnknown Kubelet stopped posting node status.} {OutOfDisk Unknown 2018-05-22 01:02:44 +0000 UTC 2019-09-13 17:01:56 +0000 UTC NodeStatusNeverUpdated Kubelet never posted node status.}],Addresses:[{InternalIP 10.10.174.119} {Hostname as-kube-node-4}],DaemonEndpoints:NodeDaemonEndpoints{KubeletEndpoint:DaemonEndpoint{Port:10250,},},NodeInfo:NodeSystemInfo{MachineID:579abb15172b4e6aa1ad0f3c4003e065,SystemUUID:42385C43-28E7-A89C-E233-1F97F7C4969D,BootID:8df67ba2-a7fb-49a1-a1f5-d8c6e9e8e51d,KernelVersion:4.16.7-coreos,OSImage:Container Linux by CoreOS 1772.0.0 (Rhyolite),ContainerRuntimeVersion:docker://18.4.0,KubeletVersion:v1.13.4,KubeProxyVersion:v1.13.4,OperatingSystem:linux,Architecture:amd64,},Images:[{[storageos/node@sha256:5d92b38979aef31a8f76dbdb6ad1c2e2ad7ea5262c61a65eb59b0416342b46ee storageos/node:1.4.0] 1146407642} {[gcr.io/google_containers/hyperkube@sha256:7837c4d98642378841cb5abf43ea9c841f6adba3d9c8c13f0eecb4766ad0bfb0 gcr.io/google_containers/hyperkube:v1.13.4] 564948754} {[storageos/init@sha256:61870f010d5034de7ca4a668f264e6eda2f24de55bdaaf0ec6b23d739fd0f2f2 storageos/init:1.0.0] 342504880} {[turbonomic/kubeturbo@sha256:be53e755eeed0118f94a0ac5ee332ca4e3ea6e4ad74156224a84b0e2be761692 turbonomic/kubeturbo:6.4.0] 315789172} {[quay.io/calico/node@sha256:19fdccdd4a90c4eb0301b280b50389a56e737e2349828d06c7ab397311638d29 quay.io/calico/node:v3.1.1] 248181151} {[ading1977/kubeturbo@sha256:178b19ae7894bd30588c4dcc62034644647f8598062a6315a9c44cbd10409078 ading1977/kubeturbo:6.4dev] 97544906} {[ading1977/kubeturbo@sha256:486bd7b6689252ab6b81935d9f91fc02da89b4d19d89ddea683754a24b802445 ading1977/kubeturbo:6.4.2] 97518972} {[ading1977/kubeturbo@sha256:0ccdaafb8fa39e4c6f63ae1e620e245bd06295d50979451cbc3f7480632fdd5b] 97510420} {[ading1977/kubeturbo@sha256:95d7666141b84f209bb5d57fa7da56762c3484a999e12d8e6bfb229bab68a26c] 97510218} {[k8s.gcr.io/kube-proxy@sha256:e57fd7593e2bdc161e41b8922e5fba6dbdab790608fc8671721eb26fbabd3090 k8s.gcr.io/kube-proxy:v1.13.4] 80253150} {[quay.io/calico/cni@sha256:dc345458d136ad9b4d01864705895e26692d2356de5c96197abff0030bf033eb quay.io/calico/cni:v3.1.1] 68844820} {[quay.io/calico/kube-controllers@sha256:6f0435a7e300599de826989fc5628dd7c43336d0f42e9520e1dec9914e951368 quay.io/calico/kube-controllers:v3.1.1] 54980970} {[k8s.gcr.io/pause-amd64@sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610 k8s.gcr.io/pause@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea k8s.gcr.io/pause-amd64:3.1 k8s.gcr.io/pause:3.1] 742472}],VolumesInUse:[],VolumesAttached:[],Config:nil,},} appeared to be flaky`

After the fix:

`E0913 17:28:08.122465       1 node_entity_dto_builder.go:92] We have used the cached data, so the node as-kube-node-4 appeared to be flaky
`