### PR TITLE
Group creation fixes

### DIFF
--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -172,7 +172,7 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework() ([]*proto.EntityDTO, []
 	dc.config.probeConfig.NodeClient.CleanupCache(nodes)
 
 	workerCount := dc.dispatcher.Dispatch(nodes, clusterSummary)
-	entityDTOs, quotaMetricsList, policyGroupList := dc.resultCollector.Collect(workerCount)
+	entityDTOs, quotaMetricsList, entityGroupList := dc.resultCollector.Collect(workerCount)
 
 	// Quota discovery worker to create quota DTOs
 	stitchType := dc.config.probeConfig.StitchingPropertyType
@@ -220,7 +220,7 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework() ([]*proto.EntityDTO, []
 	// Discovery worker for creating Group DTOs
 	targetId := dc.config.targetConfig.TargetIdentifier
 	entityGroupDiscoveryWorker := worker.Newk8sEntityGroupDiscoveryWorker(clusterSummary, targetId)
-	groupDTOs, _ := entityGroupDiscoveryWorker.Do(policyGroupList)
+	groupDTOs, _ := entityGroupDiscoveryWorker.Do(entityGroupList)
 
 	glog.V(2).Infof("There are totally %d groups DTOs", len(groupDTOs))
 	if glog.V(4) {

--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -46,27 +46,26 @@ func (worker *k8sEntityGroupDiscoveryWorker) Do(entityGroupList []*repository.En
 		if groupExists {
 			// groups by entity type
 			for etype, newmembers := range entityGroup.Members {
-				members, hasMembers := existingGroup.Members[etype]
-				if hasMembers {
-					existingGroup.Members[etype] = append(members, newmembers...)
+				if _, hasMembers := existingGroup.Members[etype]; hasMembers {
+					existingGroup.Members[etype] = append(existingGroup.Members[etype], newmembers...)
 				}
 			}
 
 			// groups by container names
 			for containerName, newMembers := range entityGroup.ContainerGroups {
-				members, hasMembers := existingGroup.ContainerGroups[containerName]
-				if hasMembers {
-					existingGroup.ContainerGroups[containerName] = append(members, newMembers...)
+				if _, hasMembers := existingGroup.ContainerGroups[containerName]; hasMembers {
+					existingGroup.ContainerGroups[containerName] = append(existingGroup.ContainerGroups[containerName], newMembers...)
+				} else {
+					existingGroup.ContainerGroups[containerName] = newMembers
 				}
 			}
-
 		} else {
 			entityGroupMap[groupId] = entityGroup
 		}
 	}
 
 	if glog.V(4) {
-		for _, entityGroup := range entityGroupList {
+		for _, entityGroup := range entityGroupMap {
 			glog.Infof("Group --> %s::%s\n", entityGroup.ParentKind, entityGroup.ParentName)
 			for etype, members := range entityGroup.Members {
 				glog.Infof("	Members: %s -> %s", etype, members)

--- a/pkg/discovery/worker/group_metrics_collector.go
+++ b/pkg/discovery/worker/group_metrics_collector.go
@@ -48,7 +48,7 @@ func (collector *GroupMetricsCollector) CollectGroupMetrics() ([]*repository.Ent
 		}
 		ownerTypeMap = entityGroups[ownerTypeString]
 		if ownerString != "" {
-			entityGroup, groupExists := ownerTypeMap[ownerTypeString]
+			entityGroup, groupExists := ownerTypeMap[ownerString]
 			if !groupExists {
 				// Create a new group for parent type & instance
 				entityGroup, _ := repository.NewEntityGroup(ownerTypeString, ownerString)


### PR DESCRIPTION
We create groups (of containers and pods) by parent workload type while discovering the cluster and report the same to opsmgr.
These groups are available to set useful policies.
The reported groups so far were one per parent kind per parent and one single group per parent type (for example `pods by all deployments` across the cluster) was missing.
Interestingly and incidentally, some code to do that already did exist but had flaws.
This PR fixes that.
I am sure this is useful to any of our customers who actually uses the containers featureset.