### PR TITLE
Option to consume opsmgr credentials via secret

### DIFF
--- a/deploy/kubeturbo_yamls/turbo_kubeturboDeploy_RBAC_sample.yml
+++ b/deploy/kubeturbo_yamls/turbo_kubeturboDeploy_RBAC_sample.yml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: kubeturbo
           # Replace the image with desired version. Refer to readme in deploy for more details
-          image: turbonomic/kubeturbo:6.4.0
+          image: turbonomic/kubeturbo:7.21.0
           imagePullPolicy: IfNotPresent
           args:
             - --turboconfig=/etc/kubeturbo/turbo.config
@@ -36,6 +36,9 @@ spec:
             - name: turbo-volume
               mountPath: /etc/kubeturbo
               readOnly: true
+            - name: turbonomic-credentials-volume
+              mountPath: /etc/turbonomic-credentials
+              readOnly: true
             - name: varlog
               mountPath: /var/log
       volumes:
@@ -43,6 +46,12 @@ spec:
           configMap:
             # Update configMap name if needed
             name: turbo-config
+        - name: turbonomic-credentials-volume
+          secret:
+            defaultMode: 420
+            optional: true
+            # Update secret name if needed
+            secretName: turbonomic-credentials
         - name: varlog
           emptyDir: {}
       restartPolicy: Always

--- a/deploy/kubeturbo_yamls/turbo_opsmgr_credentials_secret_sample.yaml
+++ b/deploy/kubeturbo_yamls/turbo_opsmgr_credentials_secret_sample.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: turbonomic-credentials
+  namespace: turbo
+type: Opaque
+data:
+  username: #####<replace with base64 encoded value>
+  password: #####<replace with base64 encoded value>

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
 	"io/ioutil"
+	"os"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
 
 	restclient "k8s.io/client-go/rest"
 
@@ -21,6 +23,11 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master"
+)
+
+const (
+	usernameFilePath = "/etc/turbonomic-credentials/username"
+	passwordFilePath = "/etc/turbonomic-credentials/password"
 )
 
 type K8sTAPServiceSpec struct {
@@ -42,6 +49,11 @@ func ParseK8sTAPServiceSpec(configFile, defaultTargetName string) (*K8sTAPServic
 	if tapSpec.TurboCommunicationConfig == nil {
 		return nil, errors.New("communication config is missing")
 	}
+
+	if err := loadOpsMgrCredentialsFromSecret(tapSpec); err != nil {
+		return nil, err
+	}
+
 	if err := tapSpec.ValidateTurboCommunicationConfig(); err != nil {
 		return nil, err
 	}
@@ -52,6 +64,7 @@ func ParseK8sTAPServiceSpec(configFile, defaultTargetName string) (*K8sTAPServic
 		}
 		tapSpec.K8sTargetConfig = &configs.K8sTargetConfig{TargetIdentifier: defaultTargetName}
 	}
+
 	if err := tapSpec.ValidateK8sTargetConfig(); err != nil {
 		return nil, err
 	}
@@ -61,6 +74,33 @@ func ParseK8sTAPServiceSpec(configFile, defaultTargetName string) (*K8sTAPServic
 		tapSpec.DaemonPodDetectors, tapSpec.HANodeConfig)
 
 	return tapSpec, nil
+}
+
+func loadOpsMgrCredentialsFromSecret(tapSpec *K8sTAPServiceSpec) error {
+	// Return unchanged if the mounted file isn't present
+	// for backward compatibility.
+	if _, err := os.Stat(usernameFilePath); os.IsNotExist(err) {
+		glog.V(3).Infof("credentials from secret unavailable. Checked path: %s", usernameFilePath)
+		return nil
+	}
+	if _, err := os.Stat(passwordFilePath); os.IsNotExist(err) {
+		glog.V(3).Infof("credentials from secret unavailable. Checked path: %s", passwordFilePath)
+		return nil
+	}
+
+	username, err := ioutil.ReadFile(usernameFilePath)
+	if err != nil {
+		return fmt.Errorf("error reading credentials from secret: username: %v", err)
+	}
+	password, err := ioutil.ReadFile(passwordFilePath)
+	if err != nil {
+		return fmt.Errorf("error reading credentials from secret: password: %v", err)
+	}
+
+	tapSpec.OpsManagerUsername = string(username[:len(username)-1])
+	tapSpec.OpsManagerPassword = string(password[:len(password)-1])
+
+	return nil
 }
 
 func readK8sTAPServiceSpec(path string) (*K8sTAPServiceSpec, error) {


### PR DESCRIPTION
The change is backward compatible. If the secret is not provided or its not loaded for some reason, the code will fallback on reading the credentials from kubeturbo configmap. If both are provided, the ones in secret are used.
The values in the secret need to be `base64` encoded as described [here](https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-manually)
I have update sample yamls, but don't have access to documentation in the wiki (which will also need update to describe this change).

Fixes https://vmturbo.atlassian.net/browse/OM-55403