### PR TITLE
Fixes for proxy VM stitching data

### DIFF
--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -198,13 +198,25 @@ func (s *StitchingManager) getStitchingPropertyName() string {
 }
 
 // Create the meta data that will be used during the reconciliation process.
+// This seems only applicable for VirtualMachines.
 func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_ReplacementEntityMetaData, error) {
 	replacementEntityMetaDataBuilder := builder.NewReplacementEntityMetaDataBuilder()
+
+	// Construct the definition to identify the matching field in the external entity
+	entityType := proto.EntityDTO_VIRTUAL_MACHINE
+	attr := s.getStitchingPropertyName()
+	useTopoExt := true
+	serverEntityPropDef := &proto.ServerEntityPropDef{
+		Entity:     &entityType,
+		Attribute:  &attr,
+		UseTopoExt: &useTopoExt,
+	}
+
 	switch s.stitchType {
 	case UUID:
-		replacementEntityMetaDataBuilder.Matching(proxyVMUUID)
+		replacementEntityMetaDataBuilder.Matching(proxyVMUUID).MatchingExternal(serverEntityPropDef)
 	case IP:
-		replacementEntityMetaDataBuilder.Matching(proxyVMIP)
+		replacementEntityMetaDataBuilder.Matching(proxyVMIP).MatchingExternal(serverEntityPropDef)
 	default:
 		return nil, fmt.Errorf("stitching property type %s is not supported", s.stitchType)
 	}

--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -201,22 +201,11 @@ func (s *StitchingManager) getStitchingPropertyName() string {
 // This seems only applicable for VirtualMachines.
 func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_ReplacementEntityMetaData, error) {
 	replacementEntityMetaDataBuilder := builder.NewReplacementEntityMetaDataBuilder()
-
-	// Construct the definition to identify the matching field in the external entity
-	entityType := proto.EntityDTO_VIRTUAL_MACHINE
-	attr := s.getStitchingPropertyName()
-	useTopoExt := true
-	serverEntityPropDef := &proto.ServerEntityPropDef{
-		Entity:     &entityType,
-		Attribute:  &attr,
-		UseTopoExt: &useTopoExt,
-	}
-
 	switch s.stitchType {
 	case UUID:
-		replacementEntityMetaDataBuilder.Matching(proxyVMUUID).MatchingExternal(serverEntityPropDef)
+		replacementEntityMetaDataBuilder.Matching(proxyVMUUID).MatchingExternal(supplychain.VM_UUID)
 	case IP:
-		replacementEntityMetaDataBuilder.Matching(proxyVMIP).MatchingExternal(serverEntityPropDef)
+		replacementEntityMetaDataBuilder.Matching(proxyVMIP).MatchingExternal(supplychain.VM_IP)
 	default:
 		return nil, fmt.Errorf("stitching property type %s is not supported", s.stitchType)
 	}

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -46,7 +46,7 @@ var (
 	// External matching property
 	VMIPFieldName  = supplychain.SUPPLY_CHAIN_CONSTANT_IP_ADDRESS
 	VMIPFieldPaths = []string{supplychain.SUPPLY_CHAIN_CONSTANT_VIRTUAL_MACHINE_DATA}
-	VMUUID         = supplychain.SUPPLY_CHAIN_CONSTANT_ID
+	VMUUID         = supplychain.SUPPLY_CHAIN_CONSTANT_UUID
 )
 
 type SupplyChainFactory struct {


### PR DESCRIPTION
This PR contains fixes on the proxy VM data to make stitching work under the scenario where VMs are discovered without any ContainerPod.

**Background about VM stitching**

Proxy VM stitching works today between Kubeturbo and IaaS probes because of the ExternalEntityLink established between ContainerPod and VM.  In other words, the stitching between ContainerPod and the real VM makes the proxy VM also stitched with the real VM.  Practically, it's all good because each VM node will have a container pod (at least some system one).

Kubeturbo on the other hand also populates proxy-VM-to-real-VM stitching data, but incorrectly such that, if Kubeturbo only sends VM entity DTOs to the Turbo server without any ContainerPod DTOs, then the proxy VMs will not be stitched.  I've confirmed this behavior by having some custom code to only send VM entity DTOs but any other DTOs.

**Fix in this PR**

In this pull request, we identify the gaps in the proxy-VM-to-real-VM stitching data and address them.  

1. The first gap is in the `replacementEntityData` block where it lacks of the `extEntityProp` field.  The block already has the so-called `identifyingProp`, which is to identify the property in the proxy entity.  The “extEntityProp” field, on the other hand, is to identify the property in the external entity.  SDK use them to match and stitch the two entities. 
2. The second gap is in the VM supply chain definition where we specified an incorrect `externalMatchingField` field.  It should be `uuid` instead of `id`.

Below are an example EntityDTO and the corresponding supply chain definition for VIRTUAL_MACHINE.  The changes in both places are highlighted in **bold**.

Example entity DTO:
```
entityDTO {
  entityType: VIRTUAL_MACHINE
  id: "21b17489-f4e9-11e7-acc0-005056802f41"
  displayName: "osp-node-1.eng.vmturbo.com"
  …
  entityProperties {
    namespace: "DEFAULT"
    name: "Proxy_VM_UUID"
    value: "4200979a-4ef9-e49b-6bd6-fdbad2be7252"
  }
  entityProperties {
    namespace: "DEFAULT"
    name: "KubernetesNodeName"
    value: "osp-node-1.eng.vmturbo.com"
  }
  origin: PROXY
  replacementEntityData {
    identifyingProp: "Proxy_VM_UUID"
    …
    **extEntityPropDef {
      entity: VIRTUAL_MACHINE
      attribute: "Uuid"
    }**
  }
  powerState: POWERED_ON
  consumerPolicy {
    controllable: true
  }
  virtual_machine_data {
    ipAddress: "10.10.174.13"
    ipAddress: "osp-node-1.eng.vmturbo.com"
  }
}
``` 
The corresponding supply chain definition for VIRTUAL_MACHINE:
```
    "templateClass": 10,
    "templateType": 0,
    "templatePriority": -1,
    …
    "mergedEntityMetaData": {
        "keepStandalone": true,
        "matchingMetadata": {
            "returnType": 1,
            "matchingData": [
                {
                    "MatchingData": {
                        "MatchingProperty": {
                            "propertyName": "Proxy_VM_UUID"
                        }
                    }
                }
            ],
            "externalEntityReturnType": 1,
            "externalEntityMatchingProperty": [
                {
                    "MatchingData": {
                        "MatchingField": {
                            "fieldName": "**uuid**"
                        }
                    }
                }
            ]
        },
        …
    }
}
```

**Testing done**

I've been testing the stitching between VC and Kubeturbo.  To test the VM only stitching, I customized the discovery code to only return VM entity DTOs and not any others.  I've verified that before this change I saw both the real VM and the proxy VM in the topology, which means the stitching wasn't working.  After this change, I don't see the proxy VM any more and only the real VM.  Using the classic advanced view, I have also verified that the real VM is now extended correctly by two extensions (one VC and one Kubernetes).

Then I removed my custom discovery code and ensure the proxy VM stitching still works with the presence of other DTOs, and ContainerPods/VDCs are still stitched correctly with the real VMs, just like before.