### PR TITLE
OM-50891 Handling of pods on unschedulable nodes

### DIFF
--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -169,7 +169,7 @@ func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node) ([]*
 	// Access commodities: labels.
 	for key, value := range node.ObjectMeta.Labels {
 		label := key + "=" + value
-		glog.V(4).Infof("label for this Node is : %s", label)
+		//glog.V(2).Infof("label for this Node is : %s", label)
 
 		accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
 			Key(label).
@@ -179,18 +179,6 @@ func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node) ([]*
 			return nil, err
 		}
 		commoditiesSold = append(commoditiesSold, accessComm)
-	}
-
-	// Access commodity: schedulable.
-	if util.NodeIsReady(node) && util.NodeIsSchedulable(node) {
-		schedAccessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
-			Key(schedAccessCommodityKey).
-			Capacity(accessCommodityDefaultCapacity).
-			Create()
-		if err != nil {
-			return nil, err
-		}
-		commoditiesSold = append(commoditiesSold, schedAccessComm)
 	}
 
 	// Cluster commodity.

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -169,7 +169,7 @@ func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node) ([]*
 	// Access commodities: labels.
 	for key, value := range node.ObjectMeta.Labels {
 		label := key + "=" + value
-		//glog.V(2).Infof("label for this Node is : %s", label)
+		glog.V(4).Infof("label for this Node is : %s", label)
 
 		accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
 			Key(label).

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -211,7 +211,6 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBought(pod *api.Pod, cpuFre
 	// Access commodities: selectors.
 	for key, value := range pod.Spec.NodeSelector {
 		selector := key + "=" + value
-		//glog.V(2).Infof("%s: node selector is %s", pod.Name, selector)
 		accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
 			Key(selector).
 			Create()

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -211,6 +211,7 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBought(pod *api.Pod, cpuFre
 	// Access commodities: selectors.
 	for key, value := range pod.Spec.NodeSelector {
 		selector := key + "=" + value
+		//glog.V(2).Infof("%s: node selector is %s", pod.Name, selector)
 		accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
 			Key(selector).
 			Create()
@@ -218,17 +219,6 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBought(pod *api.Pod, cpuFre
 			return nil, err
 		}
 		commoditiesBought = append(commoditiesBought, accessComm)
-	}
-
-	// Access commodity: schedulable
-	if util.Controllable(pod) {
-		schedAccessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
-			Key(schedAccessCommodityKey).
-			Create()
-		if err != nil {
-			return nil, err
-		}
-		commoditiesBought = append(commoditiesBought, schedAccessComm)
 	}
 
 	// Cluster commodity.

--- a/pkg/discovery/worker/compliance/schedulable_node_manager.go
+++ b/pkg/discovery/worker/compliance/schedulable_node_manager.go
@@ -1,0 +1,45 @@
+package compliance
+
+import (
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	api "k8s.io/api/core/v1"
+)
+
+type SchedulableNodeManager struct {
+	nodes            map[string]*api.Node
+	schedulableNodes map[string]bool
+}
+
+func NewSchedulableNodeManager(nodes []*api.Node) *SchedulableNodeManager {
+	nodeMap := make(map[string]*api.Node)
+	for _, node := range nodes {
+		nodeMap[node.Name] = node
+	}
+	return &SchedulableNodeManager{
+		nodes:            nodeMap,
+		schedulableNodes: make(map[string]bool),
+	}
+}
+
+func (manager *SchedulableNodeManager) checkNodes() {
+	for _, node := range manager.nodes {
+		schedulable := util.NodeIsReady(node) && util.NodeIsSchedulable(node)
+		manager.schedulableNodes[node.Name] = schedulable
+		glog.Infof("##### Node %s: %s #####", node.Name, schedulable)
+	}
+}
+
+func (manager *SchedulableNodeManager) CheckSchedulable(node *api.Node) bool {
+	if len(manager.schedulableNodes) == 0 {
+		manager.checkNodes()
+	}
+	return manager.schedulableNodes[node.Name]
+}
+
+func (manager *SchedulableNodeManager) CheckSchedulableByName(nodeName string) bool {
+	if len(manager.schedulableNodes) == 0 {
+		manager.checkNodes()
+	}
+	return manager.schedulableNodes[nodeName]
+}

--- a/pkg/discovery/worker/compliance/schedulable_node_manager.go
+++ b/pkg/discovery/worker/compliance/schedulable_node_manager.go
@@ -1,7 +1,6 @@
 package compliance
 
 import (
-	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	api "k8s.io/api/core/v1"
 )
@@ -26,7 +25,6 @@ func (manager *SchedulableNodeManager) checkNodes() {
 	for _, node := range manager.nodes {
 		schedulable := util.NodeIsReady(node) && util.NodeIsSchedulable(node)
 		manager.schedulableNodes[node.Name] = schedulable
-		glog.Infof("##### Node %s: %s #####", node.Name, schedulable)
 	}
 }
 

--- a/pkg/discovery/worker/compliance/taint_toleration_processor.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	api "k8s.io/api/core/v1"
 
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
@@ -8,6 +9,8 @@ import (
 
 	"github.com/golang/glog"
 )
+
+const schedAccessCommodityKey string = "schedulable"
 
 type NodeAndPodGetter interface {
 	GetAllNodes() ([]*api.Node, error)
@@ -26,6 +29,9 @@ type TaintTolerationProcessor struct {
 
 	// Map of node uid indexed by node name
 	nodeNameToUID map[string]string
+
+	// Manager for schedulable nodes
+	nodesManager *SchedulableNodeManager
 }
 
 func NewTaintTolerationProcessor(nodeAndPodGetter NodeAndPodGetter) (*TaintTolerationProcessor, error) {
@@ -40,6 +46,7 @@ func NewTaintTolerationProcessor(nodeAndPodGetter NodeAndPodGetter) (*TaintToler
 
 	nodeMap := make(map[string]*api.Node)
 	nodeNameToUID := make(map[string]string)
+
 	for _, node := range nodes {
 		nodeMap[string(node.UID)] = node
 		nodeNameToUID[node.Name] = string(node.UID)
@@ -50,10 +57,14 @@ func NewTaintTolerationProcessor(nodeAndPodGetter NodeAndPodGetter) (*TaintToler
 		podMap[string(pod.UID)] = pod
 	}
 
+	nodesManager := NewSchedulableNodeManager(nodes)
+	nodesManager.checkNodes()
+
 	return &TaintTolerationProcessor{
 		nodes:         nodeMap,
 		pods:          podMap,
 		nodeNameToUID: nodeNameToUID,
+		nodesManager:  nodesManager,
 	}, nil
 }
 
@@ -65,13 +76,14 @@ func (t *TaintTolerationProcessor) Process(entityDTOs []*proto.EntityDTO) {
 
 	nodeDTOs, podDTOs := retrieveNodeAndPodDTOs(entityDTOs)
 
-	createAccessCommoditiesSold(nodeDTOs, t.nodes, taintCollection)
+	t.createAccessCommoditiesSold(nodeDTOs, t.nodes, taintCollection)
 
-	createAccessCommoditiesBought(podDTOs, t.pods, t.nodeNameToUID, taintCollection)
+	t.createAccessCommoditiesBought(podDTOs, t.pods, t.nodeNameToUID, taintCollection)
 }
 
 // Creates access commodities sold by VMs.
-func createAccessCommoditiesSold(nodeDTOs []*proto.EntityDTO, nodes map[string]*api.Node, taintCollection map[api.Taint]string) {
+func (t *TaintTolerationProcessor) createAccessCommoditiesSold(nodeDTOs []*proto.EntityDTO, nodes map[string]*api.Node,
+	taintCollection map[api.Taint]string) {
 	for _, nodeDTO := range nodeDTOs {
 		node, ok := nodes[*nodeDTO.Id]
 		if !ok {
@@ -79,6 +91,14 @@ func createAccessCommoditiesSold(nodeDTOs []*proto.EntityDTO, nodes map[string]*
 			continue
 		}
 
+		// Schedulable
+		schedulableAccessComm, err := createSchedulableSoldComms(node, t.nodesManager)
+
+		if schedulableAccessComm != nil {
+			nodeDTO.CommoditiesSold = append(nodeDTO.CommoditiesSold, schedulableAccessComm)
+		}
+
+		// Taints
 		taintAccessComms, err := createTaintAccessComms(node, taintCollection)
 		if err != nil {
 			glog.Errorf("Error while process taints for node %s", node.GetName())
@@ -90,7 +110,7 @@ func createAccessCommoditiesSold(nodeDTOs []*proto.EntityDTO, nodes map[string]*
 }
 
 // Creates access commodities bought by ContainerPods.
-func createAccessCommoditiesBought(podDTOs []*proto.EntityDTO, pods map[string]*api.Pod, nodeNameToUID map[string]string, taintCollection map[api.Taint]string) {
+func (t *TaintTolerationProcessor) createAccessCommoditiesBought(podDTOs []*proto.EntityDTO, pods map[string]*api.Pod, nodeNameToUID map[string]string, taintCollection map[api.Taint]string) {
 	for _, podDTO := range podDTOs {
 		pod, ok := pods[*podDTO.Id]
 		if !ok {
@@ -104,10 +124,18 @@ func createAccessCommoditiesBought(podDTOs []*proto.EntityDTO, pods map[string]*
 			continue
 		}
 
+		// Schedulable
+		schedulableComm, _ := createSchedulableBoughtComms(pod, t.nodesManager)
+
+		// Toleration
 		tolerateAccessComms, err := createTolerationAccessComms(pod, taintCollection)
 		if err != nil {
 			glog.Errorf("Error while process tolerations for pod %s", pod.GetName())
 			continue
+		}
+
+		if schedulableComm != nil {
+			tolerateAccessComms = append(tolerateAccessComms, schedulableComm)
 		}
 
 		podBuysCommodities(podDTO, tolerateAccessComms, providerId)
@@ -157,7 +185,7 @@ func getTaintCollection(nodes map[string]*api.Node) map[api.Taint]string {
 		for _, taint := range taints {
 			if taint.Effect == api.TaintEffectNoExecute || taint.Effect == api.TaintEffectNoSchedule {
 				taintCollection[taint] = taint.Key + "=" + taint.Value + ":" + string(taint.Effect)
-				glog.V(4).Infof("Found taint (comm key = %s): %+v)", taintCollection[taint], taint)
+				glog.V(2).Infof("Found taint (comm key = %s): %+v)", taintCollection[taint], taint)
 			}
 		}
 	}
@@ -194,7 +222,7 @@ func createTaintAccessComms(node *api.Node, taintCollection map[api.Taint]string
 				return nil, err
 			}
 			visited[key] = true
-			glog.V(4).Infof("Created access commodity with key %s for node %s", key, node.GetName())
+			glog.V(2).Infof("Created access commodity with key %s for node %s", key, node.GetName())
 
 			accessComms = append(accessComms, accessComm)
 		}
@@ -217,6 +245,7 @@ func createTolerationAccessComms(pod *api.Pod, taintCollection map[api.Taint]str
 		}
 		// If the pod doesn't have the proper toleration, create access commodity to buy
 		if !TolerationsTolerateTaint(pod.Spec.Tolerations, &taint) {
+
 			accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
 				Key(key).
 				Capacity(accessCommodityDefaultCapacity).
@@ -226,7 +255,7 @@ func createTolerationAccessComms(pod *api.Pod, taintCollection map[api.Taint]str
 				return nil, err
 			}
 			visited[key] = true
-			glog.V(4).Infof("Created access commodity with key %s for pod %s", key, pod.GetName())
+			glog.V(2).Infof("Created access commodity with key %s for pod %s", key, pod.GetName())
 
 			accessComms = append(accessComms, accessComm)
 		}
@@ -245,4 +274,58 @@ func TolerationsTolerateTaint(tolerations []api.Toleration, taint *api.Taint) bo
 		}
 	}
 	return false
+}
+
+// Create an access commodity for schedulable nodes to serve as provider for pods.
+// Access commodity with a special key 'schedulable' is used to represent the fact
+// that a node can serve as providers for pods.
+func createSchedulableSoldComms(node *api.Node, nodesManager *SchedulableNodeManager) (*proto.CommodityDTO, error) {
+	// Access commodity: schedulable.
+	schedulable := nodesManager.CheckSchedulable(node)
+
+	//We create an Access commodity with a special key 'schedulable' to indicate to the market that this node
+	// is a provider for pods
+	if schedulable {
+		schedAccessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
+			Key(schedAccessCommodityKey).
+			Capacity(accessCommodityDefaultCapacity).
+			Create()
+		if err != nil {
+			return nil, err
+		}
+
+		return schedAccessComm, nil
+	} else {
+		glog.V(4).Infof("Skip schedulable commodity for node %s", node.Name)
+	}
+
+	return nil, nil
+}
+
+// Create an access commodity for the pods so it can run nodes selling the same commodity.
+// Access commodity with a special key 'schedulable' is used to represent the fact
+// that a pod can run on a node that is a valid provider. This node will sell the corresponding commodity.
+func createSchedulableBoughtComms(pod *api.Pod, nodesManager *SchedulableNodeManager) (*proto.CommodityDTO, error) {
+	nodeName := pod.Spec.NodeName
+	schedulable := nodesManager.CheckSchedulableByName(nodeName)
+
+	// Pods buy an access commodity with the special key 'schedulable' to imply that they can be deployed
+	// or run on the node that sells the same commodity.
+	// When a node becomes unschedulable, it is desirable that the pods already running on the node
+	// continue to stay on the node unless there is a resource(compute) constraint or policy violation.
+	// To prevent Turbo to give recommendations to move these pods, the schedulable access commodity for the pod
+	// is created only when it is running on a node that is schedulable
+	if schedulable {
+		if util.Controllable(pod) {
+			schedAccessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
+				Key(schedAccessCommodityKey).
+				Create()
+			if err != nil {
+				return nil, err
+			}
+			return schedAccessComm, nil
+		}
+	}
+
+	return nil, nil
 }

--- a/pkg/discovery/worker/compliance/taint_toleration_processor.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor.go
@@ -222,7 +222,7 @@ func createTaintAccessComms(node *api.Node, taintCollection map[api.Taint]string
 				return nil, err
 			}
 			visited[key] = true
-			glog.V(2).Infof("Created access commodity with key %s for node %s", key, node.GetName())
+			glog.V(4).Infof("Created access commodity with key %s for node %s", key, node.GetName())
 
 			accessComms = append(accessComms, accessComm)
 		}
@@ -245,7 +245,6 @@ func createTolerationAccessComms(pod *api.Pod, taintCollection map[api.Taint]str
 		}
 		// If the pod doesn't have the proper toleration, create access commodity to buy
 		if !TolerationsTolerateTaint(pod.Spec.Tolerations, &taint) {
-
 			accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
 				Key(key).
 				Capacity(accessCommodityDefaultCapacity).
@@ -255,7 +254,7 @@ func createTolerationAccessComms(pod *api.Pod, taintCollection map[api.Taint]str
 				return nil, err
 			}
 			visited[key] = true
-			glog.V(2).Infof("Created access commodity with key %s for pod %s", key, pod.GetName())
+			glog.V(4).Infof("Created access commodity with key %s for pod %s", key, pod.GetName())
 
 			accessComms = append(accessComms, accessComm)
 		}


### PR DESCRIPTION
Nodes in Kubernetes where new pods can be deployed are marked as 'schedulable'. This property is used to by Turbo to consider the node as a provider for moving pods.

We use Access commodity with a special key 'schedulable' to represent nodes that can serve as providers for pods.
- Nodes selling this commodity will accept pods.
- Pods buying this commodity can move to these nodes

Often a node is marked unschedulable for maintenance purposes or to prevent pods from being deployed to it. In this case, Turbo will not create the access commodity and the node will stop being a providers for pods, so there will be not be any recommendations to move pods to this node.

There is an issue on how to handle the pods that are already deployed on the unschedulable nodes. These pods are there for reasons such as 
- Pod is configured with toleration for unschedulable nodes
- Pod was deployed before the node was made unschedulable
- Specific node selectors led the pod to be deployed to this node

For these pods, it is desirable that the pods continue to stay on the node unless there is a resource(compute) constraint or policy violation. We don't want Turbo to give recommendations to move these pods.
In this change, we create the schedulable access commodity for pod when the underlying node is schedulable. When the node is unschedulable, the commodity is not created(or deleted) to prevent it from being moved out of the node.