### PR TITLE
Revert "Maxpods 6.4.3 (#332)"

### DIFF
--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -25,7 +25,6 @@ var (
 		metrics.MemoryQuota:        proto.CommodityDTO_MEM_ALLOCATION,
 		metrics.CPURequestQuota:    proto.CommodityDTO_CPU_REQUEST_ALLOCATION,
 		metrics.MemoryRequestQuota: proto.CommodityDTO_MEM_REQUEST_ALLOCATION,
-		metrics.NumPods:            proto.CommodityDTO_NUMBER_CONSUMERS,
 	}
 )
 

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -29,7 +29,6 @@ var (
 		metrics.Memory,
 		metrics.CPURequest,
 		metrics.MemoryRequest,
-		metrics.NumPods,
 		// TODO, add back provisioned commodity later
 	}
 )

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -31,7 +31,6 @@ var (
 		metrics.Memory,
 		metrics.CPURequest,
 		metrics.MemoryRequest,
-		metrics.NumPods,
 		// TODO, add back provisioned commodity later
 	}
 

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -30,7 +30,6 @@ const (
 	CPUProvisioned     ResourceType = "CPUProvisioned"
 	MemoryProvisioned  ResourceType = "MemoryProvisioned"
 	Transaction        ResourceType = "Transaction"
-	NumPods            ResourceType = "NumPods"
 
 	Access       ResourceType = "Access"
 	Cluster      ResourceType = "Cluster"

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -162,7 +162,6 @@ func (m *KubeletMonitor) parsePodStats(podStats []stats.PodStats) {
 
 		//fmt.Printf("**** generated pod used metric %s cpuUsed=%f memUsed=%f\n", key, cpuUsed, memUsed)
 		m.genUsedMetrics(metrics.PodType, key, cpuUsed, memUsed)
-		m.genNumConsumersUsedMetrics(metrics.PodType, key)
 	}
 }
 
@@ -207,10 +206,4 @@ func (m *KubeletMonitor) genUsedMetrics(etype metrics.DiscoveredEntityType, key 
 	cpuMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPU, metrics.Used, cpu)
 	memMetric := metrics.NewEntityResourceMetric(etype, key, metrics.Memory, metrics.Used, memory)
 	m.metricSink.AddNewMetricEntries(cpuMetric, memMetric)
-}
-
-func (m *KubeletMonitor) genNumConsumersUsedMetrics(etype metrics.DiscoveredEntityType, key string) {
-	// Each pod consumes one from numConsumers / Total available is node allocatable pod number
-	numConsumersMetric := metrics.NewEntityResourceMetric(etype, key, metrics.NumPods, metrics.Used, 1)
-	m.metricSink.AddNewMetricEntries(numConsumersMetric)
 }

--- a/pkg/discovery/util/resource.go
+++ b/pkg/discovery/util/resource.go
@@ -2,10 +2,7 @@ package util
 
 import (
 	"errors"
-	"math"
-	"net"
 
-	"github.com/golang/glog"
 	api "k8s.io/api/core/v1"
 )
 
@@ -33,37 +30,4 @@ func GetCpuAndMemoryValues(resource api.ResourceList) (cpuCapacityCore, memoryCa
 	cpuCapacityCore = float64(ctnCpuCapacityMilliCore) / MilliToUnit
 
 	return
-}
-
-// Gets the allocatable number of pods from the node resource
-func GetNumPodsAllocatable(node *api.Node) float64 {
-	// Compute both the available IP address range and the maxpods set on the node.
-	// Pick the smaller limit.
-	var allocatableIPAddresses float64
-	if node.Spec.PodCIDR != "" {
-		// This also validates the CIDR string for malformed values, although unlikely.
-		_, podNet, err := net.ParseCIDR(node.Spec.PodCIDR)
-		if err != nil {
-			glog.Warning("Error parsing node CIDR:", err)
-		} else {
-			allocatableIPAddresses = getAllocatableIPAddresses(podNet)
-			glog.V(4).Infof("Allocatable pod IP addresses: %f on node: %s", allocatableIPAddresses, node.Name)
-		}
-	}
-
-	allocatablePods := float64(node.Status.Allocatable.Pods().Value())
-	glog.V(4).Infof("Allocatable maxPods: %f on node: %s", allocatablePods, node.Name)
-
-	if allocatableIPAddresses < allocatablePods {
-		return allocatableIPAddresses
-	}
-	return allocatablePods
-}
-
-// Gets the number of allocatable addresses in the subnet
-// TODO: Validate if this works fine for IPV6 addresses
-func getAllocatableIPAddresses(n *net.IPNet) float64 {
-	ones, bits := n.Mask.Size()
-	// Ref: https://erikberg.com/notes/networks.html
-	return (math.Pow(2, float64(bits-ones)) - 2)
 }

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -25,7 +25,6 @@ var (
 	appCommType              = proto.CommodityDTO_APPLICATION
 	transactionType          = proto.CommodityDTO_TRANSACTION
 	respTimeType             = proto.CommodityDTO_RESPONSE_TIME
-	numPodNumConsumers       = proto.CommodityDTO_NUMBER_CONSUMERS
 
 	fakeKey = "fake"
 
@@ -33,7 +32,6 @@ var (
 	vMemTemplateComm                        = &proto.TemplateCommodity{CommodityType: &vMemType}
 	vCpuRequestTemplateComm                 = &proto.TemplateCommodity{CommodityType: &vCpuRequestType}
 	vMemRequestTemplateComm                 = &proto.TemplateCommodity{CommodityType: &vMemRequestType}
-	numPodNumConsumersTemplateComm          = &proto.TemplateCommodity{CommodityType: &numPodNumConsumers}
 	cpuAllocationTemplateCommWithKey        = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &cpuAllocationType}
 	memAllocationTemplateCommWithKey        = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &memAllocationType}
 	cpuRequestAllocationTemplateCommWithKey = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &cpuRequestAllocationType}
@@ -183,12 +181,11 @@ func (f *SupplyChainFactory) buildNodeSupplyBuilder() (*proto.TemplateDTO, error
 	nodeSupplyChainNodeBuilder.SetTemplateType(f.vmTemplateType)
 
 	nodeSupplyChainNodeBuilder = nodeSupplyChainNodeBuilder.
-		Sells(vCpuTemplateComm).              // sells to Pods
-		Sells(vMemTemplateComm).              // sells to Pods
-		Sells(vCpuRequestTemplateComm).       // sells to Pods
-		Sells(vMemRequestTemplateComm).       // sells to Pods
-		Sells(vmpmAccessTemplateComm).        // sells to Pods
-		Sells(numPodNumConsumersTemplateComm) // sells to Pods
+		Sells(vCpuTemplateComm).        // sells to Pods
+		Sells(vMemTemplateComm).        // sells to Pods
+		Sells(vCpuRequestTemplateComm). // sells to Pods
+		Sells(vMemRequestTemplateComm). // sells to Pods
+		Sells(vmpmAccessTemplateComm)   // sells to Pods
 		// also sells Cluster
 
 	return nodeSupplyChainNodeBuilder.Create()
@@ -216,7 +213,6 @@ func (f *SupplyChainFactory) buildPodSupplyBuilder() (*proto.TemplateDTO, error)
 		Buys(vMemTemplateComm).
 		Buys(vCpuRequestTemplateComm).
 		Buys(vMemRequestTemplateComm).
-		Buys(numPodNumConsumersTemplateComm).
 		Provider(proto.EntityDTO_VIRTUAL_DATACENTER, proto.Provider_LAYERED_OVER).
 		Buys(cpuAllocationTemplateCommWithKey).
 		Buys(memAllocationTemplateCommWithKey).


### PR DESCRIPTION
This reverts commit e067cc6a3fa50edcd21edd6fe8db8c1931f44684.

There seems to be some issues after stitching according to @enlinxu's test:
* In the openshift 37 env, the capacity of `numberconsumer` on node is not populated correctly, it's 0 in the discovered DTO
* I don't see the commodity sold at the vm side after stitching, only at pod bought side