### PR TITLE
Persistent volumes support

### DIFF
--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+
 	"k8s.io/client-go/dynamic"
 
 	api "k8s.io/api/core/v1"
@@ -32,6 +33,8 @@ type ClusterScraperInterface interface {
 	GetAllEndpoints() ([]*api.Endpoints, error)
 	GetAllServices() ([]*api.Service, error)
 	GetKubernetesServiceID() (svcID string, err error)
+	GetAllPVs() ([]*api.PersistentVolume, error)
+	GetAllPVCs() ([]*api.PersistentVolumeClaim, error)
 }
 
 type ClusterScraper struct {
@@ -221,4 +224,42 @@ func (s *ClusterScraper) findRunningPodsOnNode(nodeName string) ([]*api.Pod, err
 		pods[i] = &podList.Items[i]
 	}
 	return pods, nil
+}
+
+func (s *ClusterScraper) GetAllPVs() ([]*api.PersistentVolume, error) {
+	listOption := metav1.ListOptions{
+		LabelSelector: labelSelectEverything,
+	}
+
+	pvList, err := s.CoreV1().PersistentVolumes().List(listOption)
+	if err != nil {
+		return nil, err
+	}
+
+	pvs := make([]*api.PersistentVolume, len(pvList.Items))
+	for i := 0; i < len(pvList.Items); i++ {
+		pvs[i] = &pvList.Items[i]
+	}
+	return pvs, nil
+}
+
+func (s *ClusterScraper) GetAllPVCs() ([]*api.PersistentVolumeClaim, error) {
+	listOption := metav1.ListOptions{
+		LabelSelector: labelSelectEverything,
+	}
+
+	return s.GetPVCs(api.NamespaceAll, listOption)
+}
+
+func (s *ClusterScraper) GetPVCs(namespace string, opts metav1.ListOptions) ([]*api.PersistentVolumeClaim, error) {
+	pvcList, err := s.CoreV1().PersistentVolumeClaims(namespace).List(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	pvcs := make([]*api.PersistentVolumeClaim, len(pvcList.Items))
+	for i := 0; i < len(pvcList.Items); i++ {
+		pvcs[i] = &pvcList.Items[i]
+	}
+	return pvcs, nil
 }

--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -27,6 +27,7 @@ var (
 		metrics.MemoryRequestQuota: proto.CommodityDTO_MEM_REQUEST_ALLOCATION,
 		metrics.NumPods:            proto.CommodityDTO_NUMBER_CONSUMERS,
 		metrics.VStorage:           proto.CommodityDTO_VSTORAGE,
+		metrics.StorageAmount:      proto.CommodityDTO_STORAGE_AMOUNT,
 	}
 )
 

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 
@@ -62,8 +63,9 @@ func NewPodEntityDTOBuilder(sink *metrics.EntityMetricSink, stitchingManager *st
 }
 
 // Build entityDTOs based on the given pod list.
-func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod) ([]*proto.EntityDTO, error) {
+func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod, podToVolsMap map[string][]repository.MountedVolume) ([]*proto.EntityDTO, error) {
 	var result []*proto.EntityDTO
+
 	for _, pod := range pods {
 		// id.
 		podID := string(pod.UID)
@@ -109,6 +111,12 @@ func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod) ([]*proto.E
 		}
 
 		entityDTOBuilder.BuysCommodities(commoditiesBought)
+
+		// Commodities bought from volumes
+		err = builder.buyCommoditiesFromVolumes(pod, podToVolsMap[displayName], entityDTOBuilder)
+		if err != nil {
+			return nil, err
+		}
 
 		// commodities bought - from namespace provider
 		quotaUID, exists := builder.quotaNameUIDMap[pod.Namespace]
@@ -288,6 +296,44 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBoughtFromQuota(quotaUID st
 		commoditiesBought = append(commoditiesBought, commBought)
 	}
 	return commoditiesBought, nil
+}
+
+// Build the CommodityDTOs bought by the pod from the Volumes.
+func (builder *podEntityDTOBuilder) buyCommoditiesFromVolumes(pod *api.Pod, mounts []repository.MountedVolume, dtoBuilder *sdkbuilder.EntityDTOBuilder) error {
+	podKey := util.PodKeyFunc(pod)
+
+	for _, mount := range mounts {
+		mountName := mount.MountName
+		volEntityID := util.PodVolumeMetricId(podKey, mountName)
+		// We use <ns>/<pod-name>/<mounted-vol-name> as the commodity key
+		// to keep the relationship between pod and volume unique.
+		commKey := fmt.Sprintf("%s/%s", podKey, mountName)
+		commBought, err := builder.getResourceCommodityBoughtWithKey(metrics.PodType, volEntityID,
+			metrics.StorageAmount, commKey, nil, nil)
+		if err != nil {
+			glog.Errorf("Failed to build %s bought by pod %s mounted %s from volume %s: %v",
+				metrics.StorageAmount, podKey, mountName, mount.UsedVolume.Name, err)
+			return err
+		}
+
+		if mount.UsedVolume == nil {
+			glog.Errorf("Error when create commoditiesBought for pod %s mounting %s: Cannot find uuid for provider "+
+				"Vol: ", podKey, mountName)
+			continue
+		}
+
+		providerVolUID := string(mount.UsedVolume.UID)
+
+		provider := sdkbuilder.CreateProvider(proto.EntityDTO_VIRTUAL_VOLUME, providerVolUID)
+		dtoBuilder = dtoBuilder.Provider(provider)
+
+		// Each pod mounts any given volume only once
+		var singleCommoditySlice []*proto.CommodityDTO
+		singleCommoditySlice = append(singleCommoditySlice, commBought)
+		dtoBuilder.BuysCommodities(singleCommoditySlice)
+	}
+
+	return nil
 }
 
 // Get the properties of the pod. This includes property related to pod cluster property.

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -3,11 +3,12 @@ package dtofactory
 import (
 	"testing"
 
+	"reflect"
+
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 )
 
 var builder = &podEntityDTOBuilder{

--- a/pkg/discovery/dtofactory/property/volume_properties.go
+++ b/pkg/discovery/dtofactory/property/volume_properties.go
@@ -1,0 +1,23 @@
+package property
+
+import (
+	api "k8s.io/api/core/v1"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+const (
+	k8sVolumeName = "KubernetesVolumeName"
+)
+
+// Build entity properties for a volume. The name is the name of the volume shown inside Kubernetes cluster.
+func BuildVolumeProperties(vol *api.PersistentVolume) *proto.EntityDTO_EntityProperty {
+	propertyNamespace := k8sPropertyNamespace
+	propertyName := k8sVolumeName
+	propertyValue := vol.Name
+	return &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &propertyName,
+		Value:     &propertyValue,
+	}
+}

--- a/pkg/discovery/dtofactory/volume_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/volume_entity_dto_builder.go
@@ -1,0 +1,128 @@
+package dtofactory
+
+import (
+	"fmt"
+
+	api "k8s.io/api/core/v1"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
+	"github.com/golang/glog"
+)
+
+type volumeEntityDTOBuilder struct {
+	podVolumeMetrics []*repository.PodVolumeMetrics
+}
+
+func NewVolumeEntityDTOBuilder(podVolumeMetrics []*repository.PodVolumeMetrics) *volumeEntityDTOBuilder {
+	return &volumeEntityDTOBuilder{
+		podVolumeMetrics: podVolumeMetrics,
+	}
+}
+
+// Build entityDTOs based on the given volume to pod mappings.
+func (builder *volumeEntityDTOBuilder) BuildEntityDTOs(volToPodsMap map[*api.PersistentVolume][]repository.PodVolume) ([]*proto.EntityDTO, error) {
+	var result []*proto.EntityDTO
+
+	for vol, podVolumes := range volToPodsMap {
+		volID := string(vol.UID)
+		entityDTOBuilder := sdkbuilder.NewEntityDTOBuilder(proto.EntityDTO_VIRTUAL_VOLUME, volID)
+		displayName := vol.Name
+		entityDTOBuilder.DisplayName(displayName)
+
+		commoditiesSold, cap, err := builder.getVolumeCommoditiesSold(vol, podVolumes)
+		if err != nil {
+			glog.Errorf("Error when create commoditiesSold for volume %s: %s", displayName, err)
+		}
+
+		entityDTOBuilder.SellsCommodities(commoditiesSold)
+
+		// entities' properties.
+		properties := builder.getVolumeProperties(vol)
+		entityDTOBuilder = entityDTOBuilder.WithProperties(properties)
+
+		entityDTOBuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
+
+		// build entityDTO.
+		entityDto, err := entityDTOBuilder.Create()
+		if err != nil {
+			glog.Errorf("Failed to build Volume: %s entityDTO: %s", displayName, err)
+			continue
+		}
+
+		volCapacity := float32(cap)
+		isEphemaral := false
+		virtualVolumeData := &proto.EntityDTO_VirtualVolumeData{
+			StorageAmountCapacity: &volCapacity,
+			IsEphemeral:           &isEphemaral,
+		}
+		entityDto.EntityData = &proto.EntityDTO_VirtualVolumeData_{VirtualVolumeData: virtualVolumeData}
+
+		result = append(result, entityDto)
+	}
+
+	return result, nil
+
+}
+
+func (builder *volumeEntityDTOBuilder) getVolumeCommoditiesSold(vol *api.PersistentVolume, podVols []repository.PodVolume) ([]*proto.CommodityDTO, float64, error) {
+	var commoditiesSold []*proto.CommodityDTO
+
+	volumeCapacity := float64(0)
+	for _, podVol := range podVols {
+		podKey := podVol.QualifiedPodName
+		mountName := podVol.MountName
+		// Volume capacity metrics is available as part of volume spec.
+		// However we dont use that if the actual queried volume size
+		// is available and discovered by the kubelet as part of
+		// pod metrics for that volume. If a volume is not mounted, then
+		// we use the capacity listed in volume spec.
+		capacity, used, found := builder.getVolumeMetrics(vol, podVol.QualifiedPodName, podVol.MountName)
+		if !found {
+			continue
+		}
+		volumeCapacity = capacity
+
+		commKey := fmt.Sprintf("%s/%s", podKey, mountName)
+		commBuilder := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_STORAGE_AMOUNT).Key(commKey)
+		commBuilder.Used(used)
+		commBuilder.Peak(used)
+		commBuilder.Capacity(capacity)
+		commodityPerPod, err := commBuilder.Create()
+		if err != nil {
+			return nil, volumeCapacity, err
+		}
+
+		// TODO(irfanurrehman): Set resisable depending on node properties
+
+		commoditiesSold = append(commoditiesSold, commodityPerPod)
+	}
+
+	return commoditiesSold, volumeCapacity, nil
+}
+
+func (builder *volumeEntityDTOBuilder) getVolumeMetrics(vol *api.PersistentVolume, podKey, mountName string) (float64, float64, bool) {
+	for _, metricEntry := range builder.podVolumeMetrics {
+		if metricEntry.Volume.Name == vol.Name &&
+			metricEntry.MountName == mountName &&
+			metricEntry.QualifiedPodName == podKey {
+			return metricEntry.Capacity, metricEntry.Used, true
+		}
+	}
+
+	return float64(0), float64(0), false
+}
+
+// Get the properties of the volume.
+// TODO(irfanurrehman): Add stitching properties.
+func (builder *volumeEntityDTOBuilder) getVolumeProperties(vol *api.PersistentVolume) []*proto.EntityDTO_EntityProperty {
+	var properties []*proto.EntityDTO_EntityProperty
+
+	volProperty := property.BuildVolumeProperties(vol)
+	properties = append(properties, volProperty)
+
+	return properties
+}

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -16,6 +16,7 @@ const (
 	ContainerType   DiscoveredEntityType = "Container"
 	ApplicationType DiscoveredEntityType = "Application"
 	ServiceType     DiscoveredEntityType = "Service"
+	VolumeType      DiscoveredEntityType = "Volume"
 )
 
 const (

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -32,6 +32,7 @@ const (
 	Transaction        ResourceType = "Transaction"
 	NumPods            ResourceType = "NumPods"
 	VStorage           ResourceType = "VStorage"
+	StorageAmount      ResourceType = "StorageAmount"
 
 	Access       ResourceType = "Access"
 	Cluster      ResourceType = "Cluster"

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -210,11 +210,7 @@ func (m *KubeletMonitor) parseVolumeStats(volStats []stats.VolumeStats, podKey s
 			used = util.Base2BytesToMegabytes(float64(*volStat.UsedBytes))
 		}
 
-		var pvcRef stats.PVCReference
-		if volStat.PVCRef != nil {
-			pvcRef = *volStat.PVCRef
-		}
-		volKey := util.PodVolumeMetricId(podKey, volStat.Name, pvcRef)
+		volKey := util.PodVolumeMetricId(podKey, volStat.Name)
 		// TODO: Generate used on etype pod and capacity on etype volume once
 		// etype volume is in place
 		m.genPVMetrics(metrics.PodType, volKey, capacity, used)

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -194,6 +194,33 @@ func (m *KubeletMonitor) parsePodStats(podStats []stats.PodStats) {
 		m.genUsedMetrics(metrics.PodType, key, cpuUsed, memUsed)
 		m.genNumConsumersUsedMetrics(metrics.PodType, key)
 		m.genFSMetrics(metrics.PodType, key, ephemeralFsCapacity, ephemeralFsUsed)
+
+		m.parseVolumeStats(pod.VolumeStats, key)
+	}
+}
+
+func (m *KubeletMonitor) parseVolumeStats(volStats []stats.VolumeStats, podKey string) {
+	for i := range volStats {
+		volStat := volStats[i]
+		capacity, used := float64(0), float64(0)
+		if volStat.CapacityBytes != nil {
+			capacity = util.Base2BytesToMegabytes(float64(*volStat.CapacityBytes))
+		}
+		if volStat.UsedBytes != nil {
+			used = util.Base2BytesToMegabytes(float64(*volStat.UsedBytes))
+		}
+
+		var pvcRef stats.PVCReference
+		if volStat.PVCRef != nil {
+			pvcRef = *volStat.PVCRef
+		}
+		volKey := util.PodVolumeMetricId(podKey, volStat.Name, pvcRef)
+		// TODO: Generate used on etype pod and capacity on etype volume once
+		// etype volume is in place
+		m.genPVMetrics(metrics.PodType, volKey, capacity, used)
+
+		glog.V(4).Infof("Volume Usage of %s mounted by pod %s is %.3f Megabytes", volStat.Name, podKey, used)
+		glog.V(4).Infof("Volume Capacity of %s mounted by pod %s is %.3f Megabytes", volStat.Name, podKey, capacity)
 	}
 }
 
@@ -249,5 +276,11 @@ func (m *KubeletMonitor) genNumConsumersUsedMetrics(etype metrics.DiscoveredEnti
 func (m *KubeletMonitor) genFSMetrics(etype metrics.DiscoveredEntityType, key string, capacity, used float64) {
 	capacityMetric := metrics.NewEntityResourceMetric(etype, key, metrics.VStorage, metrics.Capacity, capacity)
 	usedMetric := metrics.NewEntityResourceMetric(etype, key, metrics.VStorage, metrics.Used, used)
+	m.metricSink.AddNewMetricEntries(capacityMetric, usedMetric)
+}
+
+func (m *KubeletMonitor) genPVMetrics(etype metrics.DiscoveredEntityType, key string, capacity, used float64) {
+	capacityMetric := metrics.NewEntityResourceMetric(etype, key, metrics.StorageAmount, metrics.Capacity, capacity)
+	usedMetric := metrics.NewEntityResourceMetric(etype, key, metrics.StorageAmount, metrics.Used, used)
 	m.metricSink.AddNewMetricEntries(capacityMetric, usedMetric)
 }

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -176,5 +176,8 @@ func (p *ClusterProcessor) DiscoverCluster() (*repository.KubeCluster, error) {
 	// Discover Services
 	NewServiceProcessor(p.clusterInfoScraper, kubeCluster).ProcessServices()
 
+	// Discover volumes
+	NewVolumeProcessor(p.clusterInfoScraper, kubeCluster).ProcessVolumes()
+
 	return kubeCluster, nil
 }

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -2,17 +2,18 @@ package processor
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
-	"testing"
-	"time"
 )
 
 var (
@@ -302,6 +303,8 @@ type MockClusterScrapper struct {
 	mockGetAllEndpoints        func() ([]*v1.Endpoints, error)
 	mockGetAllServices         func() ([]*v1.Service, error)
 	mockGetKubernetesServiceID func() (svcID string, err error)
+	mockGetAllPVs              func() ([]*v1.PersistentVolume, error)
+	mockGetAllPVCs             func() ([]*v1.PersistentVolumeClaim, error)
 }
 
 func (s *MockClusterScrapper) GetAllNodes() ([]*v1.Node, error) {
@@ -349,9 +352,24 @@ func (s *MockClusterScrapper) GetKubernetesServiceID() (string, error) {
 	}
 	return "", fmt.Errorf("GetKubernetesServiceID Not implemented")
 }
+
 func (s *MockClusterScrapper) GetAllServices() ([]*v1.Service, error) {
 	if s.mockGetAllServices != nil {
 		return s.mockGetAllServices()
+	}
+	return nil, fmt.Errorf("GetAllServices Not implemented")
+}
+
+func (s *MockClusterScrapper) GetAllPVs() ([]*v1.PersistentVolume, error) {
+	if s.mockGetAllPVs != nil {
+		return s.mockGetAllPVs()
+	}
+	return nil, fmt.Errorf("GetAllServices Not implemented")
+}
+
+func (s *MockClusterScrapper) GetAllPVCs() ([]*v1.PersistentVolumeClaim, error) {
+	if s.mockGetAllPVCs != nil {
+		return s.mockGetAllPVCs()
 	}
 	return nil, fmt.Errorf("GetAllServices Not implemented")
 }

--- a/pkg/discovery/processor/volume_processor.go
+++ b/pkg/discovery/processor/volume_processor.go
@@ -108,7 +108,7 @@ func inverseVolToPodsMap(volToPodsMap map[*v1.PersistentVolume][]repository.PodV
 	for vol, podVols := range volToPodsMap {
 		for _, podVol := range podVols {
 			podToVolsMap[podVol.QualifiedPodName] = append(podToVolsMap[podVol.QualifiedPodName],
-				repository.MountedVolume{vol, podVol.MountName})
+				repository.MountedVolume{UsedVolume: vol, MountName: podVol.MountName})
 		}
 	}
 	return podToVolsMap

--- a/pkg/discovery/processor/volume_processor.go
+++ b/pkg/discovery/processor/volume_processor.go
@@ -1,0 +1,115 @@
+package processor
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	v1 "k8s.io/api/core/v1"
+)
+
+type VolumeProcessor struct {
+	ClusterInfoScraper cluster.ClusterScraperInterface
+	KubeCluster        *repository.KubeCluster
+}
+
+func NewVolumeProcessor(kubeClient cluster.ClusterScraperInterface,
+	kubeCluster *repository.KubeCluster) *VolumeProcessor {
+	return &VolumeProcessor{
+		ClusterInfoScraper: kubeClient,
+		KubeCluster:        kubeCluster,
+	}
+}
+
+func (p *VolumeProcessor) ProcessVolumes() {
+	clusterName := p.KubeCluster.Name
+	pvList, err := p.ClusterInfoScraper.GetAllPVs()
+	if err != nil {
+		glog.Errorf("Failed to get persistent volumes for cluster %s: %v.", clusterName, err)
+		return
+	}
+	glog.V(2).Infof("There are %d volumes.", len(pvList))
+
+	pvcList, err := p.ClusterInfoScraper.GetAllPVCs()
+	if err != nil {
+		glog.Errorf("Failed to get persistent volumes claims for cluster %s: %v.", clusterName, err)
+		return
+	}
+	glog.V(2).Infof("There are %d volume claims.", len(pvcList))
+
+	allPods, err := p.ClusterInfoScraper.GetAllPods()
+	if err != nil {
+		glog.Errorf("Failed to get all pods for cluster %s: %v.", clusterName, err)
+		return
+	}
+
+	// A map which lists the volume to pvc bindings (1 to 1)
+	// There can be volumes which are not bound via claims
+	// and pods use them directly.
+	volumeToClaimMap := make(map[*v1.PersistentVolume]*v1.PersistentVolumeClaim)
+	for _, pv := range pvList {
+		found := false
+		for _, pvc := range pvcList {
+			if pvc.Spec.VolumeName == pv.Name {
+				volumeToClaimMap[pv] = pvc
+				found = true
+				break
+			}
+		}
+		if !found {
+			volumeToClaimMap[pv] = nil
+		}
+	}
+
+	// TODO (irfanurrehman): We might need the volume name to map the metrics generated from pod
+	// and gathered via kubelet monitor to the individual volumes.
+	// TODO (irfanurrehman): (Next Step) To find out how are metrics generated for volumes which
+	// are used by multiple pods.
+	volumeToPodsMap := make(map[*v1.PersistentVolume][]repository.PodVolume)
+	for pv, pvc := range volumeToClaimMap {
+		if pvc == nil {
+			// Unused volume.
+			volumeToPodsMap[pv] = nil
+		}
+		for _, pod := range allPods {
+			for _, vol := range pod.Spec.Volumes {
+				claim := vol.VolumeSource.PersistentVolumeClaim
+				if claim != nil {
+					if pvc != nil {
+						if claim.ClaimName == pvc.Name {
+							pVol := repository.PodVolume{
+								QualifiedPodName: fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
+								MountName:        vol.Name,
+							}
+							volumeToPodsMap[pv] = append(volumeToPodsMap[pv], pVol)
+						}
+					}
+				} else {
+					// TODO (irfanurrehman): check other volume sources categorically.
+					// This could be another volume type directly used by pod.
+					// Pod owner must know all details of the cloud/storage volume
+					// and specify that explicitly as details here (There wont be any
+					// corresponding PV or PVC resource in k8s).
+					// Although archaic this is still possible and we will need to
+					// take a call if this needs support.
+				}
+			}
+
+		}
+	}
+
+	p.KubeCluster.VolumeToPodsMap = volumeToPodsMap
+	p.KubeCluster.PodToVolumesMap = inverseVolToPodsMap(volumeToPodsMap)
+}
+
+func inverseVolToPodsMap(volToPodsMap map[*v1.PersistentVolume][]repository.PodVolume) map[string][]repository.MountedVolume {
+	podToVolsMap := make(map[string][]repository.MountedVolume)
+	for vol, podVols := range volToPodsMap {
+		for _, podVol := range podVols {
+			podToVolsMap[podVol.QualifiedPodName] = append(podToVolsMap[podVol.QualifiedPodName],
+				repository.MountedVolume{vol, podVol.MountName})
+		}
+	}
+	return podToVolsMap
+}

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -21,6 +21,33 @@ type KubeCluster struct {
 	ClusterResources map[metrics.ResourceType]*KubeDiscoveredResource
 	// Map of Service to Pod cluster Ids
 	Services map[*v1.Service][]string
+	// Map of Persistent Volumes to namespace qualified pod names with their
+	// volume names (as named in podSpec).
+	// The unused PV will have the slice value set to nil.
+	VolumeToPodsMap map[*v1.PersistentVolume][]PodVolume
+	// Map of namespace qualified pod name wrt to the volumes they mount.
+	// This map will not feature volumes which are not mounted by any pods.
+	PodToVolumesMap map[string][]MountedVolume
+}
+
+type PodVolume struct {
+	// Namespace qualified pod name.
+	QualifiedPodName string
+	// Name used by the pod to mount the volume.
+	MountName string
+}
+
+type MountedVolume struct {
+	UsedVolume *v1.PersistentVolume
+	MountName  string
+}
+
+// Volume metrics reported for a given pod
+type PodVolumeMetrics struct {
+	Volume   *v1.PersistentVolume
+	Capacity float64
+	Used     float64
+	PodVolume
 }
 
 func NewKubeCluster(clusterName string, nodes []*v1.Node) *KubeCluster {
@@ -427,4 +454,26 @@ func (quotaEntity *KubeQuota) AddNodeProvider(nodeUID string,
 	for resourceType, resourceUsed := range allocationBought {
 		quotaEntity.AddProviderResource(metrics.NodeType, nodeUID, resourceType, resourceUsed)
 	}
+}
+
+// =================================================================================================
+// The volumes in the cluster
+type KubeVolume struct {
+	*KubeEntity
+	*v1.PersistentVolume
+	ClusterName string
+}
+
+// Create a KubeVolume entity representing a volume in the cluster
+func NewKubeVolume(pv *v1.PersistentVolume, clusterName string) *KubeVolume {
+	entity := NewKubeEntity(metrics.VolumeType, clusterName,
+		pv.ObjectMeta.Namespace, pv.ObjectMeta.Name,
+		string(pv.ObjectMeta.UID))
+
+	volumeEntity := &KubeVolume{
+		KubeEntity:       entity,
+		PersistentVolume: pv,
+	}
+
+	return volumeEntity
 }

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -19,6 +19,8 @@ type Task struct {
 
 	nodeList []*api.Node
 	podList  []*api.Pod
+	pvList   []*api.PersistentVolume
+	pvcList  []*api.PersistentVolumeClaim
 	cluster  *repository.ClusterSummary
 }
 
@@ -41,6 +43,18 @@ func (t *Task) WithPods(podList []*api.Pod) *Task {
 	return t
 }
 
+// Assign pvs to the task.
+func (t *Task) WithPVs(pvList []*api.PersistentVolume) *Task {
+	t.pvList = pvList
+	return t
+}
+
+// Assign pvcs to the task.
+func (t *Task) WithPVCs(pvcList []*api.PersistentVolumeClaim) *Task {
+	t.pvcList = pvcList
+	return t
+}
+
 // Assign cluster summary to the task.
 func (t *Task) WithCluster(cluster *repository.ClusterSummary) *Task {
 	t.cluster = cluster
@@ -55,6 +69,16 @@ func (t *Task) NodeList() []*api.Node {
 // Get pod list from the task.
 func (t *Task) PodList() []*api.Pod {
 	return t.podList
+}
+
+// Get PV list from the task.
+func (t *Task) PVList() []*api.PersistentVolume {
+	return t.pvList
+}
+
+// Get PVC list from the task.
+func (t *Task) PVCList() []*api.PersistentVolumeClaim {
+	return t.pvcList
 }
 
 func (t *Task) Cluster() *repository.ClusterSummary {

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -90,13 +90,14 @@ type TaskResultState string
 // A TaskResult contains a state, indicate whether the task is finished successfully; a err if there is any; a list of
 // EntityDTO.
 type TaskResult struct {
-	workerID     string
-	state        TaskResultState
-	err          error
-	content      []*proto.EntityDTO
-	quotaMetrics []*repository.QuotaMetrics
-	entityGroups []*repository.EntityGroup
-	podEntities  []*repository.KubePod
+	workerID         string
+	state            TaskResultState
+	err              error
+	content          []*proto.EntityDTO
+	quotaMetrics     []*repository.QuotaMetrics
+	entityGroups     []*repository.EntityGroup
+	podEntities      []*repository.KubePod
+	podVolumeMetrics []*repository.PodVolumeMetrics
 }
 
 func NewTaskResult(workerID string, state TaskResultState) *TaskResult {
@@ -130,6 +131,10 @@ func (r *TaskResult) EntityGroups() []*repository.EntityGroup {
 	return r.entityGroups
 }
 
+func (r *TaskResult) PodVolumeMetrics() []*repository.PodVolumeMetrics {
+	return r.podVolumeMetrics
+}
+
 func (r *TaskResult) Err() error {
 	return r.err
 }
@@ -156,5 +161,10 @@ func (r *TaskResult) WithQuotaMetrics(quotaMetrics []*repository.QuotaMetrics) *
 
 func (r *TaskResult) WithEntityGroups(entityGroups []*repository.EntityGroup) *TaskResult {
 	r.entityGroups = entityGroups
+	return r
+}
+
+func (r *TaskResult) WithPodVolumeMetrics(podVolumeMetrics []*repository.PodVolumeMetrics) *TaskResult {
+	r.podVolumeMetrics = podVolumeMetrics
 	return r
 }

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -110,3 +110,24 @@ func NodeKeyFromPodFunc(pod *api.Pod) string {
 func VDCIdFunc(namespaceId string) string {
 	return fmt.Sprintf("%s-%s", vdcPrefix, namespaceId)
 }
+
+func PodVolumeMetricId(podKey, pvName string, pvcRef stats.PVCReference) string {
+	volKey := podKey
+	if pvName != "" {
+		volKey = volKey + "-" + pvName
+	}
+
+	pvcRefKey := pvcRefKey(pvcRef)
+	if pvcRefKey != "" {
+		volKey = volKey + "-" + pvcRefKey
+	}
+	return volKey
+}
+
+func pvcRefKey(pvcRef stats.PVCReference) string {
+	key := pvcRef.Name
+	if pvcRef.Namespace != "" {
+		key = pvcRef.Namespace + "/" + key
+	}
+	return key
+}

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -111,23 +111,11 @@ func VDCIdFunc(namespaceId string) string {
 	return fmt.Sprintf("%s-%s", vdcPrefix, namespaceId)
 }
 
-func PodVolumeMetricId(podKey, pvName string, pvcRef stats.PVCReference) string {
+func PodVolumeMetricId(podKey, volName string) string {
 	volKey := podKey
-	if pvName != "" {
-		volKey = volKey + "-" + pvName
+	if volName != "" {
+		volKey = volKey + "-" + volName
 	}
 
-	pvcRefKey := pvcRefKey(pvcRef)
-	if pvcRefKey != "" {
-		volKey = volKey + "-" + pvcRefKey
-	}
 	return volKey
-}
-
-func pvcRefKey(pvcRef stats.PVCReference) string {
-	key := pvcRef.Name
-	if pvcRef.Namespace != "" {
-		key = pvcRef.Namespace + "/" + key
-	}
-	return key
 }

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -119,3 +119,7 @@ func PodVolumeMetricId(podKey, volName string) string {
 
 	return volKey
 }
+
+func VolumeKeyFunc(vol *api.PersistentVolume) string {
+	return vol.Name
+}

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -2,10 +2,11 @@ package worker
 
 import (
 	"errors"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	"sync"
 	"time"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
@@ -310,6 +311,7 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 	// Node providers
 	nodes := currTask.NodeList()
 	cluster := currTask.Cluster()
+	volToPodsMap := currTask.Cluster().VolumeToPodsMap
 
 	for _, node := range nodes {
 		if node != nil {
@@ -342,7 +344,7 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 
 	podEntityDTOBuilder := dtofactory.NewPodEntityDTOBuilder(worker.sink, stitchingManager,
 		nodeNameUIDMap, quotaNameUIDMap)
-	podEntityDTOs, err := podEntityDTOBuilder.BuildEntityDTOs(pods)
+	podEntityDTOs, err := podEntityDTOBuilder.BuildEntityDTOs(pods, volToPodsMap)
 	if err != nil {
 		glog.Errorf("Error while creating pod entityDTOs: %v", err)
 	}

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -311,7 +311,10 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 	// Node providers
 	nodes := currTask.NodeList()
 	cluster := currTask.Cluster()
-	volToPodsMap := currTask.Cluster().VolumeToPodsMap
+	var volToPodsMap map[*api.PersistentVolume][]repository.PodVolume
+	if cluster != nil {
+		volToPodsMap = cluster.VolumeToPodsMap
+	}
 
 	for _, node := range nodes {
 		if node != nil {

--- a/pkg/discovery/worker/result_collector.go
+++ b/pkg/discovery/worker/result_collector.go
@@ -28,12 +28,13 @@ func (rc *ResultCollector) ResultPool() chan *task.TaskResult {
 }
 
 func (rc *ResultCollector) Collect(count int) ([]*proto.EntityDTO, map[string]*repository.KubePod,
-	[]*repository.QuotaMetrics, []*repository.EntityGroup) {
+	[]*repository.QuotaMetrics, []*repository.EntityGroup, []*repository.PodVolumeMetrics) {
 	discoveryResult := []*proto.EntityDTO{}
 	quotaMetricsList := []*repository.QuotaMetrics{}
 	entityGroupList := []*repository.EntityGroup{}
 	discoveryErrorString := []string{}
 	podEntitiesMap := make(map[string]*repository.KubePod)
+	podVolumeMetrics := []*repository.PodVolumeMetrics{}
 	glog.V(2).Infof("Waiting for results from %d workers.", count)
 
 	stopChan := make(chan struct{})
@@ -55,6 +56,8 @@ func (rc *ResultCollector) Collect(count int) ([]*proto.EntityDTO, map[string]*r
 					quotaMetricsList = append(quotaMetricsList, result.QuotaMetrics()...)
 					// Group data from different workers
 					entityGroupList = append(entityGroupList, result.EntityGroups()...)
+					// Volume metrics from different workers
+					podVolumeMetrics = append(podVolumeMetrics, result.PodVolumeMetrics()...)
 					// Pod data with apps from different workers
 					for _, kubePod := range result.PodEntities() {
 						podEntitiesMap[kubePod.PodClusterId] = kubePod
@@ -73,5 +76,5 @@ func (rc *ResultCollector) Collect(count int) ([]*proto.EntityDTO, map[string]*r
 		glog.Errorf("One or more discovery worker failed: %s", strings.Join(discoveryErrorString, "\t\t"))
 	}
 
-	return discoveryResult, podEntitiesMap, quotaMetricsList, entityGroupList
+	return discoveryResult, podEntitiesMap, quotaMetricsList, entityGroupList, podVolumeMetrics
 }

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -149,6 +149,16 @@ func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO
 
 	rClient.addActionPolicy(ab, node, nodePolicy)
 
+	// 6. volumes
+	volume := proto.EntityDTO_VIRTUAL_VOLUME
+	volumePolicy := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
+	volumePolicy[proto.ActionItemDTO_PROVISION] = recommend
+	volumePolicy[proto.ActionItemDTO_RIGHT_SIZE] = notSupported
+	volumePolicy[proto.ActionItemDTO_SCALE] = recommend
+	volumePolicy[proto.ActionItemDTO_SUSPEND] = notSupported
+
+	rClient.addActionPolicy(ab, volume, volumePolicy)
+
 	return ab.Create()
 }
 
@@ -171,6 +181,7 @@ func (rClient *K8sRegistrationClient) GetEntityMetadata() (result []*proto.Entit
 		proto.EntityDTO_CONTAINER,
 		proto.EntityDTO_APPLICATION,
 		proto.EntityDTO_VIRTUAL_APPLICATION,
+		proto.EntityDTO_VIRTUAL_VOLUME,
 	}
 
 	for _, etype := range entities {

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -46,6 +46,7 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 	container := proto.EntityDTO_CONTAINER
 	app := proto.EntityDTO_APPLICATION
 	vApp := proto.EntityDTO_VIRTUAL_APPLICATION
+	vol := proto.EntityDTO_VIRTUAL_VOLUME
 
 	move := proto.ActionItemDTO_MOVE
 	resize := proto.ActionItemDTO_RIGHT_SIZE
@@ -83,6 +84,12 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 	expected_node[suspend] = supported
 	expected_node[scale] = notSupported
 
+	expected_vol := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
+	expected_vol[resize] = notSupported
+	expected_vol[provision] = recommend
+	expected_vol[suspend] = notSupported
+	expected_vol[scale] = recommend
+
 	policies := reg.GetActionPolicy()
 
 	for _, item := range policies {
@@ -99,6 +106,8 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 			expected = expected_node
 		} else if entity == vApp {
 			expected = expected_vApp
+		} else if entity == vol {
+			expected = expected_vol
 		} else {
 			t.Errorf("Unknown entity type: %v", entity)
 			continue
@@ -123,6 +132,7 @@ func TestK8sRegistrationClient_GetEntityMetadata(t *testing.T) {
 		proto.EntityDTO_CONTAINER,
 		proto.EntityDTO_APPLICATION,
 		proto.EntityDTO_VIRTUAL_APPLICATION,
+		proto.EntityDTO_VIRTUAL_VOLUME,
 	}
 	entitySet := make(map[proto.EntityDTO_EntityType]struct{})
 


### PR DESCRIPTION
This PR is now functionally complete.
Please check the code commitwise for better understanding of changes.

The overall tasks include:

Completed:
1. Discover persistent volumes and persistent volume claims from cluster.
2. Get the volume metrics from kubelet source and generate relevant metrices for consumption in kubeturbo.
3. Create a mapping between pods and volumes via pvs. This helps establish relationship between the pods DTOs and yet to come PersistentVolume DTOs.
4. Include the storage amount bought commodities in the POD DTOs.
5. Build Volume entity DTOs, complete with sold commodities.
6. Include volume and related commodity information in the supply chain.
7. Include volume entity metadata info in the probe registration.

Pending:
- Stiching properties.
 