### PR TITLE
Change the external matching field back to id to fix kubeturbo VM stitching with XL

### DIFF
--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -46,7 +46,7 @@ var (
 	// External matching property
 	VMIPFieldName  = supplychain.SUPPLY_CHAIN_CONSTANT_IP_ADDRESS
 	VMIPFieldPaths = []string{supplychain.SUPPLY_CHAIN_CONSTANT_VIRTUAL_MACHINE_DATA}
-	VMUUID         = supplychain.SUPPLY_CHAIN_CONSTANT_UUID
+	VMUUID         = supplychain.SUPPLY_CHAIN_CONSTANT_ID
 )
 
 type SupplyChainFactory struct {


### PR DESCRIPTION
In the following PR we changed the external matching field to `uuid` from `id`.  That broke kubeturbo VM stitching with XL, because XL entities do not have the `uuid` field.
https://github.com/turbonomic/kubeturbo/pull/348

This PR reverted that part of the changes, i.e. changing the external matching field from `uuid` back to `id`.  It works for both XL and classic, because classic entities also have the `id` field, which is the same as the `uuid`.

**Testing done**
With this fix, kubeturbo VM stitching is now back working.  The other part of the changes in the previous PR is sufficient to make VM only stitching work, and I also verified it in classic opsmgr.