### PR TITLE
OM-51005 Pods in daemon sets are now controllable, in order to allow them to resize.

### DIFF
--- a/pkg/discovery/dtofactory/container_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_dto_builder_test.go
@@ -15,7 +15,7 @@ func TestPodFlags(t *testing.T) {
 	 * (controllable should be true, monitored should be true)
 	 *
 	 * Pod 1: controllable = false, monitored = true, parentKind = DaemonSet
-	 * (controllable should be false, monitored should be true)
+	 * (controllable should be true, monitored should be true)
 	 *
 	 * Pod 2: controllable = true, monitored = true, parentKind = ReplicaSet
 	 * (controllable should be true, monitored should be true)
@@ -29,7 +29,7 @@ func TestPodFlags(t *testing.T) {
 		Monitored    bool
 	}{
 		{true, true},
-		{false, true},
+		{true, true},
 		{true, true},
 		{false, true},
 	}

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -66,8 +66,7 @@ func Daemon(pod *api.Pod) bool {
 // Returns a boolean that indicates whether the given pod should be controllable.
 // Do not monitor mirror pods or pods created by DaemonSets.
 func Controllable(pod *api.Pod) bool {
-	controllable := !isMirrorPod(pod) && !isPodCreatedBy(pod, Kind_DaemonSet) &&
-		IsControllableFromAnnotation(pod.GetAnnotations())
+	controllable := !isMirrorPod(pod) && IsControllableFromAnnotation(pod.GetAnnotations())
 	if !controllable {
 		glog.V(4).Infof("Pod %s/%s is not controllable", pod.Namespace, pod.Name)
 	}

--- a/pkg/discovery/util/pod_util_test.go
+++ b/pkg/discovery/util/pod_util_test.go
@@ -215,8 +215,8 @@ func TestMirroredPod(t *testing.T) {
 	}
 
 	podInDaemonSet := makePodInDaemonSet()
-	if Controllable(podInDaemonSet) {
-		t.Errorf("Pod in daemon set cannot be controllable")
+	if !Controllable(podInDaemonSet) {
+		t.Errorf("Pod in daemon set must be controllable")
 	}
 
 	// Here is a different way to specify that a pod was created via a DaemonSet.
@@ -228,8 +228,8 @@ func TestMirroredPod(t *testing.T) {
 	ref.Reference.Name = "yes"
 	refbytes, _ := json.Marshal(&ref)
 	podInDaemonSet.ObjectMeta.Annotations["kubernetes.io/created-by"] = string(refbytes)
-	if Controllable(podInDaemonSet) {
-		t.Errorf("Pod in daemon set cannot be controllable")
+	if !Controllable(podInDaemonSet) {
+		t.Errorf("Pod in daemon set must be controllable")
 	}
 
 }


### PR DESCRIPTION
Previous to this change, pods in daemon sets were flagged as daemons and were also marked non-controllable. This prevented generation of any actions on them. This change retains the flagging of the pods as daemons (i.e., disables suspension, cloning, and moving), but makes them resizable.

Please note that now that we are shipping the kubeturbo configuration with no daemonPodDetectors defined, pods in daemon sets are the only entities that will be marked as daemons. All pods in kube-system, for example, will now be movable, suspendable, and clonable, regardless of whether that is the correct behavior. This behavior can still be changed by adding daemonPodDetectors in kubeturbo or defining a server-side policy.