### PR TITLE
kubeturbo operator support for http proxy

### DIFF
--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -7,11 +7,11 @@ data:
     {
       "communicationConfig": {
         "serverMeta": {
+        {{- if .Values.serverMeta.proxy }}
+          "proxy": "{{ .Values.serverMeta.proxy }}",
+        {{- end }}
           "version": "{{ .Values.serverMeta.version }}",
           "turboServer": "{{ .Values.serverMeta.turboServer }}"
-        {{- if .Values.serverMeta.proxy }}
-          "proxy": "{{ .Values.serverMeta.proxy }}"
-        {{- end }}
         },
         "restAPIConfig": {
           "opsManagerUserName": "{{ .Values.restAPIConfig.opsManagerUserName }}",

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -9,6 +9,9 @@ data:
         "serverMeta": {
           "version": "{{ .Values.serverMeta.version }}",
           "turboServer": "{{ .Values.serverMeta.turboServer }}"
+        {{- if .Values.serverMeta.proxy }}
+          "proxy": "{{ .Values.serverMeta.proxy }}"
+        {{- end }}
         },
         "restAPIConfig": {
           "opsManagerUserName": "{{ .Values.restAPIConfig.opsManagerUserName }}",

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -18,6 +18,7 @@ roleName: "cluster-admin"
 serverMeta:
   version: 7.21
   turboServer: https://Turbo_server_URL
+#  proxy: http://username:password@proxyserver:proxyport
 
 # Turbo server api user and password stored in a secret or optionally specified as username and password
 # The opsManagerUserName requires Turbo administrator role

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -7,11 +7,11 @@ data:
     {
       "communicationConfig": {
         "serverMeta": {
+        {{- if .Values.serverMeta.proxy }}
+          "proxy": "{{ .Values.serverMeta.proxy }}",
+        {{- end }}
           "version": "{{ .Values.serverMeta.version }}",
           "turboServer": "{{ .Values.serverMeta.turboServer }}"
-        {{- if .Values.serverMeta.proxy }}
-          "proxy": "{{ .Values.serverMeta.proxy }}"
-        {{- end }}
         },
         "restAPIConfig": {
           "opsManagerUserName": "{{ .Values.restAPIConfig.opsManagerUserName }}",

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -9,6 +9,9 @@ data:
         "serverMeta": {
           "version": "{{ .Values.serverMeta.version }}",
           "turboServer": "{{ .Values.serverMeta.turboServer }}"
+        {{- if .Values.serverMeta.proxy }}
+          "proxy": "{{ .Values.serverMeta.proxy }}"
+        {{- end }}
         },
         "restAPIConfig": {
           "opsManagerUserName": "{{ .Values.restAPIConfig.opsManagerUserName }}",

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -18,6 +18,7 @@ roleName: "cluster-admin"
 serverMeta:
   version: 7.21
   turboServer: https://Turbo_server_URL
+#  proxy: http://username:password@proxyserver:proxyport
 
 # Turbo server api user and password stored in a secret or optionally specified as username and password
 # The opsManagerUserName requires Turbo administrator role


### PR DESCRIPTION
```
helm install kubeturbo kubeturbo --dry-run --debug --set serverMeta.proxy=http://proxy:8080
---
# Source: kubeturbo/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: turbo-config-kubeturbo
data:
  turbo.config: |-
    {
      "communicationConfig": {
        "serverMeta": {
          "version": "7.21",
          "turboServer": "https://Turbo_server_URL"
          "proxy": "http://proxy:8080"
        },
        "restAPIConfig": {
          "opsManagerUserName": "Turbo_username",
          "opsManagerPassword": "Turbo_password"
        }
      },
      "HANodeConfig": {
        "nodeRoles": ["master"]
      }
    }
...
```