### PR TITLE
OM-50651: Create groups for containers by name per parent group

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -123,7 +123,7 @@ func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod) ([]*proto.E
 
 		controllable := util.Controllable(pod)
 		if !controllable {
-			glog.V(3).Infof("Pod %v is not controllable.", displayName)
+			glog.V(4).Infof("Pod %v is not controllable.", displayName)
 		}
 		daemon := util.Daemon(pod)
 		entityDTOBuilder.ConsumerPolicy(&proto.EntityDTO_ConsumerPolicy{

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -225,7 +225,7 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework() ([]*proto.EntityDTO, []
 	groupDTOs, _ := entityGroupDiscoveryWorker.Do(policyGroupList)
 
 	glog.V(2).Infof("There are totally %d groups DTOs", len(groupDTOs))
-	if glog.V(3) {
+	if glog.V(4) {
 		for _, groupDto := range groupDTOs {
 			glog.Infof("%s %s members: %+v",
 				groupDto.GetDisplayName(), groupDto.GetGroupName(),

--- a/pkg/discovery/repository/kube_policies.go
+++ b/pkg/discovery/repository/kube_policies.go
@@ -6,10 +6,11 @@ import (
 )
 
 type EntityGroup struct {
-	Members    map[metrics.DiscoveredEntityType][]string
-	ParentKind string
-	ParentName string
-	GroupId    string
+	Members         map[metrics.DiscoveredEntityType][]string
+	ParentKind      string
+	ParentName      string
+	GroupId         string
+	ContainerGroups map[string][]string
 }
 
 func NewEntityGroup(kind, name string) (*EntityGroup, error) {
@@ -21,10 +22,11 @@ func NewEntityGroup(kind, name string) (*EntityGroup, error) {
 		groupKey = fmt.Sprintf("%s::%s", kind, name)
 	}
 	return &EntityGroup{
-		GroupId:    groupKey,
-		ParentKind: kind,
-		ParentName: name,
-		Members:    make(map[metrics.DiscoveredEntityType][]string),
+		GroupId:         groupKey,
+		ParentKind:      kind,
+		ParentName:      name,
+		Members:         make(map[metrics.DiscoveredEntityType][]string),
+		ContainerGroups: make(map[string][]string),
 	}, nil
 }
 

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -58,7 +58,7 @@ func IsControllableFromAnnotation(annotations map[string]string) bool {
 func Daemon(pod *api.Pod) bool {
 	isDaemon := isPodCreatedBy(pod, Kind_DaemonSet) || detectors.IsDaemonDetected(pod.Name, pod.Namespace)
 	if isDaemon {
-		glog.V(3).Infof("Pod %s/%s is a daemon", pod.Namespace, pod.Name)
+		glog.V(4).Infof("Pod %s/%s is a daemon", pod.Namespace, pod.Name)
 	}
 	return isDaemon
 }
@@ -69,7 +69,7 @@ func Controllable(pod *api.Pod) bool {
 	controllable := !isMirrorPod(pod) && !isPodCreatedBy(pod, Kind_DaemonSet) &&
 		IsControllableFromAnnotation(pod.GetAnnotations())
 	if !controllable {
-		glog.V(3).Infof("Pod %s/%s is not controllable", pod.Namespace, pod.Name)
+		glog.V(4).Infof("Pod %s/%s is not controllable", pod.Namespace, pod.Name)
 	}
 	return controllable
 }

--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -65,7 +65,7 @@ func (worker *k8sEntityGroupDiscoveryWorker) Do(entityGroupList []*repository.En
 		}
 	}
 
-	if (glog.V(4)) {
+	if glog.V(4) {
 		for _, entityGroup := range entityGroupList {
 			glog.Infof("Group --> %s::%s\n", entityGroup.ParentKind, entityGroup.ParentName)
 			for etype, members := range entityGroup.Members {

--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
@@ -43,14 +44,36 @@ func (worker *k8sEntityGroupDiscoveryWorker) Do(entityGroupList []*repository.En
 		existingGroup, groupExists := entityGroupMap[groupId]
 
 		if groupExists {
+			// groups by entity type
 			for etype, newmembers := range entityGroup.Members {
 				members, hasMembers := existingGroup.Members[etype]
 				if hasMembers {
 					existingGroup.Members[etype] = append(members, newmembers...)
 				}
 			}
+
+			// groups by container names
+			for containerName, newMembers := range entityGroup.ContainerGroups {
+				members, hasMembers := existingGroup.ContainerGroups[containerName]
+				if hasMembers {
+					existingGroup.ContainerGroups[containerName] = append(members, newMembers...)
+				}
+			}
+
 		} else {
 			entityGroupMap[groupId] = entityGroup
+		}
+	}
+
+	if (glog.V(4)) {
+		for _, entityGroup := range entityGroupList {
+			glog.Infof("Group --> %s::%s\n", entityGroup.ParentKind, entityGroup.ParentName)
+			for etype, members := range entityGroup.Members {
+				glog.Infof("	Members: %s -> %s", etype, members)
+			}
+			for cname, members := range entityGroup.ContainerGroups {
+				glog.Infof("	Container Groups: %s -> %s", cname, members)
+			}
 		}
 	}
 


### PR DESCRIPTION
We want to set the resize policy independently for user app containers and the corresponding side car containers in the pod running the user app.
This PR handles the creation of additional container groups by container names as detected in a pod for different kinds of parent groups such as deployment, stateful sets etc.
For each parent group, there will one a container group for all the containers running in the pods belonging to this group. Additionally there will a container group for each container name found in the pod. The consistent resize is set to true for these container groups only.
Tested that the different container groups are created for deployment, stateful sets and other owner/parent types.