### PR TITLE
Send a regular group of VMs that belong to the cluster

### DIFF
--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -84,8 +84,8 @@ func (worker *k8sEntityGroupDiscoveryWorker) Do(entityGroupList []*repository.En
 	groupDTOs = groupDtoBuilder.BuildGroupDTOs()
 
 	// Create DTO for cluster
-	clusterDTO := dtofactory.NewClusterDTOBuilder(worker.cluster, worker.targetId).Build()
-	if clusterDTO != nil {
+	clusterDTOs := dtofactory.NewClusterDTOBuilder(worker.cluster, worker.targetId).Build()
+	for _, clusterDTO := range clusterDTOs {
 		groupDTOs = append(groupDTOs, clusterDTO)
 	}
 


### PR DESCRIPTION
This pull request allows `kubeturbo` to send a regular group of VMs without cluster constraint. This is in addition to the existing cluster group. This new VM group is needed in `7.21.1` server to create user policies for VMs in a k8s cluster. It can be removed when the server is upgraded to `7.21.2+`.

Tests:

Verify that `VMs By Cluster [cluster name]` is showing up in the list of VM groups when creating a user policies for Virtual Machine:

![image](https://user-images.githubusercontent.com/10012486/76252977-2821ca00-6220-11ea-98c1-e2e6872ffd58.png)

