### PR TITLE
Add the support for populating HANodeRole in Helm and Operator install

### DIFF
--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -30,11 +30,5 @@ data:
         "namespaces": ["{{ .Values.daemonPodDetectors.daemonPodNamespaces1 }}", "{{ .Values.daemonPodDetectors.daemonPodNamespaces2 }}"],
         "podNamePatterns": ["{{ .Values.daemonPodDetectors.daemonPodNamePatterns }}"]
       {{- end }}
-      {{- if .Values.masterNodeDetectors }}
-      },
-      "masterNodeDetectors": {
-        "nodeNamePatterns": [ "{{ .Values.masterNodeDetectors.nodeNamePatterns }}" ],
-        "nodeLabels": [ {"key": "{{ .Values.masterNodeDetectors.nodeLabelsKey }}", "value": "{{ .Values.masterNodeDetectors.nodeLabelsValue }}"} ]
-      {{- end }}
       }
     }

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -15,9 +15,8 @@ data:
           "opsManagerPassword": "{{ .Values.restAPIConfig.opsManagerPassword }}"
         }
       },
-      "masterNodeDetectors": {
-        "nodeNamePatterns": [ "{{ .Values.masterNodeDetectors.nodeNamePatterns }}" ],
-        "nodeLabels": [ {"key": "{{ .Values.masterNodeDetectors.nodeLabelsKey }}", "value": "{{ .Values.masterNodeDetectors.nodeLabelsValue }}"} ]
+      "HANodeConfig": {
+        "nodeRoles": [{{ .Values.HANodeConfig.nodeRoles }}]
       {{- if .Values.targetConfig }}
         {{- if .Values.targetConfig.targetName }}
       },
@@ -30,6 +29,12 @@ data:
       "daemonPodDetectors": {
         "namespaces": ["{{ .Values.daemonPodDetectors.daemonPodNamespaces1 }}", "{{ .Values.daemonPodDetectors.daemonPodNamespaces2 }}"],
         "podNamePatterns": ["{{ .Values.daemonPodDetectors.daemonPodNamePatterns }}"]
+      {{- end }}
+      {{- if .Values.masterNodeDetectors }}
+      },
+      "masterNodeDetectors": {
+        "nodeNamePatterns": [ "{{ .Values.masterNodeDetectors.nodeNamePatterns }}" ],
+        "nodeLabels": [ {"key": "{{ .Values.masterNodeDetectors.nodeLabelsKey }}", "value": "{{ .Values.masterNodeDetectors.nodeLabelsValue }}"} ]
       {{- end }}
       }
     }

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -29,13 +29,18 @@ restAPIConfig:
 #targetConfig:
 #  targetName: Name_Each_Cluster
 
+# In kubeturbo 6.4.3+, you can define what nodes should stay high-available based on the node role
+# Master nodes are by default populated by --set HANodeConfig.nodeRoles="\"foo\"\,\"bar\""
+HANodeConfig:
+  nodeRoles: "\"master\""
+
 # In kubeturbo 6.3+, you can define how master nodes are identified. Use either or both
 # Master nodes are not identified by default and could suspend in plans.
 # nodeLabels must provide a key value pair
-masterNodeDetectors:
-   nodeNamePatterns: .*master.*
-   nodeLabelsKey: node-role.kubernetes.io/master
-   nodeLabelsValue: .*
+#masterNodeDetectors:
+#   nodeNamePatterns: .*master.*
+#   nodeLabelsKey: node-role.kubernetes.io/master
+#   nodeLabelsValue: .*
 
 # In kubeturbo 6.3+, you can define how daemon pods are identified. Use either or both
 # Note if you do not enable daemonPodDetectors, the default is to identify all pods running as kind = daemonSet

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -5,7 +5,7 @@
 # Replace the image with desired version
 image:
   repository: turbonomic/kubeturbo
-  tag: 6.4.0
+  tag: 6.4.3
   pullPolicy: IfNotPresent
 
 #nameOverride: ""
@@ -33,14 +33,6 @@ restAPIConfig:
 # Master nodes are by default populated by --set HANodeConfig.nodeRoles="\"foo\"\,\"bar\""
 HANodeConfig:
   nodeRoles: "\"master\""
-
-# In kubeturbo 6.3+, you can define how master nodes are identified. Use either or both
-# Master nodes are not identified by default and could suspend in plans.
-# nodeLabels must provide a key value pair
-#masterNodeDetectors:
-#   nodeNamePatterns: .*master.*
-#   nodeLabelsKey: node-role.kubernetes.io/master
-#   nodeLabelsValue: .*
 
 # In kubeturbo 6.3+, you can define how daemon pods are identified. Use either or both
 # Note if you do not enable daemonPodDetectors, the default is to identify all pods running as kind = daemonSet

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -30,11 +30,5 @@ data:
         "namespaces": ["{{ .Values.daemonPodDetectors.daemonPodNamespaces1 }}", "{{ .Values.daemonPodDetectors.daemonPodNamespaces2 }}"],
         "podNamePatterns": ["{{ .Values.daemonPodDetectors.daemonPodNamePatterns }}"]
       {{- end }}
-      {{- if .Values.masterNodeDetectors }}
-      },
-      "masterNodeDetectors": {
-        "nodeNamePatterns": [ "{{ .Values.masterNodeDetectors.nodeNamePatterns }}" ],
-        "nodeLabels": [ {"key": "{{ .Values.masterNodeDetectors.nodeLabelsKey }}", "value": "{{ .Values.masterNodeDetectors.nodeLabelsValue }}"} ]
-      {{- end }}
       }
     }

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -15,9 +15,8 @@ data:
           "opsManagerPassword": "{{ .Values.restAPIConfig.opsManagerPassword }}"
         }
       },
-      "masterNodeDetectors": {
-        "nodeNamePatterns": [ "{{ .Values.masterNodeDetectors.nodeNamePatterns }}" ],
-        "nodeLabels": [ {"key": "{{ .Values.masterNodeDetectors.nodeLabelsKey }}", "value": "{{ .Values.masterNodeDetectors.nodeLabelsValue }}"} ]
+      "HANodeConfig": {
+        "nodeRoles": [{{ .Values.HANodeConfig.nodeRoles }}]
       {{- if .Values.targetConfig }}
         {{- if .Values.targetConfig.targetName }}
       },
@@ -30,6 +29,12 @@ data:
       "daemonPodDetectors": {
         "namespaces": ["{{ .Values.daemonPodDetectors.daemonPodNamespaces1 }}", "{{ .Values.daemonPodDetectors.daemonPodNamespaces2 }}"],
         "podNamePatterns": ["{{ .Values.daemonPodDetectors.daemonPodNamePatterns }}"]
+      {{- end }}
+      {{- if .Values.masterNodeDetectors }}
+      },
+      "masterNodeDetectors": {
+        "nodeNamePatterns": [ "{{ .Values.masterNodeDetectors.nodeNamePatterns }}" ],
+        "nodeLabels": [ {"key": "{{ .Values.masterNodeDetectors.nodeLabelsKey }}", "value": "{{ .Values.masterNodeDetectors.nodeLabelsValue }}"} ]
       {{- end }}
       }
     }

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -29,13 +29,18 @@ restAPIConfig:
 #targetConfig:
 #  targetName: Name_Each_Cluster
 
+# In kubeturbo 6.4.3+, you can define what nodes should stay high-available based on the node role
+# Master nodes are by default populated by --set HANodeConfig.nodeRoles="\"foo\"\,\"bar\""
+HANodeConfig:
+  nodeRoles: "\"master\""
+
 # In kubeturbo 6.3+, you can define how master nodes are identified. Use either or both
 # Master nodes are not identified by default and could suspend in plans.
 # nodeLabels must provide a key value pair
-masterNodeDetectors:
-   nodeNamePatterns: .*master.*
-   nodeLabelsKey: node-role.kubernetes.io/master
-   nodeLabelsValue: .*
+#masterNodeDetectors:
+#   nodeNamePatterns: .*master.*
+#   nodeLabelsKey: node-role.kubernetes.io/master
+#   nodeLabelsValue: .*
 
 # In kubeturbo 6.3+, you can define how daemon pods are identified. Use either or both
 # Note if you do not enable daemonPodDetectors, the default is to identify all pods running as kind = daemonSet

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -5,7 +5,7 @@
 # Replace the image with desired version
 image:
   repository: turbonomic/kubeturbo
-  tag: 6.4.0
+  tag: 6.4.3
   pullPolicy: IfNotPresent
 
 #nameOverride: ""
@@ -33,14 +33,6 @@ restAPIConfig:
 # Master nodes are by default populated by --set HANodeConfig.nodeRoles="\"foo\"\,\"bar\""
 HANodeConfig:
   nodeRoles: "\"master\""
-
-# In kubeturbo 6.3+, you can define how master nodes are identified. Use either or both
-# Master nodes are not identified by default and could suspend in plans.
-# nodeLabels must provide a key value pair
-#masterNodeDetectors:
-#   nodeNamePatterns: .*master.*
-#   nodeLabelsKey: node-role.kubernetes.io/master
-#   nodeLabelsValue: .*
 
 # In kubeturbo 6.3+, you can define how daemon pods are identified. Use either or both
 # Note if you do not enable daemonPodDetectors, the default is to identify all pods running as kind = daemonSet


### PR DESCRIPTION
This is only changing the value and default template of Helm and Operator. Tested. I didn't do any change on ReadMe yet since Eva mentioned she will do that. I can certainly help.