### PR TITLE
Update turbo-go-sdk dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.2.2
 	github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 // indirect
-	github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible
+	github.com/turbonomic/turbo-go-sdk v6.4.1+incompatible
 	go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 // indirect
 	go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df // indirect
 	go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 h1:xfnOa96E4g6MRfLPSVyL4Aprmxf8NBjsUyqUoW0VnIs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible h1:sL9P8YlheUU/Cn2o/3r9G2AVH24rtBvYd6EO9bOgh1E=
-github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
+github.com/turbonomic/turbo-go-sdk v6.4.1+incompatible h1:cl81DizNxhT3lQ6DlaogvWEDwKAn441qC5V67Y7X+8A=
+github.com/turbonomic/turbo-go-sdk v6.4.1+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 h1:nSQar3Y0E3VQF/VdZ8PTAilaXpER+d7ypdABCrpwMdg=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df h1:shvkWr0NAZkg4nPuE3XrKP0VuBPijjk3TfX6Y6acFNg=

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
@@ -47,6 +47,10 @@ func CreateWebSocketConnectionConfig(connConfig *MediationContainerConfig) (*Web
 	}
 	wsConfig := WebSocketConnectionConfig(*connConfig)
 	wsConfig.TurboServer = serverURL.String()
+	// If the path specified for the platform use it instead of assuming the default /vmturbo/remoteMediation
+	if serverURL.Path != "" && serverURL.Path != "/" {
+		wsConfig.WebSocketPath = ""
+	}
 	return &wsConfig, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/stretchr/testify/assert
 # github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
-# github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible
+# github.com/turbonomic/turbo-go-sdk v6.4.1+incompatible
 github.com/turbonomic/turbo-go-sdk/pkg/probe
 github.com/turbonomic/turbo-go-sdk/pkg/service
 github.com/turbonomic/turbo-go-sdk/pkg/proto


### PR DESCRIPTION
Update turbo-go-sdk dependency for preparation of kubeturbo 6.4.1 release.