### PR TITLE
Update deployment yaml

### DIFF
--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -21,10 +21,17 @@ data:
       "HANodeConfig": {
         "nodeRoles": [{{ .Values.HANodeConfig.nodeRoles }}]
       {{- if .Values.targetConfig }}
-        {{- if .Values.targetConfig.targetName }}
+        {{- if or .Values.targetConfig.targetName .Values.targetConfig.targetType }}
       },
       "targetConfig": {
+          {{- if and .Values.targetConfig.targetName .Values.targetConfig.targetType }}
+        "targetName": "{{ .Values.targetConfig.targetName }}",
+        "targetType": "{{ .Values.targetConfig.targetType }}"
+          {{- else if .Values.targetConfig.targetName }}
         "targetName": "{{ .Values.targetConfig.targetName }}"
+          {{- else }}
+        "targetType": "{{ .Values.targetConfig.targetType }}"
+          {{- end}}
         {{- end }}
       {{- end }}
       {{- if .Values.daemonPodDetectors }}

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -5,7 +5,7 @@
 # Replace the image with desired version
 image:
   repository: turbonomic/kubeturbo
-  tag: 7.21.1
+  tag: 7.21.2
   pullPolicy: IfNotPresent
 
 #nameOverride: ""
@@ -27,9 +27,17 @@ restAPIConfig:
   opsManagerUserName: Turbo_username
   opsManagerPassword: Turbo_password
 
-# Enabling targetConfig and providing a value will give a name to your cluster
+# For targetConfig, targetName provides better group naming to identify k8s clusters in UI
+# - If no targetConfig is specified, a default targetName will be created from the apiserver URL in
+#   the kubeconfig.
+# - Specify a targetName only will register a probe with type Kubernetes-<targetName>, as well as
+#   adding your cluster as a target with the name Kubernetes-<targetName>.
+# - Specify a targetType only will register a probe without adding your cluster as a target.
+#   The probe will appear as a Cloud Native probe in the UI with a type Kubernetes-<targetType>.
+#
 #targetConfig:
-#  targetName: Name_Each_Cluster
+#  targetName: Cluster_Name
+#  targetType: Target_Type
 
 # In kubeturbo 6.4.3+, you can define what nodes should stay high-available based on the node role
 # Master nodes are by default populated by --set HANodeConfig.nodeRoles="\"foo\"\,\"bar\""

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -21,10 +21,17 @@ data:
       "HANodeConfig": {
         "nodeRoles": [{{ .Values.HANodeConfig.nodeRoles }}]
       {{- if .Values.targetConfig }}
-        {{- if .Values.targetConfig.targetName }}
+        {{- if or .Values.targetConfig.targetName .Values.targetConfig.targetType }}
       },
       "targetConfig": {
+          {{- if and .Values.targetConfig.targetName .Values.targetConfig.targetType }}
+        "targetName": "{{ .Values.targetConfig.targetName }}",
+        "targetType": "{{ .Values.targetConfig.targetType }}"
+          {{- else if .Values.targetConfig.targetName }}
         "targetName": "{{ .Values.targetConfig.targetName }}"
+          {{- else }}
+        "targetType": "{{ .Values.targetConfig.targetType }}"
+          {{- end}}
         {{- end }}
       {{- end }}
       {{- if .Values.daemonPodDetectors }}

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -5,7 +5,7 @@
 # Replace the image with desired version
 image:
   repository: turbonomic/kubeturbo
-  tag: 7.21.1
+  tag: 7.21.2
   pullPolicy: IfNotPresent
 
 #nameOverride: ""
@@ -27,9 +27,17 @@ restAPIConfig:
   opsManagerUserName: Turbo_username
   opsManagerPassword: Turbo_password
 
-# Enabling targetConfig and providing a value will give a name to your cluster
+# For targetConfig, targetName provides better group naming to identify k8s clusters in UI
+# - If no targetConfig is specified, a default targetName will be created from the apiserver URL in
+#   the kubeconfig.
+# - Specify a targetName only will register a probe with type Kubernetes-<targetName>, as well as
+#   adding your cluster as a target with the name Kubernetes-<targetName>.
+# - Specify a targetType only will register a probe without adding your cluster as a target.
+#   The probe will appear as a Cloud Native probe in the UI with a type Kubernetes-<targetType>.
+#
 #targetConfig:
-#  targetName: Name_Each_Cluster
+#  targetName: Cluster_Name
+#  targetType: Target_Type
 
 # In kubeturbo 6.4.3+, you can define what nodes should stay high-available based on the node role
 # Master nodes are by default populated by --set HANodeConfig.nodeRoles="\"foo\"\,\"bar\""

--- a/deploy/kubeturbo_yamls/step4_turbo_configMap_721sample.yaml
+++ b/deploy/kubeturbo_yamls/step4_turbo_configMap_721sample.yaml
@@ -10,14 +10,22 @@ data:
   # Update the values for version, turboServer, opsManagerUserName, opsManagerPassword
   # For version, use Turbo Server Version, even when running CWOM
   # The opsManagerUserName requires Turbo administrator role
-  # targetConfig is optional. targetName provides better group naming to identify k8s clusters in UI
+  #
+  # For targetConfig, targetName provides better group naming to identify k8s clusters in UI
+  # - If no targetConfig is specified, a default targetName will be created from the apiserver URL in
+  #   the kubeconfig.
+  # - Specify a targetName only will register a probe with type Kubernetes-<targetName>, as well as
+  #   adding your cluster as a target with the name Kubernetes-<targetName>.
+  # - Specify a targetType only will register a probe without adding your cluster as a target.
+  #   The probe will appear as a Cloud Native probe in the UI with a type Kubernetes-<targetType>.
+  #
   # Define node groups by node role, and automatically enable placement policies to limit to 1 per host
   # DaemonSets are identified by default. Use daemonPodDetectors to identify by name patterns using regex or by namespace.
   turbo.config: |-
     {
         "communicationConfig": {
             "serverMeta": {
-                "version": "6.4",
+                "version": "7.21",
                 "turboServer": "https://<Turbo_server_URL>"
             },
             "restAPIConfig": {

--- a/deploy/kubeturbo_yamls/step5_turbo_kubeturboDeploy.yaml
+++ b/deploy/kubeturbo_yamls/step5_turbo_kubeturboDeploy.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: kubeturbo
         # Replace the image with desired version:6.4.4 or latest
-        image: turbonomic/kubeturbo:7.21.1
+        image: turbonomic/kubeturbo:7.21.2
         args:
           - --turboconfig=/etc/kubeturbo/turbo.config
           - --v=2

--- a/deploy/kubeturbo_yamls/turbo_kubeturbo_full_721.yaml
+++ b/deploy/kubeturbo_yamls/turbo_kubeturbo_full_721.yaml
@@ -42,7 +42,15 @@ data:
   # Update the values for version, turboServer, opsManagerUserName, opsManagerPassword
   # For version, use Turbo Server Version, even when running CWOM
   # The opsManagerUserName requires Turbo administrator role
-  # targetConfig is optional. targetName provides better group naming to identify k8s clusters in UI
+  #
+  # For targetConfig, targetName provides better group naming to identify k8s clusters in UI
+  # - If no targetConfig is specified, a default targetName will be created from the apiserver URL in
+  #   the kubeconfig.
+  # - Specify a targetName only will register a probe with type Kubernetes-<targetName>, as well as
+  #   adding your cluster as a target with the name Kubernetes-<targetName>.
+  # - Specify a targetType only will register a probe without adding your cluster as a target.
+  #   The probe will appear as a Cloud Native probe in the UI with a type Kubernetes-<targetType>.
+  #
   # Define node groups by node role, and automatically enable placement policies to limit to 1 per host
   # DaemonSets are identified by default. Use daemonPodDetectors to identify by name patterns using regex or by namespace.
   turbo.config: |-
@@ -89,7 +97,7 @@ spec:
       containers:
       - name: kubeturbo
         # Replace the image with desired version:6.4.4 or latest
-        image: turbonomic/kubeturbo:7.21.1
+        image: turbonomic/kubeturbo:7.21.2
         args:
           - --turboconfig=/etc/kubeturbo/turbo.config
           - --v=2


### PR DESCRIPTION
This PR update `kubeturbo` deployment yamls:

* Update the default image tag to `7.21.2`
* Support the `targetType` configuration in helm charts.
* Add instructions on how to enable registering `kubeturbo` as a probe without adding a target. 