### PR TITLE
Allow missing or empty targetConfig

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -243,7 +243,7 @@ func (s *VMTServer) Run() {
 
 	glog.V(3).Infof("Turbonomic config path is: %v", s.K8sTAPSpec)
 
-	k8sTAPSpec, err := kubeturbo.ParseK8sTAPServiceSpec(s.K8sTAPSpec)
+	k8sTAPSpec, err := kubeturbo.ParseK8sTAPServiceSpec(s.K8sTAPSpec, kubeConfig.Host)
 	if err != nil {
 		glog.Errorf("Failed to generate correct TAP config: %v", err.Error())
 		os.Exit(1)

--- a/pkg/discovery/configs/target_config.go
+++ b/pkg/discovery/configs/target_config.go
@@ -2,7 +2,6 @@ package configs
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 
@@ -42,9 +41,6 @@ func (config *K8sTargetConfig) ValidateK8sTargetConfig() error {
 	// Determine target type
 	prefix := defaultTargetType + "-"
 	if config.TargetType == "" {
-		if config.TargetIdentifier == "" {
-			return fmt.Errorf("neither targetType nor targetIdentifier is specified")
-		}
 		config.TargetType = config.TargetIdentifier
 	}
 	// Prefix targetType with Kubernetes if needed

--- a/test/config/turbo-config-with-empty-targetconfig
+++ b/test/config/turbo-config-with-empty-targetconfig
@@ -8,7 +8,5 @@
             "opsManagerPassword": "bar"
         }
     },
-    "targetConfig": {
-        "targetName":"cluster-foo"
-    }
+    "targetConfig": {}
 }

--- a/test/config/turbo-config-with-target-name-and-target-type
+++ b/test/config/turbo-config-with-target-name-and-target-type
@@ -1,15 +1,15 @@
 {
-	"communicationConfig": {
-		"serverMeta": {
-			"turboServer": "https://127.1.1.1:9444"
-		},
-		"restAPIConfig": {
-			"opsManagerUserName": "foo",
-			"opsManagerPassword": "bar"
-		}
-	},
-     	"targetConfig": {
-     	    "targetName":"cluster-foo",
-     		"targetType":"Kubernetes-Openshift"
-     	}
+    "communicationConfig": {
+        "serverMeta": {
+            "turboServer": "https://127.1.1.1:9444"
+        },
+        "restAPIConfig": {
+            "opsManagerUserName": "foo",
+            "opsManagerPassword": "bar"
+        }
+    },
+    "targetConfig": {
+        "targetName":"cluster-foo",
+        "targetType":"Kubernetes-Openshift"
+    }
 }

--- a/test/config/turbo-config-with-target-type
+++ b/test/config/turbo-config-with-target-type
@@ -1,14 +1,14 @@
 {
-	"communicationConfig": {
-		"serverMeta": {
-			"turboServer": "https://127.1.1.1:9444"
-		},
-		"restAPIConfig": {
-			"opsManagerUserName": "foo",
-			"opsManagerPassword": "bar"
-		}
-	},
-     	"targetConfig": {
-     		"targetType":"cluster-foo"
-     	}
+    "communicationConfig": {
+        "serverMeta": {
+            "turboServer": "https://127.1.1.1:9444"
+        },
+        "restAPIConfig": {
+            "opsManagerUserName": "foo",
+            "opsManagerPassword": "bar"
+        }
+    },
+    "targetConfig": {
+        "targetType":"cluster-foo"
+    }
 }


### PR DESCRIPTION
This PR allows missing or empty `targetConfig` to make `kubeturbo` backward compatible. 

The logic is:

* If `targetConfig` is missing or empty in the configmap, we will use the apiserver URL in the `kubeconfig` as the target name AND target type (prefixed with Kubernetes).
* If only `targetConfig.targetName` is set, that will become both the target name AND target type (prefixed with Kubernetes).
* If only `targetConfig.targetType` is set, that will become the target type (prefixed with Kubernetes), and `kubeturbo` will only register the probe without adding target.
* Otherwise, `targetConfig.targetName` is the target name, and `targetConfig.targetType` is the target type (prefixed with Kubernetes).

Tests done:

* Add more unit tests.
* Deploy a `kubeturbo` with missing or empty `targetConfig`, and observe the probe gets registered and target gets added:

![image](https://user-images.githubusercontent.com/10012486/78052476-2d6cc300-734d-11ea-8d39-e55fcfd5cfd8.png)
![image](https://user-images.githubusercontent.com/10012486/78052991-eaf7b600-734d-11ea-9081-8dfc8cba6363.png)

