### PR TITLE
Create new WorkloadController entity for new container model

### DIFF
--- a/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
@@ -40,6 +40,10 @@ func (builder *namespaceEntityDTOBuilder) BuildEntityDTOs() ([]*proto.EntityDTO,
 		}
 		entityDTOBuilder.SellsCommodities(commoditiesSold)
 
+		// Namespace entity cannot be provisioned or suspended by Turbonomic analysis
+		entityDTOBuilder.IsProvisionable(false)
+		entityDTOBuilder.IsSuspendable(false)
+
 		entityDTOBuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
 
 		// build entityDTO.
@@ -91,6 +95,7 @@ func (builder *namespaceEntityDTOBuilder) getQuotaCommoditiesSold(kubeNamespace 
 
 		commSoldBuilder := sdkbuilder.NewCommodityDTOBuilder(cType)
 		commSoldBuilder.Used(usedValue)
+		commSoldBuilder.Peak(usedValue)
 		commSoldBuilder.Capacity(capacityValue)
 		commSoldBuilder.Resizable(false)
 		commSoldBuilder.Key(kubeNamespace.UID)

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
@@ -1,0 +1,180 @@
+package dtofactory
+
+import (
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/util"
+	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+type workloadControllerDTOBuilder struct {
+	kubeControllersMap map[string]*repository.KubeController
+	namespaceUIDMap    map[string]string
+}
+
+func NewWorkloadControllerDTOBuilder(kubeControllersMap map[string]*repository.KubeController,
+	namespaceUIDMap map[string]string) *workloadControllerDTOBuilder {
+	return &workloadControllerDTOBuilder{
+		kubeControllersMap: kubeControllersMap,
+		namespaceUIDMap:    namespaceUIDMap,
+	}
+}
+
+// Build entityDTOs based on the given map from controller UID to KubeController entity.
+func (builder *workloadControllerDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, error) {
+	var result []*proto.EntityDTO
+	for _, kubeController := range builder.kubeControllersMap {
+		// Id
+		workloadControllerId := kubeController.UID
+		entityDTOBuilder := sdkbuilder.NewEntityDTOBuilder(proto.EntityDTO_WORKLOAD_CONTROLLER, workloadControllerId)
+
+		// Display name
+		workloadControllerDisplayName := kubeController.Name
+		entityDTOBuilder.DisplayName(workloadControllerDisplayName)
+
+		// Resource commodities sold
+		commoditiesSold, err := builder.getCommoditiesSold(kubeController)
+		if err != nil {
+			glog.Errorf("Error creating commoditiesSold for %s: %v", kubeController.GetFullName(), err)
+			continue
+		}
+		entityDTOBuilder.SellsCommodities(commoditiesSold)
+
+		// Resource commodities bought from namespace
+		namespaceUID, exists := builder.namespaceUIDMap[kubeController.Namespace]
+		if exists {
+			commoditiesBought, err := builder.getCommoditiesBought(kubeController, namespaceUID)
+			if err != nil {
+				glog.Errorf("Error creating commoditiesBought for %s: %v", kubeController.GetFullName(), err)
+				continue
+			}
+			entityDTOBuilder.Provider(sdkbuilder.CreateProvider(proto.EntityDTO_NAMESPACE, namespaceUID)).BuysCommodities(commoditiesBought)
+			// Set movable false to avoid moving WorkloadController across namespaces
+			entityDTOBuilder.IsMovable(proto.EntityDTO_NAMESPACE, false)
+		} else {
+			glog.Errorf("Failed to get namespaceUID from namespace %s for controller %s", kubeController.Namespace,
+				kubeController.GetFullName())
+		}
+
+		// Create WorkloadControllerData to store controller type data
+		entityDTOBuilder.WorkloadControllerData(builder.createWorkloadControllerData(kubeController))
+
+		// WorkloadController cannot be provisioned or suspended by Turbonomic analysis
+		entityDTOBuilder.IsProvisionable(false)
+		entityDTOBuilder.IsSuspendable(false)
+
+		entityDTOBuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
+
+		entityDTO, err := entityDTOBuilder.Create()
+		if err != nil {
+			glog.Errorf("failed to build WorkloadController[%s] entityDTO: %v", workloadControllerDisplayName, err)
+		}
+		result = append(result, entityDTO)
+	}
+	return result, nil
+}
+
+func (builder *workloadControllerDTOBuilder) getCommoditiesSold(kubeController *repository.KubeController) ([]*proto.CommodityDTO, error) {
+	var commoditiesSold []*proto.CommodityDTO
+	for resourceType, resource := range kubeController.AllocationResources {
+		commodityType, exist := rTypeMapping[resourceType]
+		if !exist {
+			glog.Errorf("ResourceType %s is not supported", resourceType)
+			continue
+		}
+		commSoldBuilder := sdkbuilder.NewCommodityDTOBuilder(commodityType)
+		commSoldBuilder.Used(resource.Used)
+		commSoldBuilder.Peak(resource.Used)
+		commSoldBuilder.Capacity(resource.Capacity)
+		commSoldBuilder.Resizable(false)
+		commSoldBuilder.Key(kubeController.UID)
+		commSold, err := commSoldBuilder.Create()
+		if err != nil {
+			glog.Errorf("%s: Failed to build commodity sold %s: %s", kubeController.GetFullName(), commodityType, err)
+			continue
+		}
+		commoditiesSold = append(commoditiesSold, commSold)
+	}
+	return commoditiesSold, nil
+}
+
+func (builder *workloadControllerDTOBuilder) getCommoditiesBought(kubeController *repository.KubeController,
+	namespaceUID string) ([]*proto.CommodityDTO, error) {
+	var commoditiesBought []*proto.CommodityDTO
+	for resourceType, resource := range kubeController.AllocationResources {
+		commodityType, exist := rTypeMapping[resourceType]
+		if !exist {
+			glog.Errorf("ResourceType %s is not supported", resourceType)
+			continue
+		}
+		commBoughtBuilder := sdkbuilder.NewCommodityDTOBuilder(commodityType)
+		commBoughtBuilder.Used(resource.Used)
+		commBoughtBuilder.Peak(resource.Used)
+		commBoughtBuilder.Resizable(false)
+		commBoughtBuilder.Key(namespaceUID)
+		commBought, err := commBoughtBuilder.Create()
+		if err != nil {
+			glog.Errorf("%s: Failed to build commodity bought %s: %s", kubeController.GetFullName(), commodityType, err)
+			continue
+		}
+		commoditiesBought = append(commoditiesBought, commBought)
+	}
+	return commoditiesBought, nil
+}
+
+func (builder *workloadControllerDTOBuilder) createWorkloadControllerData(kubeController *repository.KubeController) *proto.EntityDTO_WorkloadControllerData {
+	controllerType := kubeController.ControllerType
+	switch controllerType {
+	case util.KindCronJob:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_CronJobData{
+				CronJobData: &proto.EntityDTO_CronJobData{},
+			},
+		}
+	case util.KindDaemonSet:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_DaemonSetData{
+				DaemonSetData: &proto.EntityDTO_DaemonSetData{},
+			},
+		}
+	case util.KindDeployment:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_DeploymentData{
+				DeploymentData: &proto.EntityDTO_DeploymentData{},
+			},
+		}
+	case util.KindJob:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_JobData{
+				JobData: &proto.EntityDTO_JobData{},
+			},
+		}
+	case util.KindReplicaSet:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_ReplicaSetData{
+				ReplicaSetData: &proto.EntityDTO_ReplicaSetData{},
+			},
+		}
+	case util.KindReplicationController:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_ReplicationControllerData{
+				ReplicationControllerData: &proto.EntityDTO_ReplicationControllerData{},
+			},
+		}
+	case util.KindStatefulSet:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_StatefulSetData{
+				StatefulSetData: &proto.EntityDTO_StatefulSetData{},
+			},
+		}
+	default:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_CustomControllerData{
+				CustomControllerData: &proto.EntityDTO_CustomControllerData{
+					CustomControllerType: &controllerType,
+				},
+			},
+		}
+	}
+}

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
@@ -111,7 +111,6 @@ func (builder *workloadControllerDTOBuilder) getCommoditiesBought(kubeController
 		commBoughtBuilder := sdkbuilder.NewCommodityDTOBuilder(commodityType)
 		commBoughtBuilder.Used(resource.Used)
 		commBoughtBuilder.Peak(resource.Used)
-		commBoughtBuilder.Resizable(false)
 		commBoughtBuilder.Key(namespaceUID)
 		commBought, err := commBoughtBuilder.Create()
 		if err != nil {

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
@@ -138,7 +138,6 @@ func createCommoditiesBought(key string) []*proto.CommodityDTO {
 			Key:           &key,
 			Used:          &resource.Used,
 			Peak:          &resource.Used,
-			Resizable:     &testResizable,
 		}
 		commoditiesBought = append(commoditiesBought, commodityDTO)
 	}

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
@@ -1,0 +1,146 @@
+package dtofactory
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/util"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"testing"
+)
+
+var (
+	testCustomControllerType = "CustomControllerType"
+	testClusterName          = "cluster"
+	testNamespace            = "namespace"
+	testNamespaceUID         = "namespace-UID"
+	testResizable            = false
+
+	testAllocationResources = []*repository.KubeDiscoveredResource{
+		{
+			Type:     metrics.CPULimitQuota,
+			Capacity: 5327.0,
+			Used:     5061.0,
+		},
+		{
+			Type:     metrics.CPURequestQuota,
+			Capacity: 2663.0,
+			Used:     2397.0,
+		},
+		{
+			Type:     metrics.MemoryLimitQuota,
+			Capacity: 2097152.0,
+			Used:     1945600.0,
+		},
+		{
+			Type:     metrics.MemoryRequestQuota,
+			Capacity: 1048576.0,
+			Used:     921600.0,
+		},
+	}
+
+	// Create testKubeController1 with allocation resources
+	testKubeController1 = createKubeController(testClusterName, testNamespace, "controller1", util.KindDeployment,
+		"controller1-UID", testAllocationResources)
+	testKubeController2 = repository.NewKubeController(testClusterName, testNamespace, "controller2", testCustomControllerType, "controller2-UID")
+
+	testWorkloadControllerDTOBuilder = NewWorkloadControllerDTOBuilder(
+		map[string]*repository.KubeController{
+			"controller1-UID": testKubeController1,
+			"controller2-UID": testKubeController2,
+		},
+		map[string]string{
+			testNamespace: testNamespaceUID,
+		})
+)
+
+func TestBuildDTOs(t *testing.T) {
+	entityDTOs, _ := testWorkloadControllerDTOBuilder.BuildDTOs()
+	for _, entityDTO := range entityDTOs {
+		if entityDTO.GetId() == "controller1-UID" {
+			// cloneable and suspendable is false for WorkloadController
+			actionEligibility := entityDTO.GetActionEligibility()
+			assert.False(t, actionEligibility.GetCloneable())
+			assert.False(t, actionEligibility.GetSuspendable())
+
+			// Test commodity sold DTOs
+			expectedCommoditiesSold := createCommoditiesSold(testKubeController1.UID)
+			commoditiesSold := entityDTO.GetCommoditiesSold()
+			assert.ElementsMatch(t, expectedCommoditiesSold, commoditiesSold)
+
+			// Test commodity bought DTOs
+			expectedCommoditiesBought := createCommoditiesBought(testNamespaceUID)
+			commoditiesBought := entityDTO.GetCommoditiesBought()[0]
+			assert.Equal(t, proto.EntityDTO_NAMESPACE, commoditiesBought.GetProviderType())
+			assert.Equal(t, testNamespaceUID, commoditiesBought.GetProviderId())
+			assert.ElementsMatch(t, expectedCommoditiesBought, commoditiesBought.GetBought())
+
+			// Test create WorkloadControllerData with DeploymentData
+			expectedWorkloadControllerData1 := &proto.EntityDTO_WorkloadControllerData{
+				ControllerType: &proto.EntityDTO_WorkloadControllerData_DeploymentData{
+					DeploymentData: &proto.EntityDTO_DeploymentData{},
+				},
+			}
+			workloadControllerData1 := entityDTO.GetWorkloadControllerData()
+			assert.EqualValues(t, expectedWorkloadControllerData1, workloadControllerData1)
+		} else if entityDTO.GetId() == "controller2-UID" {
+			// cloneable and suspendable is false for WorkloadController
+			actionEligibility := entityDTO.GetActionEligibility()
+			assert.False(t, actionEligibility.GetCloneable())
+			assert.False(t, actionEligibility.GetSuspendable())
+
+			// Test create WorkloadControllerData with CustomControllerData
+			expectedWorkloadControllerData2 := &proto.EntityDTO_WorkloadControllerData{
+				ControllerType: &proto.EntityDTO_WorkloadControllerData_CustomControllerData{
+					CustomControllerData: &proto.EntityDTO_CustomControllerData{
+						CustomControllerType: &testCustomControllerType,
+					},
+				},
+			}
+			workloadControllerData2 := entityDTO.GetWorkloadControllerData()
+			assert.EqualValues(t, expectedWorkloadControllerData2, workloadControllerData2)
+		}
+	}
+}
+
+func createKubeController(clustername, namespace, name, controllerType, uid string,
+	testAllocationResources []*repository.KubeDiscoveredResource) *repository.KubeController {
+	kubeController := repository.NewKubeController(clustername, namespace, name, controllerType, uid)
+	for _, allocationResource := range testAllocationResources {
+		kubeController.AddAllocationResource(allocationResource.Type, allocationResource.Capacity, allocationResource.Used)
+	}
+	return kubeController
+}
+
+func createCommoditiesSold(key string) []*proto.CommodityDTO {
+	var commoditiesSold []*proto.CommodityDTO
+	for _, resource := range testAllocationResources {
+		commodityType, _ := rTypeMapping[resource.Type]
+		commodityDTO := &proto.CommodityDTO{
+			CommodityType: &commodityType,
+			Key:           &key,
+			Used:          &resource.Used,
+			Peak:          &resource.Used,
+			Capacity:      &resource.Capacity,
+			Resizable:     &testResizable,
+		}
+		commoditiesSold = append(commoditiesSold, commodityDTO)
+	}
+	return commoditiesSold
+}
+
+func createCommoditiesBought(key string) []*proto.CommodityDTO {
+	var commoditiesBought []*proto.CommodityDTO
+	for _, resource := range testAllocationResources {
+		commodityType, _ := rTypeMapping[resource.Type]
+		commodityDTO := &proto.CommodityDTO{
+			CommodityType: &commodityType,
+			Key:           &key,
+			Used:          &resource.Used,
+			Peak:          &resource.Used,
+			Resizable:     &testResizable,
+		}
+		commoditiesBought = append(commoditiesBought, commodityDTO)
+	}
+	return commoditiesBought
+}

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -242,7 +242,7 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 
 	// K8s workload controller discovery worker to create WorkloadController DTOs
 	controllerDiscoveryWorker := worker.NewK8sControllerDiscoveryWorker(clusterSummary)
-	workloadControllerDtos, _ := controllerDiscoveryWorker.Do(kubeControllerList)
+	workloadControllerDtos, err := controllerDiscoveryWorker.Do(kubeControllerList)
 	if err != nil {
 		glog.Errorf("Failed to discover workload controllers from current Kubernetes cluster with the new discovery framework: %s", err)
 	} else {

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -241,7 +241,7 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 	}
 
 	// K8s workload controller discovery worker to create WorkloadController DTOs
-	controllerDiscoveryWorker := worker.NewControllerDiscoveryWorker(clusterSummary)
+	controllerDiscoveryWorker := worker.NewK8sControllerDiscoveryWorker(clusterSummary)
 	workloadControllerDtos, _ := controllerDiscoveryWorker.Do(kubeControllerList)
 	if err != nil {
 		glog.Errorf("Failed to discover workload controllers from current Kubernetes cluster with the new discovery framework: %s", err)

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -224,15 +224,31 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 	// Call cache cleanup
 	dc.config.probeConfig.NodeClient.CleanupCache(nodes)
 
-	// Discover pods and create DTOs for nodes, pods, containers, application.
-	// Collect the kubePod, kubeNamespace metrics, groups from all the discovery workers
+	// Discover pods and create DTOs for nodes, namespaces, controllers, pods, containers, application.
+	// Collect the kubePod, kubeNamespace metrics, groups and kubeControllers from all the discovery workers
 	workerCount := dc.dispatcher.Dispatch(nodes, clusterSummary)
-	entityDTOs, podEntitiesMap, namespaceMetricsList, entityGroupList := dc.resultCollector.Collect(workerCount)
+	entityDTOs, podEntitiesMap, namespaceMetricsList, entityGroupList, kubeControllerList := dc.resultCollector.Collect(workerCount)
 
-	// Quota discovery worker to create namespace DTOs
+	// Namespace discovery worker to create namespace DTOs
 	stitchType := dc.config.probeConfig.StitchingPropertyType
-	quotasDiscoveryWorker := worker.Newk8sResourceQuotasDiscoveryWorker(clusterSummary, stitchType)
-	namespaceDtos, _ := quotasDiscoveryWorker.Do(namespaceMetricsList)
+	namespacesDiscoveryWorker := worker.Newk8sNamespaceDiscoveryWorker(clusterSummary, stitchType)
+	namespaceDtos, err := namespacesDiscoveryWorker.Do(namespaceMetricsList)
+	if err != nil {
+		glog.Errorf("Failed to discover namespaces from current Kubernetes cluster with the new discovery framework: %s", err)
+	} else {
+		glog.V(2).Infof("There are %d namespace entityDTOs.", len(namespaceDtos))
+		entityDTOs = append(entityDTOs, namespaceDtos...)
+	}
+
+	// K8s workload controller discovery worker to create WorkloadController DTOs
+	controllerDiscoveryWorker := worker.NewControllerDiscoveryWorker(clusterSummary)
+	workloadControllerDtos, _ := controllerDiscoveryWorker.Do(kubeControllerList)
+	if err != nil {
+		glog.Errorf("Failed to discover workload controllers from current Kubernetes cluster with the new discovery framework: %s", err)
+	} else {
+		glog.V(2).Infof("There are %d WorkloadController entityDTOs.", len(workloadControllerDtos))
+		entityDTOs = append(entityDTOs, workloadControllerDtos...)
+	}
 
 	// Service DTOs
 	glog.V(2).Infof("Begin to generate service EntityDTOs.")
@@ -244,9 +260,6 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 		glog.V(2).Infof("There are %d vApp entityDTOs.", len(serviceDtos))
 		entityDTOs = append(entityDTOs, serviceDtos...)
 	}
-
-	// All the DTOs
-	entityDTOs = append(entityDTOs, namespaceDtos...)
 
 	glog.V(2).Infof("There are totally %d entityDTOs.", len(entityDTOs))
 

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -12,6 +12,7 @@ const (
 	ClusterType     DiscoveredEntityType = "Cluster"
 	NamespaceType   DiscoveredEntityType = "Namespace"
 	NodeType        DiscoveredEntityType = "Node"
+	ControllerType  DiscoveredEntityType = "Controller"
 	PodType         DiscoveredEntityType = "Pod"
 	ContainerType   DiscoveredEntityType = "Container"
 	ApplicationType DiscoveredEntityType = "Application"

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -264,6 +264,36 @@ func parseResourceValue(computeResourceType metrics.ResourceType, resourceList v
 }
 
 // =================================================================================================
+// K8s controller in the cluster
+type KubeController struct {
+	*KubeEntity
+	ControllerType string
+	Pods           []*v1.Pod
+}
+
+func NewKubeController(clusterName, namespace, name, controllerType, uid string) *KubeController {
+	entity := NewKubeEntity(metrics.ControllerType, clusterName, namespace, name, uid)
+	return &KubeController{
+		KubeEntity:     entity,
+		ControllerType: controllerType,
+		Pods:           []*v1.Pod{},
+	}
+}
+
+// Construct controller full name by: "namespace/controllerType/controllerName"
+func (kubeController *KubeController) GetFullName() string {
+	return kubeController.Namespace + "/" + kubeController.ControllerType + "/" + kubeController.Name
+}
+
+func (kubeController *KubeController) String() string {
+	var buffer bytes.Buffer
+	line := fmt.Sprintf("K8s controller: %s\n", kubeController.GetFullName())
+	buffer.WriteString(line)
+	buffer.WriteString(kubeController.KubeEntity.String())
+	return buffer.String()
+}
+
+// =================================================================================================
 // The namespace in the cluster
 type KubeNamespace struct {
 	*KubeEntity

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -73,6 +73,7 @@ type TaskResult struct {
 	namespaceMetrics []*repository.NamespaceMetrics
 	entityGroups     []*repository.EntityGroup
 	podEntities      []*repository.KubePod
+	kubeControllers  []*repository.KubeController
 }
 
 func NewTaskResult(workerID string, state TaskResultState) *TaskResult {
@@ -106,6 +107,10 @@ func (r *TaskResult) EntityGroups() []*repository.EntityGroup {
 	return r.entityGroups
 }
 
+func (r *TaskResult) KubeControllers() []*repository.KubeController {
+	return r.kubeControllers
+}
+
 func (r *TaskResult) Err() error {
 	return r.err
 }
@@ -132,5 +137,10 @@ func (r *TaskResult) WithNamespaceMetrics(namespaceMetrics []*repository.Namespa
 
 func (r *TaskResult) WithEntityGroups(entityGroups []*repository.EntityGroup) *TaskResult {
 	r.entityGroups = entityGroups
+	return r
+}
+
+func (r *TaskResult) WithKubeControllers(kubeControllers []*repository.KubeController) *TaskResult {
+	r.kubeControllers = kubeControllers
 	return r
 }

--- a/pkg/discovery/worker/controller_discovery_worker.go
+++ b/pkg/discovery/worker/controller_discovery_worker.go
@@ -1,0 +1,80 @@
+package worker
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+// Converts the cluster K8s controller objects to entity DTOs
+type ControllerDiscoveryWorker struct {
+	cluster *repository.ClusterSummary
+}
+
+func NewControllerDiscoveryWorker(cluster *repository.ClusterSummary) *ControllerDiscoveryWorker {
+	return &ControllerDiscoveryWorker{
+		cluster: cluster,
+	}
+}
+
+// Controller discovery worker collects KubeController entities discovered by different discovery workers.
+// It merges the pods belonging to the same controller but discovered by different discovery workers, and aggregates
+// allocation resources usage of the same KubeController from different workers.
+// Then it creates entity DTOs for the K8s controllers to be sent to the Turbonomic server.
+func (worker *ControllerDiscoveryWorker) Do(kubeControllers []*repository.KubeController) ([]*proto.EntityDTO, error) {
+	namespacesMap := worker.cluster.NamespaceMap
+	// Map from controller UID to the corresponding kubeController
+	kubeControllersMap := make(map[string]*repository.KubeController)
+	// Combine the pods and allocation resources usage from different discovery workers but belonging to the same K8s controller.
+	for _, kubeController := range kubeControllers {
+		existingKubeController, exists := kubeControllersMap[kubeController.UID]
+		if !exists {
+			kubeNamespace, exists := namespacesMap[kubeController.Namespace]
+			if !exists {
+				glog.Errorf("Namespace %s does not exist in cluster %s", kubeController.Namespace, worker.cluster.Name)
+				continue
+			}
+			for resourceType, resource := range kubeController.AllocationResources {
+				// For CPU resources, convert the capacity values expressed in number of cores to MHz.
+				// Skip the conversion if capacity value is repository.DEFAULT_METRIC_CAPACITY_VALUE (infinity), which
+				// means resource quota is not configured on the corresponding namespace.
+				if metrics.IsCPUType(resourceType) && resource.Capacity != repository.DEFAULT_METRIC_CAPACITY_VALUE &&
+					kubeNamespace.AverageNodeCpuFrequency > 0.0 {
+					newCapacity := resource.Capacity * kubeNamespace.AverageNodeCpuFrequency
+					glog.V(4).Infof("Changing capacity of %s::%s from %f cores to %f MHz",
+						kubeController.GetFullName(), resourceType, resource.Capacity, newCapacity)
+					resource.Capacity = newCapacity
+				}
+			}
+			kubeControllersMap[kubeController.UID] = kubeController
+		} else {
+			for resourceType, resource := range existingKubeController.AllocationResources {
+				usedValue, err := kubeController.GetResourceUsed(resourceType)
+				if err != nil {
+					glog.Error(err)
+					continue
+				}
+				// Aggregate allocation resource usage of the same kubeController discovered by different discovery worker.
+				// The usage values of CPU resources have already been converted from cores to MHz based on the CPU
+				// frequency of the corresponding node in controller_metrics_collector.
+				resource.Used += usedValue
+			}
+			// Update the pod lists of the existing KubeController
+			existingKubeController.Pods = append(existingKubeController.Pods, kubeController.Pods...)
+		}
+
+	}
+	for _, kubeController := range kubeControllersMap {
+		glog.V(4).Infof("Discovered WorkloadController entity: %s", kubeController)
+	}
+	// Create DTOs for each k8s WorkloadController entity
+	workloadControllerDTOBuilder := dtofactory.NewWorkloadControllerDTOBuilder(kubeControllersMap, worker.cluster.NamespaceUIDMap)
+	workloadControllerDtos, err := workloadControllerDTOBuilder.BuildDTOs()
+	if err != nil {
+		return nil, fmt.Errorf("error while creating WorkloadController entityDTOs: %v", err)
+	}
+	return workloadControllerDtos, nil
+}

--- a/pkg/discovery/worker/controller_discovery_worker.go
+++ b/pkg/discovery/worker/controller_discovery_worker.go
@@ -63,6 +63,8 @@ func (worker *K8sControllerDiscoveryWorker) Do(kubeControllers []*repository.Kub
 				resource.Used += usedValue
 			}
 			// Update the pod lists of the existing KubeController
+			// TODO yue will use the pods of each KubeController to create ContainerSpec entity DTOs to simplify the logic
+			// in container_spec_entity_dto_builder.go
 			existingKubeController.Pods = append(existingKubeController.Pods, kubeController.Pods...)
 		}
 

--- a/pkg/discovery/worker/controller_discovery_worker.go
+++ b/pkg/discovery/worker/controller_discovery_worker.go
@@ -10,12 +10,12 @@ import (
 )
 
 // Converts the cluster K8s controller objects to entity DTOs
-type ControllerDiscoveryWorker struct {
+type K8sControllerDiscoveryWorker struct {
 	cluster *repository.ClusterSummary
 }
 
-func NewControllerDiscoveryWorker(cluster *repository.ClusterSummary) *ControllerDiscoveryWorker {
-	return &ControllerDiscoveryWorker{
+func NewK8sControllerDiscoveryWorker(cluster *repository.ClusterSummary) *K8sControllerDiscoveryWorker {
+	return &K8sControllerDiscoveryWorker{
 		cluster: cluster,
 	}
 }
@@ -24,7 +24,7 @@ func NewControllerDiscoveryWorker(cluster *repository.ClusterSummary) *Controlle
 // It merges the pods belonging to the same controller but discovered by different discovery workers, and aggregates
 // allocation resources usage of the same KubeController from different workers.
 // Then it creates entity DTOs for the K8s controllers to be sent to the Turbonomic server.
-func (worker *ControllerDiscoveryWorker) Do(kubeControllers []*repository.KubeController) ([]*proto.EntityDTO, error) {
+func (worker *K8sControllerDiscoveryWorker) Do(kubeControllers []*repository.KubeController) ([]*proto.EntityDTO, error) {
 	namespacesMap := worker.cluster.NamespaceMap
 	// Map from controller UID to the corresponding kubeController
 	kubeControllersMap := make(map[string]*repository.KubeController)

--- a/pkg/discovery/worker/controller_discovery_worker.go
+++ b/pkg/discovery/worker/controller_discovery_worker.go
@@ -24,6 +24,7 @@ func NewK8sControllerDiscoveryWorker(cluster *repository.ClusterSummary) *K8sCon
 // It merges the pods belonging to the same controller but discovered by different discovery workers, and aggregates
 // allocation resources usage of the same KubeController from different workers.
 // Then it creates entity DTOs for the K8s controllers to be sent to the Turbonomic server.
+// This runs after cluster NamespaceMap is populated.
 func (worker *K8sControllerDiscoveryWorker) Do(kubeControllers []*repository.KubeController) ([]*proto.EntityDTO, error) {
 	namespacesMap := worker.cluster.NamespaceMap
 	// Map from controller UID to the corresponding kubeController
@@ -37,12 +38,17 @@ func (worker *K8sControllerDiscoveryWorker) Do(kubeControllers []*repository.Kub
 				glog.Errorf("Namespace %s does not exist in cluster %s", kubeController.Namespace, worker.cluster.Name)
 				continue
 			}
+			averageNodeCpuFrequency := kubeNamespace.AverageNodeCpuFrequency
+			if averageNodeCpuFrequency <= 0.0 {
+				glog.Errorf("Average node CPU frequency is not larger than zero in namespace %s. Skip KubeController %s",
+					kubeNamespace.Name, kubeController.GetFullName())
+				continue
+			}
 			for resourceType, resource := range kubeController.AllocationResources {
 				// For CPU resources, convert the capacity values expressed in number of cores to MHz.
 				// Skip the conversion if capacity value is repository.DEFAULT_METRIC_CAPACITY_VALUE (infinity), which
 				// means resource quota is not configured on the corresponding namespace.
-				if metrics.IsCPUType(resourceType) && resource.Capacity != repository.DEFAULT_METRIC_CAPACITY_VALUE &&
-					kubeNamespace.AverageNodeCpuFrequency > 0.0 {
+				if metrics.IsCPUType(resourceType) && resource.Capacity != repository.DEFAULT_METRIC_CAPACITY_VALUE {
 					newCapacity := resource.Capacity * kubeNamespace.AverageNodeCpuFrequency
 					glog.V(4).Infof("Changing capacity of %s::%s from %f cores to %f MHz",
 						kubeController.GetFullName(), resourceType, resource.Capacity, newCapacity)

--- a/pkg/discovery/worker/controller_metrics_collector.go
+++ b/pkg/discovery/worker/controller_metrics_collector.go
@@ -1,0 +1,171 @@
+package worker
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	api "k8s.io/api/core/v1"
+)
+
+// Collect K8s controller info from the pods by the given discovery worker and convert to KubeController objects.
+type ControllerMetricsCollector struct {
+	podList     []*api.Pod
+	cluster     *repository.ClusterSummary
+	metricsSink *metrics.EntityMetricSink
+	workerId    string
+}
+
+func NewControllerMetricsCollector(discoveryWorker *k8sDiscoveryWorker, currTask *task.Task) *ControllerMetricsCollector {
+	metricsCollector := &ControllerMetricsCollector{
+		podList:     currTask.PodList(),
+		cluster:     currTask.Cluster(),
+		metricsSink: discoveryWorker.sink,
+		workerId:    discoveryWorker.id,
+	}
+	return metricsCollector
+}
+
+// Collect allocation resource metrics for K8s controllers where usage values are aggregated from pods and capacity values
+// are from namespace quota capacity.
+func (collector *ControllerMetricsCollector) CollectControllerMetrics() ([]*repository.KubeController, error) {
+	if collector.cluster == nil {
+		return nil, fmt.Errorf("error collecting K8s controller metrics, because cluster summary object is null for discovery worker %s",
+			collector.workerId)
+	}
+	kubeNamespaceMap := collector.cluster.NamespaceMap
+	// Map from controller UID to the corresponding kubeController
+	kubeControllersMap := make(map[string]*repository.KubeController)
+	var kubeControllerList []*repository.KubeController
+	for _, pod := range collector.podList {
+		if pod.OwnerReferences == nil {
+			// If pod has no OwnerReferences, it is a bare pod without controller. Skip this.
+			glog.V(4).Infof("Skip creating KubeController for bare Pod %s", util.PodKeyFunc(pod))
+			continue
+		}
+		controllerType, controllerName, controllerUID, err := collector.getKubeControllerInfo(metrics.PodType, util.PodKeyFunc(pod))
+		if err != nil {
+			glog.Errorf("Error getting controller info from Pod %s: %v", util.PodKeyFunc(pod), err)
+			continue
+		}
+		kubeController, exists := kubeControllersMap[controllerUID]
+		if !exists {
+			namespace := pod.Namespace
+			// Create default KubeController entity
+			kubeController = repository.NewKubeController(collector.cluster.Name, namespace, controllerName, controllerType,
+				controllerUID)
+			kubeNamespace, namespaceExists := kubeNamespaceMap[namespace]
+			if !namespaceExists {
+				glog.Errorf("Namespace %s does not exist in cluster %s", namespace, collector.cluster.Name)
+				continue
+			}
+			// Add quota resources to KubeController entity with capacity as namespace quota capacity
+			for _, resourceType := range metrics.QuotaResources {
+				namespaceQuotaResource, err := kubeNamespace.GetAllocationResource(resourceType)
+				resourceCapacity := repository.DEFAULT_METRIC_CAPACITY_VALUE
+				if err != nil {
+					glog.Errorf("KubeNamespace %s has invalid resource %s. Set %s capacity of k8s controller %s to %v",
+						kubeNamespace.Name, resourceType, resourceType, kubeController.GetFullName(), repository.DEFAULT_METRIC_CAPACITY_VALUE)
+				} else {
+					// For CPU resources, set capacity values in number of cores here. Will update CPU resources capacity
+					// to MHz based on average node CPU frequency when building workload controller entity DTO in
+					// controller_discovery_worker. Each k8s controller metrics collector collects controller metrics
+					// from certain amount of nodes run by a k8s discovery worker. So at this point, there's no way to
+					// calculate average CPU frequency of all nodes in the cluster.
+					resourceCapacity = namespaceQuotaResource.Capacity
+				}
+				kubeController.AddAllocationResource(resourceType, resourceCapacity, repository.DEFAULT_METRIC_VALUE)
+			}
+			kubeControllersMap[controllerUID] = kubeController
+			kubeControllerList = append(kubeControllerList, kubeController)
+		}
+		kubeController.Pods = append(kubeController.Pods, pod)
+		// Update quota resources usage for the controller aggregated from pods quota usage
+		collector.updateQuotaResourcesUsed(kubeController, pod)
+	}
+	return kubeControllerList, nil
+}
+
+// Get KubeController info from the given pod from metrics sink, including controller type, name and UID.
+func (collector *ControllerMetricsCollector) getKubeControllerInfo(entityType metrics.DiscoveredEntityType,
+	entityKey string) (string, string, string, error) {
+	controllerType, err := collector.getOwnerMetric(entityType, entityKey, metrics.OwnerType)
+	if err != nil {
+		return "", "", "", err
+	}
+	controllerName, err := collector.getOwnerMetric(entityType, entityKey, metrics.Owner)
+	if err != nil {
+		return "", "", "", err
+	}
+	controllerUID, err := collector.getOwnerMetric(entityType, entityKey, metrics.OwnerUID)
+	if err != nil {
+		return "", "", "", err
+	}
+	return controllerType, controllerName, controllerUID, nil
+}
+
+// Get Pod owner metric value of a given metric type from metrics sink. Metric type can be Owner (owner name), OwnerType
+// or OwnerUID.
+func (collector *ControllerMetricsCollector) getOwnerMetric(entityType metrics.DiscoveredEntityType, entityKey string,
+	ownerMetricType metrics.ResourceType) (string, error) {
+	ownerMetricId := metrics.GenerateEntityStateMetricUID(entityType, entityKey, ownerMetricType)
+	ownerMetric, err := collector.metricsSink.GetMetric(ownerMetricId)
+	if err != nil {
+		return "", fmt.Errorf("error getting %s from metrics sink for pod %s --> %v", ownerMetricType, entityKey, err)
+	}
+	ownerMetricValue := ownerMetric.GetValue()
+	metricValue, ok := ownerMetricValue.(string)
+	if !ok {
+		return "", fmt.Errorf("error getting %s from metrics sink for pod %s", ownerMetricType, entityKey)
+	}
+	return metricValue, nil
+}
+
+// Update quota resources used for the controller from pod quota usage. The usage values of CPU resources are converted
+// from cores to MHz based on the CPU frequency of the corresponding node where the given pod is located.
+func (collector *ControllerMetricsCollector) updateQuotaResourcesUsed(kubeController *repository.KubeController, pod *api.Pod) {
+	for _, resourceType := range metrics.QuotaResources {
+		podKey := util.PodKeyFunc(pod)
+		metricId := metrics.GenerateEntityResourceMetricUID(metrics.PodType, podKey, resourceType, metrics.Used)
+		metric, err := collector.metricsSink.GetMetric(metricId)
+		if err != nil {
+			glog.Errorf("Error getting %s used value from metrics sink for pod %s: %v", resourceType, podKey, err)
+			continue
+		}
+		resourceUsed := metric.GetValue().(float64)
+		if metrics.IsCPUType(resourceType) {
+			// For CPU resources, convert the usage values expressed in cores to MHz based on the CPU frequency of the
+			// corresponding node where the given pod is located
+			cpuFrequency, err := collector.getNodeCPUFrequency(pod)
+			if err != nil {
+				glog.Errorf("Error getting node cpuFrequency from pod %s: %v", podKey, err)
+				continue
+			}
+			if cpuFrequency > 0.0 {
+				resourceUsed *= cpuFrequency
+			}
+		}
+		// Get existing resource of the given resourceType where used value is to be updated
+		existingResource, err := kubeController.GetResource(resourceType)
+		if err != nil {
+			glog.Errorf("Error getting resource %s from controller %s", resourceType, kubeController.GetFullName())
+			continue
+		}
+		existingResource.Used += resourceUsed
+	}
+}
+
+// Get hosting node CPU frequency.
+func (collector *ControllerMetricsCollector) getNodeCPUFrequency(pod *api.Pod) (float64, error) {
+	key := util.NodeKeyFromPodFunc(pod)
+	cpuFrequencyUID := metrics.GenerateEntityStateMetricUID(metrics.NodeType, key, metrics.CpuFrequency)
+	cpuFrequencyMetric, err := collector.metricsSink.GetMetric(cpuFrequencyUID)
+	if err != nil {
+		err := fmt.Errorf("failed to get cpu frequency from sink for node %s: %v", key, err)
+		return 0.0, err
+	}
+	cpuFrequency := cpuFrequencyMetric.GetValue().(float64)
+	return cpuFrequency, nil
+}

--- a/pkg/discovery/worker/controller_metrics_collector.go
+++ b/pkg/discovery/worker/controller_metrics_collector.go
@@ -144,7 +144,12 @@ func (collector *ControllerMetricsCollector) updateQuotaResourcesUsed(kubeContro
 				continue
 			}
 			if cpuFrequency > 0.0 {
-				resourceUsed *= cpuFrequency
+				usedValue := resourceUsed * cpuFrequency
+				if usedValue > 0.0 {
+					glog.V(4).Infof("Changing usage of %s::%s from pod %s from %f cores to %f MHz",
+						kubeController.GetFullName(), resourceType, pod.Name, resourceUsed, usedValue)
+				}
+				resourceUsed = usedValue
 			}
 		}
 		// Get existing resource of the given resourceType where used value is to be updated

--- a/pkg/discovery/worker/controller_metrics_collector_test.go
+++ b/pkg/discovery/worker/controller_metrics_collector_test.go
@@ -1,0 +1,168 @@
+package worker
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
+	discoveryutil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/turbonomic/kubeturbo/pkg/util"
+	api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+)
+
+var (
+	namespace      = "namespace"
+	controller1    = "controller1"
+	controllerUID1 = "controllerUID1"
+	controller2    = "controller2"
+	controllerUID2 = "controllerUID2"
+
+	// testPod1 and testPod2 are from the same Deployment controller
+	testPod1 = &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "pod1",
+			UID:       "pod1-UID",
+			OwnerReferences: []metav1.OwnerReference{
+				mockOwnerReference(util.KindDeployment, controller1, controllerUID1),
+			},
+		},
+		Spec: api.PodSpec{
+			NodeName: "node1",
+		},
+	}
+	testPod2 = &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "pod2",
+			UID:       "pod2-UID",
+			OwnerReferences: []metav1.OwnerReference{
+				mockOwnerReference(util.KindDeployment, controller1, controllerUID1),
+			},
+		},
+		Spec: api.PodSpec{
+			NodeName: "node2",
+		},
+	}
+	// pod3 is from StatefulSet controller
+	testPod3 = &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "pod3",
+			UID:       "pod3-UID",
+			OwnerReferences: []metav1.OwnerReference{
+				mockOwnerReference(util.KindStatefulSet, controller2, controllerUID2),
+			},
+		},
+		Spec: api.PodSpec{
+			NodeName: "node1",
+		},
+	}
+
+	// Create owner metrics for testPod1, testPod2 and testPod3, including owner kind, name and uid
+	pod1OwnerMetrics = createOwnerMetrics(testPod1, util.KindDeployment, controller1, controllerUID1)
+	pod2OwnerMetrics = createOwnerMetrics(testPod2, util.KindDeployment, controller1, controllerUID1)
+	pod3OwnerMetrics = createOwnerMetrics(testPod3, util.KindStatefulSet, controller2, controllerUID2)
+
+	pod1CPULimitQuotaUsed      = metrics.NewEntityResourceMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod1), metrics.CPULimitQuota, metrics.Used, 1.0)
+	pod2CPULimitQuotaUsed      = metrics.NewEntityResourceMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod2), metrics.CPULimitQuota, metrics.Used, 2.0)
+	pod3MemoryRequestQuotaUsed = metrics.NewEntityResourceMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod3), metrics.MemoryRequestQuota, metrics.Used, 10.0)
+
+	cpuFrequency = 1000.0
+
+	pod1NodeCPUFrequency = metrics.NewEntityStateMetric(metrics.NodeType, discoveryutil.NodeKeyFromPodFunc(testPod1), metrics.CpuFrequency, cpuFrequency)
+	pod2NodeCPUFrequency = metrics.NewEntityStateMetric(metrics.NodeType, discoveryutil.NodeKeyFromPodFunc(testPod2), metrics.CpuFrequency, cpuFrequency)
+)
+
+func TestCollectControllerMetrics(t *testing.T) {
+	kubeNamespace := repository.CreateDefaultKubeNamespace(cluster1, namespace, "namespace-uuid")
+	_ = kubeNamespace.SetResourceCapacity(metrics.CPULimitQuota, 4.0)
+	_ = kubeNamespace.SetResourceCapacity(metrics.MemoryLimitQuota, 3.0)
+
+	kubeCluster := &repository.KubeCluster{
+		Name: "cluster",
+		Namespaces: map[string]*repository.KubeNamespace{
+			namespace: kubeNamespace,
+		},
+	}
+	clusterSummary := repository.CreateClusterSummary(kubeCluster)
+	pods := []*api.Pod{testPod1, testPod2, testPod3}
+	currTask := task.NewTask().WithPods(pods).WithCluster(clusterSummary)
+
+	workerConfig := NewK8sDiscoveryWorkerConfig("sType").WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil))
+	discoveryWorker, _ := NewK8sDiscoveryWorker(workerConfig, "wid")
+
+	// Add owner metrics to the metric sink
+	var ownerMetricsList []metrics.EntityStateMetric
+	ownerMetricsList = append(ownerMetricsList, pod1OwnerMetrics...)
+	ownerMetricsList = append(ownerMetricsList, pod2OwnerMetrics...)
+	ownerMetricsList = append(ownerMetricsList, pod3OwnerMetrics...)
+	for _, ownerMetrics := range ownerMetricsList {
+		discoveryWorker.sink.AddNewMetricEntries(ownerMetrics)
+	}
+
+	// Add resource usage metrics to the metric sink
+	discoveryWorker.sink.AddNewMetricEntries(pod1CPULimitQuotaUsed)
+	discoveryWorker.sink.AddNewMetricEntries(pod2CPULimitQuotaUsed)
+	discoveryWorker.sink.AddNewMetricEntries(pod3MemoryRequestQuotaUsed)
+
+	// Add CPU frequency metrics to the metric sink
+	discoveryWorker.sink.AddNewMetricEntries(pod1NodeCPUFrequency)
+	discoveryWorker.sink.AddNewMetricEntries(pod2NodeCPUFrequency)
+
+	// Test CollectControllerMetrics
+	controllerMetricsCollector := NewControllerMetricsCollector(discoveryWorker, currTask)
+	kubeControllers, _ := controllerMetricsCollector.CollectControllerMetrics()
+
+	// 2 KubeControllers are created
+	assert.Equal(t, 2, len(kubeControllers))
+
+	// CPULimitQuota usage of the first controller is aggregated from testPod1 and testPod2 and converted from cores to MHz.
+	kubeController1 := kubeControllers[0]
+	assert.Equal(t, util.KindDeployment, kubeController1.ControllerType)
+	assert.Equal(t, 2, len(kubeController1.Pods))
+	kubeController1AllocationResources := kubeController1.AllocationResources
+	assert.Equal(t, 4, int(kubeController1AllocationResources[metrics.CPULimitQuota].Capacity))
+	// Usage value is aggregated from testPod1 and testPod2 and converted to MHz, which is calculated by:
+	// (1.0 + 2.0) * 1000 = 3000
+	assert.Equal(t, 3000, int(kubeController1AllocationResources[metrics.CPULimitQuota].Used))
+	assert.Equal(t, 4, int(kubeController1AllocationResources[metrics.CPULimitQuota].Capacity))
+	assert.Equal(t, 3, int(kubeController1AllocationResources[metrics.MemoryLimitQuota].Capacity))
+	// Resource capacity of metrics.CPURequestQuota and metrics.MemoryRequestQuota is not configured on namespace,
+	// by default capacity is repository.DEFAULT_METRIC_CAPACITY_VALUE
+	assert.Equal(t, repository.DEFAULT_METRIC_CAPACITY_VALUE, kubeController1AllocationResources[metrics.CPURequestQuota].Capacity)
+	assert.Equal(t, repository.DEFAULT_METRIC_CAPACITY_VALUE, kubeController1AllocationResources[metrics.MemoryRequestQuota].Capacity)
+
+	kubeController2 := kubeControllers[1]
+	assert.Equal(t, util.KindStatefulSet, kubeController2.ControllerType)
+	assert.Equal(t, 1, len(kubeController2.Pods))
+	kubeController2AllocationResources := kubeController2.AllocationResources
+	assert.Equal(t, 10, int(kubeController2AllocationResources[metrics.MemoryRequestQuota].Used))
+	assert.Equal(t, 4, int(kubeController2AllocationResources[metrics.CPULimitQuota].Capacity))
+	assert.Equal(t, 3, int(kubeController2AllocationResources[metrics.MemoryLimitQuota].Capacity))
+	// Resource capacity of metrics.CPURequestQuota and metrics.MemoryRequestQuota is not configured on namespace,
+	// by default capacity is repository.DEFAULT_METRIC_CAPACITY_VALUE
+	assert.Equal(t, repository.DEFAULT_METRIC_CAPACITY_VALUE, kubeController2AllocationResources[metrics.CPURequestQuota].Capacity)
+	assert.Equal(t, repository.DEFAULT_METRIC_CAPACITY_VALUE, kubeController2AllocationResources[metrics.MemoryRequestQuota].Capacity)
+}
+
+func mockOwnerReference(kind, name, uid string) metav1.OwnerReference {
+	isController := true
+	return metav1.OwnerReference{
+		Kind:       kind,
+		Name:       name,
+		UID:        types.UID(uid),
+		Controller: &isController,
+	}
+}
+
+func createOwnerMetrics(pod *api.Pod, kind, name, uid string) []metrics.EntityStateMetric {
+	ownerTypeMetric := metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(pod), metrics.OwnerType, kind)
+	ownerMetric := metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(pod), metrics.Owner, name)
+	ownerUIDMetric := metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(pod), metrics.OwnerUID, uid)
+	return []metrics.EntityStateMetric{ownerTypeMetric, ownerMetric, ownerUIDMetric}
+}

--- a/pkg/discovery/worker/namespace_discovery_worker.go
+++ b/pkg/discovery/worker/namespace_discovery_worker.go
@@ -14,22 +14,22 @@ const (
 )
 
 // Converts the cluster namespaceEntity and NamespaceMetrics objects to create Namespace DTOs
-type k8sResourceQuotasDiscoveryWorker struct {
+type k8sNamespaceDiscoveryWorker struct {
 	id         string
 	Cluster    *repository.ClusterSummary
 	stitchType stitching.StitchingPropertyType
 }
 
-func Newk8sResourceQuotasDiscoveryWorker(cluster *repository.ClusterSummary, pType stitching.StitchingPropertyType,
-) *k8sResourceQuotasDiscoveryWorker {
-	return &k8sResourceQuotasDiscoveryWorker{
+func Newk8sNamespaceDiscoveryWorker(cluster *repository.ClusterSummary, pType stitching.StitchingPropertyType,
+) *k8sNamespaceDiscoveryWorker {
+	return &k8sNamespaceDiscoveryWorker{
 		Cluster:    cluster,
 		id:         k8sQuotasWorkerID,
 		stitchType: pType,
 	}
 }
 
-func (worker *k8sResourceQuotasDiscoveryWorker) Do(namespaceMetricsList []*repository.NamespaceMetrics,
+func (worker *k8sNamespaceDiscoveryWorker) Do(namespaceMetricsList []*repository.NamespaceMetrics,
 ) ([]*proto.EntityDTO, error) {
 	// Combine quota discovery results from different nodes
 	namespaceMetricsMap := make(map[string]*repository.NamespaceMetrics)

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -166,6 +166,7 @@ func (rClient *K8sRegistrationClient) GetEntityMetadata() (result []*proto.Entit
 
 	entities := []proto.EntityDTO_EntityType{
 		proto.EntityDTO_NAMESPACE,
+		proto.EntityDTO_WORKLOAD_CONTROLLER,
 		proto.EntityDTO_VIRTUAL_MACHINE,
 		proto.EntityDTO_CONTAINER_SPEC,
 		proto.EntityDTO_CONTAINER_POD,

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -118,6 +118,7 @@ func TestK8sRegistrationClient_GetEntityMetadata(t *testing.T) {
 	//1. all the entity types
 	entities := []proto.EntityDTO_EntityType{
 		proto.EntityDTO_NAMESPACE,
+		proto.EntityDTO_WORKLOAD_CONTROLLER,
 		proto.EntityDTO_VIRTUAL_MACHINE,
 		proto.EntityDTO_CONTAINER_SPEC,
 		proto.EntityDTO_CONTAINER_POD,

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -3,9 +3,14 @@ package util
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	KindReplicationController = "ReplicationController"
-	KindReplicaSet            = "ReplicaSet"
+	// Kubernetes workload controller types
+	KindCronJob               = "CronJob"
+	KindDaemonSet             = "DaemonSet"
 	KindDeployment            = "Deployment"
+	KindJob                   = "Job"
+	KindReplicaSet            = "ReplicaSet"
+	KindReplicationController = "ReplicationController"
+	KindStatefulSet           = "StatefulSet"
 
 	K8sExtensionsGroupName = "extensions"
 	K8sAppsGroupName       = "apps"


### PR DESCRIPTION
**Intent**:
The intent is to
1. Explicitly represent k8s controller as an entity in the supply chain so as to show the aggregated data of a controller and in the future store the spec data.
2. Have WorkloadController entity sell VCPULimitQuota/VMemLimitQuotaand VCPURequestQuota/VMemRequestQuota commodities as a "_reseller_" to take K8s namespace resource quota into consideration for container resizing

**Background**:
The supply chain and resource commodities bought and sold by WorkloadController are shown in the screenshot below:
<img width="1287" alt="Screen Shot 2020-04-13 at 11 16 05" src="https://user-images.githubusercontent.com/23689754/79132393-3eb7c580-7d78-11ea-96f7-315a92677615.png">
<img width="1307" alt="Screen Shot 2020-04-13 at 11 16 24" src="https://user-images.githubusercontent.com/23689754/79132399-411a1f80-7d78-11ea-8a39-0f73e68c7f01.png">
where WorkloadController sells commodities to Pod and buys commodities from Namespace.

**Implementation**:
1. Create `KubeController` type in `kube_cluster.go` to represent a k8s controller.
2. In `controller_metrics_collector.go`, 1) create `KubeController` entity by retrieving pod owner name, type and UID from metrics sink by calling `getKubeControllerInfo` func; 2) collect allocation resource metrics for K8s controllers from the pods by a given discovery worker, where usage values are aggregated from pods and capacity values are from namespace quota capacity. Note that for a pod deployed by Deployment controller, the created `KubeController` entity has controllerType as "Deployment" not "ReplicaSet".
3. Send list of `KubeController` discovered by a discovery worker in `k8s_discovery_worker::executeTask`
4. Collect all KubeControllers discovered by different discovery workers in `result_collector:: Collect` 
5. In `controller_discovery_worker.go`, merge the KubeControllers discovered by different discovery workers and invoke `workload_controller_entity_dto_builder` to create entity DTOs.
6. Create WorkloadController entity DTOs with commodities bought and sold as well as `WorkloadControllerData` with controller type data in `workload_controller_entity_dto_builder`. 
7. Add `EntityDTO_WORKLOAD_CONTROLLER` in `registration_client` and build `WorkloadControllerSupplyBuilder` in `supply_chain_factory`
8. Rename `k8sResourceQuotasDiscoveryWorker` to `k8sNamespaceDiscoveryWorker` to avoid confusion.

**Unit Test**:
Created new unit tests `controller_metrics_collector_test.go` and `workload_controller_entity_dto_builder_test.go`

**Testing Done**:
Added kubeturbo target (dc11) with the changes and dumped discovery dtos.
1. In the supply chain, WorkloadControllers are buying from Namespaces:
![Screen Shot 2020-04-13 at 11 33 53](https://user-images.githubusercontent.com/23689754/79133846-b38bff00-7d7a-11ea-823c-83a4a3d2d1b6.png)
2. Here's a snippet of a WorkloadController entityDTO where quota is configured on the corresponding namespace:
```json
entityDTO {
  entityType: WORKLOAD_CONTROLLER
  id: "1d187381-0ba6-11ea-878a-005056803aed"
  displayName: "sc-testing"
  commoditiesSold {
    commodityType: VCPU_REQUEST_QUOTA
    key: "1d187381-0ba6-11ea-878a-005056803aed"
    used: 2397.4002
    capacity: 2663.778
    peak: 2397.4002
    resizable: false
  }
  ...
  commoditiesBought {
    providerId: "10c7cf65-0ba6-11ea-878a-005056803aed"
    bought {
      commodityType: VCPU_LIMIT_QUOTA
      key: "10c7cf65-0ba6-11ea-878a-005056803aed"
      used: 5061.178199999999
      peak: 5061.178199999999
      resizable: false
    }
    ...
    providerType: NAMESPACE
    actionEligibility {
      movable: false
    }
  }
  powerState: POWERED_ON
  actionEligibility {
    suspendable: false
    cloneable: false
  }
  workload_controller_data {
    deployment_data {
    }
  }
```
where
* WorkloadControlelr entity sells commodities with `resizable` as false
* entity buys commodities from Namespace with `resizable` as false and movable as false
* suspendable and cloneable are false
* entity has `deployment_data` in `workload_controller_data` which means this controller is a Deployment

3. If the corresponding Namespace has no quota configured and all containers in the pods have no compute resources (limits or requests) configured, the WorkloadController entity sells the commodity with capacity as "infinity" as 1e12 and usage/peak as 0:
```json
entityDTO {
  entityType: WORKLOAD_CONTROLLER
  id: "90e3886e-0489-11ea-878a-005056803aed"
  displayName: "kubeturbo-arsen-dep-6.4"
  commoditiesSold {
    commodityType: VCPU_REQUEST_QUOTA
    key: "90e3886e-0489-11ea-878a-005056803aed"
    used: 0.0
    capacity: 1.0E12
    peak: 0.0
    resizable: false
  }
```

4. Commodities of WorkloadController are correctly shown in "Capacity and Usage" widget:
![Screen Shot 2020-04-13 at 11 44 15](https://user-images.githubusercontent.com/23689754/79134746-306ba880-7d7c-11ea-954f-a3845c2284dc.png)
where the first four are commodities sold and last four are commodities bought from the Namespace.