### PR TITLE
Create HA node group and policy based on HANodeConfig policy in the configmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.2.2
 	github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 // indirect
-	github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible
+	github.com/turbonomic/turbo-go-sdk v6.4.1-0.20190919201535-c2695c1fd85c+incompatible
 	go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 // indirect
 	go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df // indirect
 	go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 h1:xfnOa96E4g6MRfLPSVyL4Aprmxf8NBjsUyqUoW0VnIs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible h1:sL9P8YlheUU/Cn2o/3r9G2AVH24rtBvYd6EO9bOgh1E=
-github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
+github.com/turbonomic/turbo-go-sdk v6.4.1-0.20190919201535-c2695c1fd85c+incompatible h1:6hhYXTdnvFpTDwdns0/RpuhcJxs5hG3eZRfrnFTZQI4=
+github.com/turbonomic/turbo-go-sdk v6.4.1-0.20190919201535-c2695c1fd85c+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 h1:nSQar3Y0E3VQF/VdZ8PTAilaXpER+d7ypdABCrpwMdg=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df h1:shvkWr0NAZkg4nPuE3XrKP0VuBPijjk3TfX6Y6acFNg=

--- a/pkg/discovery/dtofactory/ha_nodes_group_dto_builder.go
+++ b/pkg/discovery/dtofactory/ha_nodes_group_dto_builder.go
@@ -1,0 +1,90 @@
+package dtofactory
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/turbo-go-sdk/pkg/builder/group"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"strings"
+)
+
+// There are two node labels that can be used to specify node roles:
+// 1. node-role.kubernetes.io/<role-name>=
+// 2. kubernetes.io/role=<role-name>
+const (
+	// labelNodeRolePrefix is a label prefix for node roles
+	labelNodeRolePrefix = "node-role.kubernetes.io/"
+	// nodeLabelRole specifies the role of a node
+	nodeLabelRole = "kubernetes.io/role"
+)
+
+type HANodesGroupDTOBuilder struct {
+	cluster  *repository.ClusterSummary
+	targetId string
+}
+
+func NewHANodesGroupDTOBuilder(cluster *repository.ClusterSummary,
+	targetId string) *HANodesGroupDTOBuilder {
+	return &HANodesGroupDTOBuilder{
+		cluster:  cluster,
+		targetId: targetId,
+	}
+}
+
+func (builder *HANodesGroupDTOBuilder) Build() []*proto.GroupDTO {
+	if len(detectors.HANodeRoles) == 0 {
+		glog.Infof("HA node groups not specified.")
+		return nil
+	}
+	HANodeGroups := builder.buildHANodeGroups()
+	if len(HANodeGroups) == 0 {
+		glog.Infof("HA node groups not detected.")
+		return nil
+	}
+	var groupDTOs []*proto.GroupDTO
+	for role, members := range HANodeGroups {
+		groupID := fmt.Sprintf("HANodes-%s-%s", role, builder.targetId)
+		displayName := fmt.Sprintf("HANodes::%s [%s]", role, builder.targetId)
+		groupDTO, err := group.DoNotPlaceTogether(groupID).
+			WithDisplayName(displayName).
+			OnSellerType(proto.EntityDTO_PHYSICAL_MACHINE).
+			WithBuyers(group.StaticBuyers(members).OfType(proto.EntityDTO_VIRTUAL_MACHINE).AtMost(1)).
+			Build()
+		if err != nil {
+			glog.Errorf("Failed to build DTO for HA node group %s: %v", groupID, err)
+			continue
+		}
+		glog.V(3).Infof("HA node group: %+v", groupDTO)
+		groupDTOs = append(groupDTOs, groupDTO...)
+	}
+	return groupDTOs
+}
+
+// buildHANodeGroups constructs a nodeRole -> nodeList map
+// This needs to be done for every discovery as node roles can change
+func (builder *HANodesGroupDTOBuilder) buildHANodeGroups() map[string][]string {
+	HANodeGroups := map[string][]string{}
+	for _, node := range builder.cluster.NodeList {
+		// Parse all roles of a node, and add them to a set
+		allRoles := sets.NewString()
+		for k, v := range node.Labels {
+			switch {
+			case strings.HasPrefix(k, labelNodeRolePrefix):
+				if role := strings.TrimPrefix(k, labelNodeRolePrefix); len(role) > 0 {
+					allRoles.Insert(role)
+				}
+			case k == nodeLabelRole && v != "":
+				allRoles.Insert(v)
+			}
+		}
+		// Get the roles that are defined as HA roles
+		HARoles := allRoles.Intersection(detectors.HANodeRoles)
+		for _, HARole := range HARoles.List() {
+			HANodeGroups[HARole] = append(HANodeGroups[HARole], string(node.UID))
+		}
+	}
+	return HANodeGroups
+}

--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -62,11 +62,11 @@ func (worker *k8sEntityGroupDiscoveryWorker) Do(entityGroupList []*repository.En
 
 	groupDtos, _ = groupDtoBuilder.BuildGroupDTOs()
 
-	// Create a static group for Master Nodes
-	masterNodesGroupDTO := dtofactory.NewMasterNodesGroupDTOBuilder(worker.Cluster, worker.targetId).Build()
-	if masterNodesGroupDTO != nil {
-		groupDtos = append(groupDtos, masterNodesGroupDTO)
-	}
+	// Create static groups for HA Nodes
+	HANodeGroupDTOs := dtofactory.
+		NewHANodesGroupDTOBuilder(worker.Cluster, worker.targetId).
+		Build()
+	groupDtos = append(groupDtos, HANodeGroupDTOs...)
 
 	return groupDtos, nil
 }

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -28,6 +28,7 @@ type K8sTAPServiceSpec struct {
 	*configs.K8sTargetConfig          `json:"targetConfig,omitempty"`
 	*detectors.MasterNodeDetectors    `json:"masterNodeDetectors,omitempty"`
 	*detectors.DaemonPodDetectors     `json:"daemonPodDetectors,omitempty"`
+	*detectors.HANodeConfig           `json:"HANodeConfig,omitempty"`
 }
 
 func ParseK8sTAPServiceSpec(configFile, defaultTargetName string) (*K8sTAPServiceSpec, error) {
@@ -54,9 +55,11 @@ func ParseK8sTAPServiceSpec(configFile, defaultTargetName string) (*K8sTAPServic
 	if err := tapSpec.ValidateK8sTargetConfig(); err != nil {
 		return nil, err
 	}
-	if err := detectors.ValidateAndParseDetectors(tapSpec.MasterNodeDetectors, tapSpec.DaemonPodDetectors); err != nil {
-		return nil, err
-	}
+
+	// This function aborts the program upon fatal error
+	detectors.ValidateAndParseDetectors(tapSpec.MasterNodeDetectors,
+		tapSpec.DaemonPodDetectors, tapSpec.HANodeConfig)
+
 	return tapSpec, nil
 }
 

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/cluster_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/cluster_builder.go
@@ -1,0 +1,37 @@
+package group
+
+import "github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
+type ClusterBuilder struct {
+	*AbstractConstraintGroupBuilder
+}
+
+// Cluster is the builder for a group with Cluster constraint
+func Cluster(id string) *ClusterBuilder {
+	return &ClusterBuilder{
+		&AbstractConstraintGroupBuilder{
+			StaticGroup(id),
+			newConstraintBuilder(proto.GroupDTO_CLUSTER, id),
+		},
+	}
+}
+
+func (c *ClusterBuilder) OfType(eType proto.EntityDTO_EntityType) *ClusterBuilder {
+	c.AbstractBuilder.OfType(eType)
+	return c
+}
+
+func (c *ClusterBuilder) WithEntities(entities []string) *ClusterBuilder {
+	c.AbstractBuilder.WithEntities(entities)
+	return c
+}
+
+func (c *ClusterBuilder) WithDisplayName(displayName string) *ClusterBuilder {
+	c.AbstractBuilder.WithDisplayName(displayName)
+	c.ConstraintInfoBuilder.WithDisplayName(displayName)
+	return c
+}
+
+func (c *ClusterBuilder) Build() (*proto.GroupDTO, error) {
+	return c.AbstractConstraintGroupBuilder.Build()
+}

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/constraint_group_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/constraint_group_builder.go
@@ -1,0 +1,123 @@
+package group
+
+import (
+	"fmt"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+// ConstraintInfoBuilder is the builder for the constraint info data in a Group DTO
+type ConstraintInfoBuilder struct {
+	constraintType        proto.GroupDTO_ConstraintType
+	constraintId          string
+	constraintName        string
+	constraintDisplayName string
+	providerTypePtr       *proto.EntityDTO_EntityType
+	isBuyer               bool
+
+	maxBuyers int32
+}
+
+func newConstraintBuilder(constraintType proto.GroupDTO_ConstraintType, constraintId string) *ConstraintInfoBuilder {
+
+	return &ConstraintInfoBuilder{
+		constraintId:          constraintId,
+		constraintName:        constraintId, // default name as the id
+		constraintDisplayName: constraintId, // default display name as the id
+		constraintType:        constraintType,
+	}
+}
+
+func (constraintInfoBuilder *ConstraintInfoBuilder) WithName(constraintName string) *ConstraintInfoBuilder {
+	constraintInfoBuilder.constraintName = constraintName
+	return constraintInfoBuilder
+}
+
+func (constraintInfoBuilder *ConstraintInfoBuilder) WithDisplayName(constraintDisplayName string) *ConstraintInfoBuilder {
+	constraintInfoBuilder.constraintDisplayName = constraintDisplayName
+	return constraintInfoBuilder
+}
+
+// Set the entity type of the seller group for the buyer entities
+func (constraintInfoBuilder *ConstraintInfoBuilder) WithSellerType(providerType proto.EntityDTO_EntityType) *ConstraintInfoBuilder {
+	constraintInfoBuilder.providerTypePtr = &providerType
+	return constraintInfoBuilder
+}
+
+// Set the maximum number of buyer entities allowed in the policy
+func (constraintInfoBuilder *ConstraintInfoBuilder) AtMostBuyers(maxBuyers int32) *ConstraintInfoBuilder {
+	constraintInfoBuilder.maxBuyers = maxBuyers
+	return constraintInfoBuilder
+}
+
+// Build the ConstraintInfo DTO
+func (constraintInfoBuilder *ConstraintInfoBuilder) Build() (*proto.GroupDTO_ConstraintInfo, error) {
+	constraintInfo := &proto.GroupDTO_ConstraintInfo{
+		ConstraintId:          &constraintInfoBuilder.constraintId,
+		ConstraintType:        &constraintInfoBuilder.constraintType,
+		ConstraintName:        &constraintInfoBuilder.constraintName,
+		ConstraintDisplayName: &constraintInfoBuilder.constraintDisplayName,
+	}
+
+	if constraintInfoBuilder.isBuyer {
+		// buyer group specific metadata
+		constraintInfo.BuyerMetaData = &proto.GroupDTO_BuyerMetaData{}
+		boolVal := true
+		constraintInfo.IsBuyer = &boolVal
+		// seller entity type should be provided for buyer seller policies
+		setProvider := (constraintInfoBuilder.constraintType == proto.GroupDTO_BUYER_SELLER_AFFINITY) ||
+			(constraintInfoBuilder.constraintType == proto.GroupDTO_BUYER_SELLER_ANTI_AFFINITY)
+		if setProvider && constraintInfoBuilder.providerTypePtr == nil {
+			return nil, fmt.Errorf("seller type required")
+		}
+		constraintInfo.BuyerMetaData.SellerType = constraintInfoBuilder.providerTypePtr
+		// max buyers allowed
+		if constraintInfoBuilder.maxBuyers > 0 {
+			constraintInfo.BuyerMetaData.AtMost = &constraintInfoBuilder.maxBuyers
+		}
+	}
+
+	// seller group specific metadata
+	needsComplementary := constraintInfoBuilder.constraintType == proto.GroupDTO_BUYER_SELLER_ANTI_AFFINITY
+	constraintInfo.NeedComplementary = &needsComplementary
+
+	return constraintInfo, nil
+}
+
+// AbstractConstraintGroupBuilder is the builder of a Group with constraint
+type AbstractConstraintGroupBuilder struct {
+	*AbstractBuilder
+	*ConstraintInfoBuilder
+}
+
+// Build policy group with Constraint Info
+func (groupBuilder *AbstractConstraintGroupBuilder) Build() (*proto.GroupDTO, error) {
+
+	groupDTO, err := groupBuilder.AbstractBuilder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build group: %v", err)
+	}
+
+	var constraintInfo *proto.GroupDTO_ConstraintInfo
+	constraintInfo, err = groupBuilder.ConstraintInfoBuilder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build group constraint: %v", err)
+	}
+
+	if groupBuilder.constraintType == proto.GroupDTO_CLUSTER {
+		entityType := *groupBuilder.entityTypePtr
+		if entityType != proto.EntityDTO_VIRTUAL_MACHINE &&
+			entityType != proto.EntityDTO_PHYSICAL_MACHINE &&
+			entityType != proto.EntityDTO_STORAGE {
+			return nil, fmt.Errorf("failed to build cluster: unsupported entity type %v", entityType)
+		}
+	}
+
+	// set constraint info in the group DTO
+	info := &proto.GroupDTO_ConstraintInfo_{
+		ConstraintInfo: constraintInfo,
+	}
+
+	groupDTO.Info = info
+
+	return groupDTO, nil
+}

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/group_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/group/group_builder.go
@@ -91,7 +91,7 @@ func (groupBuilder *AbstractBuilder) Build() (*proto.GroupDTO, error) {
 	groupDTO.IsConsistentResizing = &groupBuilder.consistentResize
 
 	if groupBuilder.ec.Count() > 0 {
-		glog.Errorf("GroupBuilder Error %s : %s\n", groupBuilder.groupId, groupBuilder.ec.Error())
+		glog.Errorf("%s : %s", groupBuilder.groupId, groupBuilder.ec.Error())
 		return nil, fmt.Errorf("%s: %s", groupBuilder.groupId, groupBuilder.ec.Error())
 	}
 
@@ -114,7 +114,7 @@ func (groupBuilder *AbstractBuilder) OfType(eType proto.EntityDTO_EntityType) *A
 
 	// Check entity type
 	if groupBuilder.entityTypePtr != nil && *groupBuilder.entityTypePtr != eType {
-		groupBuilder.ec.Collect(fmt.Errorf("Cannot add members, input EntityType - %s is not consistent with existing EntityType %s ",
+		groupBuilder.ec.Collect(fmt.Errorf("cannot add members, input entityType %v is not consistent with existing entityType %v",
 			eType, *groupBuilder.entityTypePtr))
 		return groupBuilder
 	}
@@ -127,14 +127,14 @@ func (groupBuilder *AbstractBuilder) OfType(eType proto.EntityDTO_EntityType) *A
 
 func (groupBuilder *AbstractBuilder) setupEntityType(groupDTO *proto.GroupDTO) error {
 	if groupBuilder.entityTypePtr == nil {
-		return fmt.Errorf("Entity type is not set")
+		return fmt.Errorf("entity type is not set")
 	}
 	// Validate entity type
 	entityType := *groupBuilder.entityTypePtr
 	_, valid := proto.EntityDTO_EntityType_name[int32(entityType)]
 
 	if !valid {
-		return fmt.Errorf("Invalid entity type %v\n", entityType)
+		return fmt.Errorf("invalid entity type %v", entityType)
 	}
 
 	// Setup entity type
@@ -147,7 +147,7 @@ func (groupBuilder *AbstractBuilder) WithEntities(entities []string) *AbstractBu
 
 	// Assert that the group is a static group
 	if groupBuilder.groupType != STATIC_GROUP {
-		groupBuilder.ec.Collect(fmt.Errorf("Cannot set member uuid list for dynamic group"))
+		groupBuilder.ec.Collect(fmt.Errorf("cannot set member uuid list for dynamic group"))
 		return groupBuilder
 	}
 	groupBuilder.memberList = entities
@@ -158,7 +158,7 @@ func (groupBuilder *AbstractBuilder) WithEntities(entities []string) *AbstractBu
 func (groupBuilder *AbstractBuilder) setUpStaticMembers(groupDTO *proto.GroupDTO) error {
 
 	if len(groupBuilder.memberList) == 0 {
-		return fmt.Errorf("Empty member list")
+		return fmt.Errorf("empty member list")
 	}
 
 	// Set the Group DTO member field
@@ -176,7 +176,7 @@ func (groupBuilder *AbstractBuilder) MatchingEntities(matching *Matching) *Abstr
 
 	// Assert that the group is a dynamci group
 	if groupBuilder.groupType != DYNAMIC_GROUP {
-		groupBuilder.ec.Collect(fmt.Errorf("Cannot set matching criteria for static group"))
+		groupBuilder.ec.Collect(fmt.Errorf("cannot set matching criteria for static group"))
 		return groupBuilder
 	}
 	groupBuilder.matching = matching
@@ -187,7 +187,7 @@ func (groupBuilder *AbstractBuilder) MatchingEntities(matching *Matching) *Abstr
 func (groupBuilder *AbstractBuilder) setUpDynamicGroup(groupDTO *proto.GroupDTO) error {
 
 	if groupBuilder.matching == nil {
-		return fmt.Errorf("Null matching criteria for member selection")
+		return fmt.Errorf("null matching criteria for member selection")
 	}
 
 	var selectionSpecList []*proto.GroupDTO_SelectionSpec

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
@@ -47,6 +47,10 @@ func CreateWebSocketConnectionConfig(connConfig *MediationContainerConfig) (*Web
 	}
 	wsConfig := WebSocketConnectionConfig(*connConfig)
 	wsConfig.TurboServer = serverURL.String()
+	// If the path specified for the platform use it instead of assuming the default /vmturbo/remoteMediation
+	if serverURL.Path != "" && serverURL.Path != "/" {
+		wsConfig.WebSocketPath = ""
+	}
 	return &wsConfig, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/stretchr/testify/assert
 # github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
-# github.com/turbonomic/turbo-go-sdk v6.4.0+incompatible
+# github.com/turbonomic/turbo-go-sdk v6.4.1-0.20190919201535-c2695c1fd85c+incompatible
 github.com/turbonomic/turbo-go-sdk/pkg/probe
 github.com/turbonomic/turbo-go-sdk/pkg/service
 github.com/turbonomic/turbo-go-sdk/pkg/proto
@@ -170,10 +170,10 @@ k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/labels
+k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/runtime
-k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/types


### PR DESCRIPTION
This pull request creates HA node groups and anti-affinity policy for those groups based on the `HANodeConfig` policy specified in the `kubeturbo` configmap, for example:

```
apiVersion: v1
data:
  turbo.config: |-
    {
...
        "HANodeConfig": {
           "nodeRoles": [ "master", "worker" ]
        },
...
    }
kind: ConfigMap

```