### PR TITLE
Update kubernetes client lib to dynamic client

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -401,7 +401,7 @@ func discoverk8sAPIResourceGV(client *kubernetes.Clientset, resourceName string)
 
 		gv, err := schema.ParseGroupVersion(apiResourceList.GroupVersion)
 		if err != nil {
-			return defaultGV, fmt.Errorf("Error parsing GroupVersion: %v", err)
+			return defaultGV, fmt.Errorf("error parsing GroupVersion: %v", err)
 		}
 
 		group := gv.Group

--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -12,6 +12,8 @@ import (
 
 	clusterclient "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	versionhelper "k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -39,10 +41,15 @@ const (
 	defaultDiscoveryIntervalSec = 600
 	defaultValidationWorkers    = 10
 	defaultValidationTimeout    = 60
+	k8sExtensionsGroupName      = "extensions"
+	k8sAppsGroupName            = "apps"
 )
 
 var (
 	defaultSccSupport = []string{"restricted"}
+
+	// The API group version under which deployments and replicasets are exposed by the given k8s cluster
+	k8sAPIDeploymentReplicasetGV = &schema.GroupVersion{k8sAppsGroupName, "v1"}
 
 	// these variables will be deprecated. Keep it here for backward compatibility only
 	k8sVersion        = "1.8"
@@ -228,6 +235,13 @@ func (s *VMTServer) Run() {
 	isOpenshift := checkServerVersion(kubeClient.DiscoveryClient.RESTClient())
 	glog.V(2).Info("Openshift cluster? ", isOpenshift)
 
+	var err error
+	k8sAPIDeploymentReplicasetGV, err = discoverk8sAPIDeploymentReplicasetGV(kubeClient)
+	if err != nil {
+		glog.Warningf("Failure in discovering k8s deployment and replicaset API group/version: %v", err.Error())
+	}
+	glog.V(2).Infof("Using group version %v for k8s deployments and replicasets", k8sAPIDeploymentReplicasetGV)
+
 	// Allow insecure connection only if it's not an Openshift cluster
 	// For Kubernetes distro, the secure connection to Kubelet will fail due to
 	// the certificate issue of 'doesn't contain any IP SANs'.
@@ -343,4 +357,54 @@ func checkServerVersion(restClient restclient.Interface) bool {
 	}
 
 	return false
+}
+
+func discoverk8sAPIDeploymentReplicasetGV(client *kubernetes.Clientset) (*schema.GroupVersion, error) {
+	// We optimistically use a globally set default if we cannot discover the GV.
+	defaultGV := *k8sAPIDeploymentReplicasetGV
+
+	apiResourceLists, err := client.ServerPreferredResources()
+	if apiResourceLists == nil {
+		return &defaultGV, err
+	}
+	if err != nil {
+		// We don't exit here as ServerPreferredResources can return the resource list even with errors.
+		glog.Warningf("Error listing api resources: %v", err)
+	}
+
+	latestExtensionsVersion := schema.GroupVersion{k8sExtensionsGroupName, ""}
+	latestAppsVersion := schema.GroupVersion{k8sAppsGroupName, ""}
+	for _, apiResourceList := range apiResourceLists {
+		if len(apiResourceList.APIResources) == 0 {
+			continue
+		}
+
+		gv, err := schema.ParseGroupVersion(apiResourceList.GroupVersion)
+		if err != nil {
+			return &defaultGV, fmt.Errorf("Error parsing GroupVersion: %v", err)
+		}
+
+		group := gv.Group
+		version := gv.Version
+		if group == k8sExtensionsGroupName {
+			latestExtensionsVersion.Version = latestComparedVersion(version, latestExtensionsVersion.Version)
+		} else if group == k8sAppsGroupName {
+			latestAppsVersion.Version = latestComparedVersion(version, latestAppsVersion.Version)
+		}
+	}
+
+	if latestAppsVersion.Version != "" {
+		return &latestAppsVersion, nil
+	}
+	if latestExtensionsVersion.Version != "" {
+		return &latestExtensionsVersion, nil
+	}
+	return &defaultGV, nil
+}
+
+func latestComparedVersion(newVersion, existingVersion string) string {
+	if existingVersion != "" && versionhelper.CompareKubeAwareVersionStrings(newVersion, existingVersion) <= 0 {
+		return existingVersion
+	}
+	return newVersion
 }

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	k8s.io/klog v0.0.0-20190306015804-8e90cee79f82
 	k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30 // indirect
 	k8s.io/kubernetes v1.13.1
-	sigs.k8s.io/cluster-api v0.0.0-20190418151011-abfd18620fd0 // indirect
 	sigs.k8s.io/controller-runtime v0.1.10 // indirect
 	sigs.k8s.io/testing_frameworks v0.1.1 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,7 +63,6 @@ github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3 h1:EooPXg51Tn+xmWPXJUG
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/openshift/cluster-api v0.0.0-20190822130419-53b696be18ad h1:t6+UYvBUJD8gXxgrvavZqmd0DRm5vWHgrX0v/GA/0a4=
 github.com/openshift/cluster-api v0.0.0-20190822130419-53b696be18ad/go.mod h1:mNsD1dsD4T57kV4/C6zTHke/Ro166xgnyyRZqkamiEU=
-github.com/openshift/cluster-api v0.0.0-20191003080455-24cfb34ea1f9 h1:H0RCaP7ftrTYu4LRM8d+2bYZpI7jgjtbpzhP/rr2DxQ=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
@@ -92,8 +91,6 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 h1:xfnOa96E4g6MRfLPSVyL4Aprmxf8NBjsUyqUoW0VnIs=
 github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v6.4.1-0.20190920204752-15606b6f2fc8+incompatible h1:n4cu0HFWmtWkNHcAWXkLXJhoSjczixToIbN6CiK8+oI=
-github.com/turbonomic/turbo-go-sdk v6.4.1-0.20190920204752-15606b6f2fc8+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
 github.com/turbonomic/turbo-go-sdk v6.4.1-0.20191120011039-887da256d38c+incompatible h1:V+MNNKayDy+aSsGW4VLuX8tse9UIA/RBhCKlxPScDZI=
 github.com/turbonomic/turbo-go-sdk v6.4.1-0.20191120011039-887da256d38c+incompatible/go.mod h1:sKRnBmuIMyFQoQnd0TubqLSN4Kob/KZCe7LIdwoVsVE=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 h1:nSQar3Y0E3VQF/VdZ8PTAilaXpER+d7ypdABCrpwMdg=
@@ -159,8 +156,6 @@ k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30 h1:TRb4wNWoBVrH9plmkp2q86
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kubernetes v1.13.1 h1:IwCCcPOZwY9rKcQyBJYXAE4Wgma4oOW5NYR3HXKFfZ8=
 k8s.io/kubernetes v1.13.1/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
-sigs.k8s.io/cluster-api v0.0.0-20190418151011-abfd18620fd0 h1:mMY9TP1yluHRDLL3LB9Lb1xPc90eBJMUeSPf8cfNqVw=
-sigs.k8s.io/cluster-api v0.0.0-20190418151011-abfd18620fd0/go.mod h1:aEXstFx3krpj6/AOcV/rOP2VLKdrtSNUMDR2Kmt6YSs=
 sigs.k8s.io/controller-runtime v0.1.10 h1:amLOmcekVdnsD1uIpmgRqfTbQWJ2qxvQkcdeFhcotn4=
 sigs.k8s.io/controller-runtime v0.1.10/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -2,23 +2,23 @@ package action
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset"
+	"strings"
 	"time"
 
-	client "k8s.io/client-go/kubernetes"
+	"github.com/golang/glog"
 
+	"github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset"
 	"github.com/turbonomic/kubeturbo/pkg/action/executor"
 	"github.com/turbonomic/kubeturbo/pkg/action/util"
+	api "k8s.io/api/core/v1"
+	"k8s.io/client-go/dynamic"
+	kubeclient "k8s.io/client-go/kubernetes"
 
 	sdkprobe "github.com/turbonomic/turbo-go-sdk/pkg/probe"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 
-	"strings"
-
-	"github.com/golang/glog"
-	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
+	kubeletclient "github.com/turbonomic/kubeturbo/pkg/kubeclient"
 	"github.com/turbonomic/kubeturbo/pkg/turbostore"
-	api "k8s.io/api/core/v1"
 )
 
 const (
@@ -41,15 +41,16 @@ var (
 )
 
 type ActionHandlerConfig struct {
-	kubeClient     *client.Clientset
+	kubeClient     *kubeclient.Clientset
+	dynamicClient  dynamic.Interface
 	cApiClient     *clientset.Clientset
-	kubeletClient  *kubeclient.KubeletClient
+	kubeletClient  *kubeletclient.KubeletClient
 	StopEverything chan struct{}
 	sccAllowedSet  map[string]struct{}
 	cAPINamespace  string
 }
 
-func NewActionHandlerConfig(cApiNamespace string, cApiClient *clientset.Clientset, kubeClient *client.Clientset, kubeletClient *kubeclient.KubeletClient, sccSupport []string) *ActionHandlerConfig {
+func NewActionHandlerConfig(cApiNamespace string, cApiClient *clientset.Clientset, kubeClient *kubeclient.Clientset, kubeletClient *kubeletclient.KubeletClient, dynamicClient dynamic.Interface, sccSupport []string) *ActionHandlerConfig {
 	sccAllowedSet := make(map[string]struct{})
 	for _, sccAllowed := range sccSupport {
 		sccAllowedSet[strings.TrimSpace(sccAllowed)] = struct{}{}
@@ -58,6 +59,7 @@ func NewActionHandlerConfig(cApiNamespace string, cApiClient *clientset.Clientse
 
 	config := &ActionHandlerConfig{
 		kubeClient:     kubeClient,
+		dynamicClient:  dynamicClient,
 		kubeletClient:  kubeletClient,
 		StopEverything: make(chan struct{}),
 		sccAllowedSet:  sccAllowedSet,
@@ -101,7 +103,7 @@ func NewActionHandler(config *ActionHandlerConfig) *ActionHandler {
 // As action executor is stateless, they can be safely reused.
 func (h *ActionHandler) registerActionExecutors() {
 	c := h.config
-	ae := executor.NewTurboK8sActionExecutor(c.kubeClient, c.cApiClient, h.podManager)
+	ae := executor.NewTurboK8sActionExecutor(c.kubeClient, c.dynamicClient, c.cApiClient, h.podManager)
 
 	reScheduler := executor.NewReScheduler(ae, c.sccAllowedSet)
 	h.actionExecutors[turboActionPodMove] = reScheduler

--- a/pkg/action/executor/action_executor.go
+++ b/pkg/action/executor/action_executor.go
@@ -5,6 +5,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/action/util"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	api "k8s.io/api/core/v1"
+	"k8s.io/client-go/dynamic"
 	kclient "k8s.io/client-go/kubernetes"
 )
 
@@ -24,15 +25,17 @@ type TurboActionExecutor interface {
 }
 
 type TurboK8sActionExecutor struct {
-	kubeClient *kclient.Clientset
-	cApiClient *clientset.Clientset
-	podManager util.IPodManager
+	kubeClient    *kclient.Clientset
+	dynamicClient dynamic.Interface
+	cApiClient    *clientset.Clientset
+	podManager    util.IPodManager
 }
 
-func NewTurboK8sActionExecutor(kubeClient *kclient.Clientset, cApiClient *clientset.Clientset, podManager util.IPodManager) TurboK8sActionExecutor {
+func NewTurboK8sActionExecutor(kubeClient *kclient.Clientset, dynamicClient dynamic.Interface, cApiClient *clientset.Clientset, podManager util.IPodManager) TurboK8sActionExecutor {
 	return TurboK8sActionExecutor{
-		kubeClient: kubeClient,
-		cApiClient: cApiClient,
-		podManager: podManager,
+		kubeClient:    kubeClient,
+		dynamicClient: dynamicClient,
+		cApiClient:    cApiClient,
+		podManager:    podManager,
 	}
 }

--- a/pkg/action/executor/constants.go
+++ b/pkg/action/executor/constants.go
@@ -1,6 +1,8 @@
 package executor
 
-import "time"
+import (
+	"time"
+)
 
 const (
 	defaultRetryLess = 3

--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -29,7 +29,7 @@ func (h *HorizontalScaler) Execute(input *TurboActionExecutorInput) (*TurboActio
 		return nil, err
 	}
 	//2. Prepare controllerUpdater
-	controllerUpdater, err := newK8sControllerUpdater(h.kubeClient, pod)
+	controllerUpdater, err := newK8sControllerUpdater(h.kubeClient, h.dynamicClient, pod)
 	if err != nil {
 		glog.Errorf("Failed to create controllerUpdater: %v", err)
 		return &TurboActionExecutorOutput{}, err

--- a/pkg/action/executor/k8s_controller.go
+++ b/pkg/action/executor/k8s_controller.go
@@ -32,6 +32,7 @@ type k8sControllerSpec struct {
 type parentController struct {
 	dynNamespacedClient dynamic.ResourceInterface
 	obj                 *unstructured.Unstructured
+	name                string
 }
 
 func (c *parentController) get(name string) (*k8sControllerSpec, error) {
@@ -87,8 +88,5 @@ func (c *parentController) update(updatedSpec *k8sControllerSpec) error {
 }
 
 func (rc *parentController) String() string {
-	if rc.obj != nil {
-		return rc.obj.GetKind()
-	}
-	return "Unknown"
+	return rc.name
 }

--- a/pkg/action/executor/k8s_controller.go
+++ b/pkg/action/executor/k8s_controller.go
@@ -44,17 +44,17 @@ func (c *parentController) get(name string) (*k8sControllerSpec, error) {
 
 	replicas, found, err := unstructured.NestedInt64(obj.Object, "spec", "replicas")
 	if err != nil || !found {
-		return nil, fmt.Errorf("Error retrieving replicas from %s %s: %v", kind, objName, err)
+		return nil, fmt.Errorf("error retrieving replicas from %s %s: %v", kind, objName, err)
 	}
 
 	podSpecUnstructured, found, err := unstructured.NestedFieldCopy(obj.Object, "spec", "template", "spec")
 	if err != nil || !found {
-		return nil, fmt.Errorf("Error retrieving podSpec from %s %s: %v", kind, objName, err)
+		return nil, fmt.Errorf("error retrieving podSpec from %s %s: %v", kind, objName, err)
 	}
 
 	podSpec := apicorev1.PodSpec{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(podSpecUnstructured.(map[string]interface{}), &podSpec); err != nil {
-		return nil, fmt.Errorf("Error converting unstructured pod spec to typed pod spec for %s %s: %v", kind, objName, err)
+		return nil, fmt.Errorf("error converting unstructured pod spec to typed pod spec for %s %s: %v", kind, objName, err)
 	}
 
 	c.obj = obj
@@ -72,14 +72,14 @@ func (c *parentController) update(updatedSpec *k8sControllerSpec) error {
 	replicaVal := int64(*updatedSpec.replicas)
 	podSpecUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(updatedSpec.podSpec)
 	if err != nil {
-		return fmt.Errorf("Error converting pod spec to unstructured pod spec for %s %s: %v", kind, objName, err)
+		return fmt.Errorf("error converting pod spec to unstructured pod spec for %s %s: %v", kind, objName, err)
 	}
 
 	if err := unstructured.SetNestedField(c.obj.Object, replicaVal, "spec", "replicas"); err != nil {
-		return fmt.Errorf("Error setting replicas into unstructured %s %s: %v", kind, objName, err)
+		return fmt.Errorf("error setting replicas into unstructured %s %s: %v", kind, objName, err)
 	}
 	if err := unstructured.SetNestedField(c.obj.Object, podSpecUnstructured, "spec", "template", "spec"); err != nil {
-		return fmt.Errorf("Error setting podSpec into unstructured %s %s: %v", kind, objName, err)
+		return fmt.Errorf("error setting podSpec into unstructured %s %s: %v", kind, objName, err)
 	}
 
 	_, err = c.dynNamespacedClient.Update(c.obj, metav1.UpdateOptions{})

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -48,13 +48,13 @@ func newK8sControllerUpdater(client *kclient.Clientset, dynamicClient dynamic.In
 			Resource: util.ReplicationControllerResName}
 	case util.KindReplicaSet:
 		res = schema.GroupVersionResource{
-			Group:    util.K8sAPIDeploymentReplicasetGV.Group,
-			Version:  util.K8sAPIDeploymentReplicasetGV.Version,
+			Group:    util.K8sAPIDeploymentGV.Group,
+			Version:  util.K8sAPIDeploymentGV.Version,
 			Resource: util.ReplicaSetResName}
 	case util.KindDeployment:
 		res = schema.GroupVersionResource{
-			Group:    util.K8sAPIDeploymentReplicasetGV.Group,
-			Version:  util.K8sAPIDeploymentReplicasetGV.Version,
+			Group:    util.K8sAPIReplicasetGV.Group,
+			Version:  util.K8sAPIReplicasetGV.Version,
 			Resource: util.DeploymentResName}
 	default:
 		err := fmt.Errorf("unsupport controller type %s for pod %s/%s", kind, pod.Namespace, pod.Name)

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -7,6 +7,8 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/util"
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	kclient "k8s.io/client-go/kubernetes"
 	"time"
 )
@@ -30,36 +32,42 @@ type controllerSpec struct {
 }
 
 // newK8sControllerUpdater returns a k8sControllerUpdater based on the parent kind of a pod
-func newK8sControllerUpdater(client *kclient.Clientset, pod *api.Pod) (*k8sControllerUpdater, error) {
+func newK8sControllerUpdater(client *kclient.Clientset, dynamicClient dynamic.Interface, pod *api.Pod) (*k8sControllerUpdater, error) {
 	// Find parent kind of the pod
-	kind, name, err := podutil.GetPodGrandInfo(client, pod)
+	kind, name, err := podutil.GetPodGrandInfo(client, dynamicClient, pod)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get parent info of pod %s/%s: %v", pod.Namespace, pod.Name, err)
 	}
-	var controller k8sController
+
+	var res schema.GroupVersionResource
 	switch kind {
 	case util.KindReplicationController:
-		controller = &replicationController{
-			client: client.CoreV1().ReplicationControllers(pod.Namespace),
-		}
+		res = schema.GroupVersionResource{
+			Group:    util.K8sAPIReplicationControllerGV.Group,
+			Version:  util.K8sAPIReplicationControllerGV.Version,
+			Resource: util.ReplicationControllerResName}
 	case util.KindReplicaSet:
-		controller = &replicaSet{
-			client: client.ExtensionsV1beta1().ReplicaSets(pod.Namespace),
-		}
+		res = schema.GroupVersionResource{
+			Group:    util.K8sAPIDeploymentReplicasetGV.Group,
+			Version:  util.K8sAPIDeploymentReplicasetGV.Version,
+			Resource: util.ReplicaSetResName}
 	case util.KindDeployment:
-		controller = &deployment{
-			client: client.AppsV1beta1().Deployments(pod.Namespace),
-		}
+		res = schema.GroupVersionResource{
+			Group:    util.K8sAPIDeploymentReplicasetGV.Group,
+			Version:  util.K8sAPIDeploymentReplicasetGV.Version,
+			Resource: util.DeploymentResName}
 	default:
 		err := fmt.Errorf("unsupport controller type %s for pod %s/%s", kind, pod.Namespace, pod.Name)
 		return nil, err
 	}
 	return &k8sControllerUpdater{
-		controller: controller,
-		client:     client,
-		name:       name,
-		namespace:  pod.Namespace,
-		podName:    pod.Name,
+		controller: &parentController{
+			dynNamespacedClient: dynamicClient.Resource(res).Namespace(pod.Namespace),
+		},
+		client:    client,
+		name:      name,
+		namespace: pod.Namespace,
+		podName:   pod.Name,
 	}, nil
 }
 
@@ -95,7 +103,7 @@ func (c *k8sControllerUpdater) update(desired *controllerSpec) error {
 			c.controller, c.namespace, c.podName)
 		return nil
 	}
-	if err := c.controller.update(); err != nil {
+	if err := c.controller.update(current); err != nil {
 		return err
 	}
 	glog.V(2).Infof("Successfully updated %v of pod %s/%s",

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -34,7 +34,7 @@ type controllerSpec struct {
 // newK8sControllerUpdater returns a k8sControllerUpdater based on the parent kind of a pod
 func newK8sControllerUpdater(client *kclient.Clientset, dynamicClient dynamic.Interface, pod *api.Pod) (*k8sControllerUpdater, error) {
 	// Find parent kind of the pod
-	kind, name, err := podutil.GetPodGrandInfo(client, dynamicClient, pod)
+	kind, name, err := podutil.GetPodGrandInfo(dynamicClient, pod)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get parent info of pod %s/%s: %v", pod.Namespace, pod.Name, err)
 	}

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -63,6 +63,7 @@ func newK8sControllerUpdater(client *kclient.Clientset, dynamicClient dynamic.In
 	return &k8sControllerUpdater{
 		controller: &parentController{
 			dynNamespacedClient: dynamicClient.Resource(res).Namespace(pod.Namespace),
+			name:                kind,
 		},
 		client:    client,
 		name:      name,

--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -244,6 +244,7 @@ func (r *ContainerResizer) Execute(input *TurboActionExecutorInput) (*TurboActio
 	// execute the Action
 	npod, err := resizeContainer(
 		r.kubeClient,
+		r.dynamicClient,
 		pod,
 		spec,
 		actionItem.GetConsistentScalingCompliance(),

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"k8s.io/client-go/dynamic"
 
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,11 +36,13 @@ type ClusterScraperInterface interface {
 
 type ClusterScraper struct {
 	*client.Clientset
+	DynamicClient dynamic.Interface
 }
 
-func NewClusterScraper(kclient *client.Clientset) *ClusterScraper {
+func NewClusterScraper(kclient *client.Clientset, dynamicClient dynamic.Interface) *ClusterScraper {
 	return &ClusterScraper{
-		Clientset: kclient,
+		Clientset:     kclient,
+		DynamicClient: dynamicClient,
 	}
 }
 

--- a/pkg/discovery/configs/probe_config.go
+++ b/pkg/discovery/configs/probe_config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -16,6 +17,8 @@ type ProbeConfig struct {
 
 	// Rest Client for the kubernetes server API
 	ClusterClient *kubernetes.Clientset
+	// Dynamic client for the kubernetes server API
+	DynamicClient dynamic.Interface
 	// Rest Client for the kubelet module in each node
 	NodeClient *kubeclient.KubeletClient
 }

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -52,7 +52,7 @@ type K8sDiscoveryClient struct {
 }
 
 func NewK8sDiscoveryClient(config *DiscoveryClientConfig) *K8sDiscoveryClient {
-	k8sClusterScraper := cluster.NewClusterScraper(config.probeConfig.ClusterClient)
+	k8sClusterScraper := cluster.NewClusterScraper(config.probeConfig.ClusterClient, config.probeConfig.DynamicClient)
 
 	// for discovery tasks
 	clusterProcessor := processor.NewClusterProcessor(k8sClusterScraper, config.probeConfig.NodeClient, config.ValidationWorkers, config.ValidationTimeoutSec)

--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -3,6 +3,7 @@ package master
 import (
 	"errors"
 	"fmt"
+	"k8s.io/client-go/dynamic"
 
 	api "k8s.io/api/core/v1"
 
@@ -209,7 +210,7 @@ func (m *ClusterMonitor) genNodePodsMetrics(node *api.Node, cpuCapacity, memCapa
 	for _, pod := range podList {
 		key := util.PodKeyFunc(pod)
 		// Pod owners
-		podOwner, err := m.getPodOwner(pod)
+		podOwner, err := m.getPodOwner(pod, m.clusterClient.DynamicClient)
 		if err == nil {
 			m.podOwners[key] = podOwner
 		}
@@ -224,11 +225,11 @@ func (m *ClusterMonitor) genNodePodsMetrics(node *api.Node, cpuCapacity, memCapa
 	return
 }
 
-func (m *ClusterMonitor) getPodOwner(pod *api.Pod) (*PodOwner, error) {
+func (m *ClusterMonitor) getPodOwner(pod *api.Pod, dynClient dynamic.Interface) (*PodOwner, error) {
 	key := util.PodKeyFunc(pod)
 	glog.V(4).Infof("begin to generate pod[%s]'s Owner metric.", key)
 
-	kind, parentName, err := util.GetPodGrandInfo(m.clusterClient.Clientset, pod)
+	kind, parentName, err := util.GetPodGrandInfo(m.clusterClient.Clientset, dynClient, pod)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting pod owner: %v", err)
 	}

--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -229,7 +229,7 @@ func (m *ClusterMonitor) getPodOwner(pod *api.Pod, dynClient dynamic.Interface) 
 	key := util.PodKeyFunc(pod)
 	glog.V(4).Infof("begin to generate pod[%s]'s Owner metric.", key)
 
-	kind, parentName, err := util.GetPodGrandInfo(m.clusterClient.Clientset, dynClient, pod)
+	kind, parentName, err := util.GetPodGrandInfo(dynClient, pod)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting pod owner: %v", err)
 	}

--- a/pkg/discovery/monitoring/master/config.go
+++ b/pkg/discovery/monitoring/master/config.go
@@ -3,6 +3,7 @@ package master
 import (
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
+	"k8s.io/client-go/dynamic"
 
 	"k8s.io/client-go/kubernetes"
 )
@@ -11,8 +12,8 @@ type ClusterMonitorConfig struct {
 	clusterInfoScraper *cluster.ClusterScraper
 }
 
-func NewClusterMonitorConfig(kclient *kubernetes.Clientset) *ClusterMonitorConfig {
-	k8sClusterScraper := cluster.NewClusterScraper(kclient)
+func NewClusterMonitorConfig(kclient *kubernetes.Clientset, dynamicClient dynamic.Interface) *ClusterMonitorConfig {
+	k8sClusterScraper := cluster.NewClusterScraper(kclient, dynamicClient)
 	return &ClusterMonitorConfig{
 		clusterInfoScraper: k8sClusterScraper,
 	}

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -282,8 +282,8 @@ func GetPodGrandInfo(kclient *client.Clientset, dynClient dynamic.Interface, pod
 		//2.1 get parent object
 
 		rsRes := schema.GroupVersionResource{
-			Group:    commonutil.K8sAPIDeploymentReplicasetGV.Group,
-			Version:  commonutil.K8sAPIDeploymentReplicasetGV.Version,
+			Group:    commonutil.K8sAPIReplicasetGV.Group,
+			Version:  commonutil.K8sAPIReplicasetGV.Version,
 			Resource: commonutil.ReplicaSetResName}
 		rs, err := dynClient.Resource(rsRes).Namespace(pod.Namespace).Get(name, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -270,7 +270,7 @@ func GetPodParentInfo(pod *api.Pod) (string, string, error) {
 // GetPodGrandInfo gets grandParent (parent's parent) information of a pod: kind, name
 // If parent does not have parent, then return parent info.
 // Note: if parent kind is "ReplicaSet", then its parent's parent can be a "Deployment"
-func GetPodGrandInfo(kclient *client.Clientset, dynClient dynamic.Interface, pod *api.Pod) (string, string, error) {
+func GetPodGrandInfo(dynClient dynamic.Interface, pod *api.Pod) (string, string, error) {
 	//1. get Parent info: kind and name;
 	kind, name, err := GetPodParentInfo(pod)
 	if err != nil {

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -7,14 +7,17 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
+
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	client "k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 
-	goutil "github.com/turbonomic/kubeturbo/pkg/util"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
+	commonutil "github.com/turbonomic/kubeturbo/pkg/util"
 )
 
 const (
@@ -267,7 +270,7 @@ func GetPodParentInfo(pod *api.Pod) (string, string, error) {
 // GetPodGrandInfo gets grandParent (parent's parent) information of a pod: kind, name
 // If parent does not have parent, then return parent info.
 // Note: if parent kind is "ReplicaSet", then its parent's parent can be a "Deployment"
-func GetPodGrandInfo(kclient *client.Clientset, pod *api.Pod) (string, string, error) {
+func GetPodGrandInfo(kclient *client.Clientset, dynClient dynamic.Interface, pod *api.Pod) (string, string, error) {
 	//1. get Parent info: kind and name;
 	kind, name, err := GetPodParentInfo(pod)
 	if err != nil {
@@ -277,7 +280,12 @@ func GetPodGrandInfo(kclient *client.Clientset, pod *api.Pod) (string, string, e
 	//2. if parent is "ReplicaSet", check parent's parent
 	if strings.EqualFold(kind, Kind_ReplicaSet) {
 		//2.1 get parent object
-		rs, err := kclient.ExtensionsV1beta1().ReplicaSets(pod.Namespace).Get(name, metav1.GetOptions{})
+
+		rsRes := schema.GroupVersionResource{
+			Group:    commonutil.K8sAPIDeploymentReplicasetGV.Group,
+			Version:  commonutil.K8sAPIDeploymentReplicasetGV.Version,
+			Resource: commonutil.ReplicaSetResName}
+		rs, err := dynClient.Resource(rsRes).Namespace(pod.Namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			err = fmt.Errorf("Failed to get ReplicaSet[%v/%v]: %v", pod.Namespace, name, err)
 			glog.Error(err.Error())
@@ -286,8 +294,9 @@ func GetPodGrandInfo(kclient *client.Clientset, pod *api.Pod) (string, string, e
 
 		//2.2 get parent's parent info by parsing ownerReferences:
 		// TODO: The ownerReferences of ReplicaSet is supported only in 1.6.0 and afetr
-		if rs.OwnerReferences != nil && len(rs.OwnerReferences) > 0 {
-			gkind, gname := ParseOwnerReferences(rs.OwnerReferences)
+		rsOwnerReferences := rs.GetOwnerReferences()
+		if rsOwnerReferences != nil && len(rsOwnerReferences) > 0 {
+			gkind, gname := ParseOwnerReferences(rsOwnerReferences)
 			if len(gkind) > 0 && len(gname) > 0 {
 				return gkind, gname, nil
 			}
@@ -307,7 +316,7 @@ func WaitForPodReady(client *client.Clientset, namespace, podName, nodeName stri
 	retry int, interval time.Duration) error {
 	// check pod readiness with retries
 	timeout := time.Duration(retry+1) * interval
-	err := goutil.RetrySimple(retry, timeout, interval, func() (bool, error) {
+	err := commonutil.RetrySimple(retry, timeout, interval, func() (bool, error) {
 		return checkPodNode(client, namespace, podName, nodeName)
 	})
 	// log a list of unique events that belong to the pod

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -85,7 +85,7 @@ func createProbeConfigOrDie(c *Config) *configs.ProbeConfig {
 	kubeletMonitoringConfig := kubelet.NewKubeletMonitorConfig(c.KubeletClient)
 
 	// Create cluster monitoring
-	masterMonitoringConfig := master.NewClusterMonitorConfig(c.KubeClient)
+	masterMonitoringConfig := master.NewClusterMonitorConfig(c.KubeClient, c.DynamicClient)
 
 	// TODO for now kubelet is the only monitoring source. As we have more sources, we should choose what to be added into the slice here.
 	monitoringConfigs := []monitoring.MonitorWorkerConfig{
@@ -97,6 +97,7 @@ func createProbeConfigOrDie(c *Config) *configs.ProbeConfig {
 		StitchingPropertyType: c.StitchingPropType,
 		MonitoringConfigs:     monitoringConfigs,
 		ClusterClient:         c.KubeClient,
+		DynamicClient:         c.DynamicClient,
 		NodeClient:            c.KubeletClient,
 	}
 
@@ -118,7 +119,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	probeConfig := createProbeConfigOrDie(config)
 	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig, config.ValidationWorkers, config.ValidationTimeoutSec)
 
-	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.KubeClient, config.KubeletClient, config.SccSupport)
+	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.KubeClient, config.KubeletClient, config.DynamicClient, config.SccSupport)
 
 	// Kubernetes Probe Registration Client
 	registrationClient := registration.NewK8sRegistrationClient(registrationClientConfig)

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -85,7 +85,7 @@ func createProbeConfigOrDie(c *Config) *configs.ProbeConfig {
 	kubeletMonitoringConfig := kubelet.NewKubeletMonitorConfig(c.KubeletClient)
 
 	// Create cluster monitoring
-	masterMonitoringConfig := master.NewClusterMonitorConfig(c.Client)
+	masterMonitoringConfig := master.NewClusterMonitorConfig(c.KubeClient)
 
 	// TODO for now kubelet is the only monitoring source. As we have more sources, we should choose what to be added into the slice here.
 	monitoringConfigs := []monitoring.MonitorWorkerConfig{
@@ -96,7 +96,7 @@ func createProbeConfigOrDie(c *Config) *configs.ProbeConfig {
 	probeConfig := &configs.ProbeConfig{
 		StitchingPropertyType: c.StitchingPropType,
 		MonitoringConfigs:     monitoringConfigs,
-		ClusterClient:         c.Client,
+		ClusterClient:         c.KubeClient,
 		NodeClient:            c.KubeletClient,
 	}
 
@@ -118,7 +118,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	probeConfig := createProbeConfigOrDie(config)
 	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig, config.ValidationWorkers, config.ValidationTimeoutSec)
 
-	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.Client, config.KubeletClient, config.SccSupport)
+	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.KubeClient, config.KubeletClient, config.SccSupport)
 
 	// Kubernetes Probe Registration Client
 	registrationClient := registration.NewK8sRegistrationClient(registrationClientConfig)

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -3,8 +3,9 @@ package kubeturbo
 import (
 	"github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
-	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
-	client "k8s.io/client-go/kubernetes"
+	kubeletclient "github.com/turbonomic/kubeturbo/pkg/kubeclient"
+	"k8s.io/client-go/dynamic"
+	kubeclient "k8s.io/client-go/kubernetes"
 )
 
 // Configuration created using the parameters passed to the kubeturbo service container.
@@ -18,8 +19,9 @@ type Config struct {
 	// VMIsBase: Is VM is the base template from kubeturbo, when stitching with other VM probes, should be false;
 	VMIsBase bool
 
-	Client        *client.Clientset
-	KubeletClient *kubeclient.KubeletClient
+	KubeClient    *kubeclient.Clientset
+	DynamicClient dynamic.Interface
+	KubeletClient *kubeletclient.KubeletClient
 	CAClient      *clientset.Clientset
 
 	// Close this to stop all reflectors
@@ -41,8 +43,13 @@ func NewVMTConfig2() *Config {
 	return cfg
 }
 
-func (c *Config) WithKubeClient(client *client.Clientset) *Config {
-	c.Client = client
+func (c *Config) WithKubeClient(client *kubeclient.Clientset) *Config {
+	c.KubeClient = client
+	return c
+}
+
+func (c *Config) WithDynamicClient(client dynamic.Interface) *Config {
+	c.DynamicClient = client
 	return c
 }
 
@@ -51,7 +58,7 @@ func (c *Config) WithClusterAPIClient(client *clientset.Clientset) *Config {
 	return c
 }
 
-func (c *Config) WithKubeletClient(client *kubeclient.KubeletClient) *Config {
+func (c *Config) WithKubeletClient(client *kubeletclient.KubeletClient) *Config {
 	c.KubeletClient = client
 	return c
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,7 +1,0 @@
-package util
-
-const (
-	KindReplicationController = "ReplicationController"
-	KindReplicaSet            = "ReplicaSet"
-	KindDeployment            = "Deployment"
-)

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -1,0 +1,22 @@
+package util
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	KindReplicationController = "ReplicationController"
+	KindReplicaSet            = "ReplicaSet"
+	KindDeployment            = "Deployment"
+
+	K8sExtensionsGroupName = "extensions"
+	K8sAppsGroupName       = "apps"
+
+	ReplicationControllerResName = "replicationcontrollers"
+	ReplicaSetResName            = "replicasets"
+	DeploymentResName            = "deployments"
+)
+
+// The API group version under which deployments and replicasets are exposed by the k8s cluster
+var K8sAPIDeploymentReplicasetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
+
+// The API group under which replicationcontrollers are exposed by the k8s server
+var K8sAPIReplicationControllerGV = schema.GroupVersion{Group: "", Version: "v1"}

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -15,8 +15,15 @@ const (
 	DeploymentResName            = "deployments"
 )
 
-// The API group version under which deployments and replicasets are exposed by the k8s cluster
-var K8sAPIDeploymentReplicasetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
+// The API group version under which deployments and replicasets are exposed by the k8s cluster as of today
+var K8sAPIDeploymentReplicasetDefaultGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
+
+// The API group version under which deployments are exposed by the k8s cluster
+var K8sAPIDeploymentGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
+
+// The API group version under which replicasets are exposed by the k8s cluster
+var K8sAPIReplicasetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
 
 // The API group under which replicationcontrollers are exposed by the k8s server
+// We do not discover the latest GV for this as we know that it has matured under core/v1
 var K8sAPIReplicationControllerGV = schema.GroupVersion{Group: "", Version: "v1"}

--- a/vendor/k8s.io/client-go/dynamic/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/interface.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type Interface interface {
+	Resource(resource schema.GroupVersionResource) NamespaceableResourceInterface
+}
+
+type ResourceInterface interface {
+	Create(obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	Update(obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	UpdateStatus(obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error)
+	Delete(name string, options *metav1.DeleteOptions, subresources ...string) error
+	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
+	List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Patch(name string, pt types.PatchType, data []byte, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
+}
+
+type NamespaceableResourceInterface interface {
+	Namespace(string) ResourceInterface
+	ResourceInterface
+}
+
+// APIPathResolverFunc knows how to convert a groupVersion to its API path. The Kind field is optional.
+// TODO find a better place to move this for existing callers
+type APIPathResolverFunc func(kind schema.GroupVersionKind) string
+
+// LegacyAPIPathResolverFunc can resolve paths properly with the legacy API.
+// TODO find a better place to move this for existing callers
+func LegacyAPIPathResolverFunc(kind schema.GroupVersionKind) string {
+	if len(kind.Group) == 0 {
+		return "/api"
+	}
+	return "/apis"
+}

--- a/vendor/k8s.io/client-go/dynamic/scheme.go
+++ b/vendor/k8s.io/client-go/dynamic/scheme.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+)
+
+var watchScheme = runtime.NewScheme()
+var basicScheme = runtime.NewScheme()
+var deleteScheme = runtime.NewScheme()
+var parameterScheme = runtime.NewScheme()
+var deleteOptionsCodec = serializer.NewCodecFactory(deleteScheme)
+var dynamicParameterCodec = runtime.NewParameterCodec(parameterScheme)
+
+var versionV1 = schema.GroupVersion{Version: "v1"}
+
+func init() {
+	metav1.AddToGroupVersion(watchScheme, versionV1)
+	metav1.AddToGroupVersion(basicScheme, versionV1)
+	metav1.AddToGroupVersion(parameterScheme, versionV1)
+	metav1.AddToGroupVersion(deleteScheme, versionV1)
+}
+
+var watchJsonSerializerInfo = runtime.SerializerInfo{
+	MediaType:        "application/json",
+	EncodesAsText:    true,
+	Serializer:       json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, false),
+	PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, true),
+	StreamSerializer: &runtime.StreamSerializerInfo{
+		EncodesAsText: true,
+		Serializer:    json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, false),
+		Framer:        json.Framer,
+	},
+}
+
+// watchNegotiatedSerializer is used to read the wrapper of the watch stream
+type watchNegotiatedSerializer struct{}
+
+var watchNegotiatedSerializerInstance = watchNegotiatedSerializer{}
+
+func (s watchNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{watchJsonSerializerInfo}
+}
+
+func (s watchNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, encoder, nil, gv, nil)
+}
+
+func (s watchNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, nil, decoder, nil, gv)
+}
+
+// basicNegotiatedSerializer is used to handle discovery and error handling serialization
+type basicNegotiatedSerializer struct{}
+
+func (s basicNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, false),
+			PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, true),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, false),
+				Framer:        json.Framer,
+			},
+		},
+	}
+}
+
+func (s basicNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, encoder, nil, gv, nil)
+}
+
+func (s basicNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, nil, decoder, nil, gv)
+}

--- a/vendor/k8s.io/client-go/dynamic/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/simple.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+type dynamicClient struct {
+	client *rest.RESTClient
+}
+
+var _ Interface = &dynamicClient{}
+
+// NewForConfigOrDie creates a new Interface for the given config and
+// panics if there is an error in the config.
+func NewForConfigOrDie(c *rest.Config) Interface {
+	ret, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+func NewForConfig(inConfig *rest.Config) (Interface, error) {
+	config := rest.CopyConfig(inConfig)
+	// for serializing the options
+	config.GroupVersion = &schema.GroupVersion{}
+	config.APIPath = "/if-you-see-this-search-for-the-break"
+	config.AcceptContentTypes = "application/json"
+	config.ContentType = "application/json"
+	config.NegotiatedSerializer = basicNegotiatedSerializer{} // this gets used for discovery and error handling types
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dynamicClient{client: restClient}, nil
+}
+
+type dynamicResourceClient struct {
+	client    *dynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+func (c *dynamicClient) Resource(resource schema.GroupVersionResource) NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	name := ""
+	if len(subresources) > 0 {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name = accessor.GetName()
+	}
+
+	result := c.client.client.
+		Post().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Put().
+		AbsPath(append(c.makeURLSegments(accessor.GetName()), subresources...)...).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Put().
+		AbsPath(append(c.makeURLSegments(accessor.GetName()), "status")...).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, subresources ...string) error {
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(deleteOptionsByte).
+		Do()
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(c.makeURLSegments("")...).
+		Body(deleteOptionsByte).
+		SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).
+		Do()
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	if list, ok := uncastObj.(*unstructured.UnstructuredList); ok {
+		return list, nil
+	}
+
+	list, err := uncastObj.(*unstructured.Unstructured).ToList()
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	internalGV := schema.GroupVersions{
+		{Group: c.resource.Group, Version: runtime.APIVersionInternal},
+		// always include the legacy group as a decoding target to handle non-error `Status` return types
+		{Group: "", Version: runtime.APIVersionInternal},
+	}
+	s := &rest.Serializers{
+		Encoder: watchNegotiatedSerializerInstance.EncoderForVersion(watchJsonSerializerInfo.Serializer, c.resource.GroupVersion()),
+		Decoder: watchNegotiatedSerializerInstance.DecoderToVersion(watchJsonSerializerInfo.Serializer, internalGV),
+
+		RenegotiatedDecoder: func(contentType string, params map[string]string) (runtime.Decoder, error) {
+			return watchNegotiatedSerializerInstance.DecoderToVersion(watchJsonSerializerInfo.Serializer, internalGV), nil
+		},
+		StreamingSerializer: watchJsonSerializerInfo.StreamSerializer.Serializer,
+		Framer:              watchJsonSerializerInfo.StreamSerializer.Framer,
+	}
+
+	wrappedDecoderFn := func(body io.ReadCloser) streaming.Decoder {
+		framer := s.Framer.NewFrameReader(body)
+		return streaming.NewDecoder(framer, s.StreamingSerializer)
+	}
+
+	opts.Watch = true
+	return c.client.client.Get().AbsPath(c.makeURLSegments("")...).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		WatchWithSpecificDecoders(wrappedDecoderFn, unstructured.UnstructuredJSONScheme)
+}
+
+func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	result := c.client.client.
+		Patch(pt).
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(data).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) makeURLSegments(name string) []string {
+	url := []string{}
+	if len(c.resource.Group) == 0 {
+		url = append(url, "api")
+	} else {
+		url = append(url, "apis", c.resource.Group)
+	}
+	url = append(url, c.resource.Version)
+
+	if len(c.namespace) > 0 {
+		url = append(url, "namespaces", c.namespace)
+	}
+	url = append(url, c.resource.Resource)
+
+	if len(name) > 0 {
+		url = append(url, name)
+	}
+
+	return url
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -222,6 +222,7 @@ k8s.io/apiserver/pkg/util/feature
 k8s.io/apiserver/pkg/util/flag
 # k8s.io/client-go v0.0.0-20181213151034-8d9ed539ba31
 k8s.io/client-go/discovery
+k8s.io/client-go/dynamic
 k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1


### PR DESCRIPTION
This has been done for `replicationcontrollers` `replicasets` and `deployments`.

The code:
- Discovers the group version exposed by the given k8s server
- Uses the discovered group version of the resources with the dynamic client for all get and update operations.
- Modifies `pod utils`, pod `parent controller` and `executor` code to work with `unstructured` content rather then `typed` content. 

@enlinxu @chlam4 @ading1977 