### PR TITLE
OM-55951: Implement gathering relevant storage metrics per pod

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -32,6 +32,7 @@ var (
 		metrics.CPURequest,
 		metrics.MemoryRequest,
 		metrics.NumPods,
+		metrics.VStorage,
 		// TODO, add back provisioned commodity later
 	}
 

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
@@ -60,6 +60,13 @@ func createPodStat(podname string) *stats.PodStats {
 		Containers: containers,
 	}
 
+	fsStats := &stats.FsStats{}
+	capacity := uint64(rand.Intn(200) * 1e9)
+	used := uint64(rand.Intn(100) * 1e9)
+	fsStats.CapacityBytes = &capacity
+	fsStats.UsedBytes = &used
+	pod.EphemeralStorage = fsStats
+
 	return pod
 }
 

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -250,6 +250,7 @@ func (f *SupplyChainFactory) buildPodSupplyBuilder() (*proto.TemplateDTO, error)
 		Buys(vCpuRequestTemplateComm).
 		Buys(vMemRequestTemplateComm).
 		Buys(numPodNumConsumersTemplateComm).
+		Buys(vStorageTemplateComm).
 		Provider(proto.EntityDTO_VIRTUAL_DATACENTER, proto.Provider_LAYERED_OVER).
 		Buys(cpuAllocationTemplateCommWithKey).
 		Buys(memAllocationTemplateCommWithKey).


### PR DESCRIPTION
Implements code for https://vmturbo.atlassian.net/browse/OM-55951.
This PR currently picks the ephemeral storage details used by the pods. Future work will improve on this and include details of persistent volumes used by pods. 
This is on top of #383 and only last 2 commits are reviewable here.
Please ensure that #383 merges before this one.