### PR TITLE
Provide ContainerSpec relationships in new container model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/sirupsen/logrus v1.2.0 // indirect
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20200326155922-81acd4cd0f43
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20200421152643-8b3f53587765
 	go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 // indirect
 	go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df // indirect
 	go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/turbonomic/turbo-go-sdk v0.0.0-20200316032753-8ec05236846c h1:RFwbO20
 github.com/turbonomic/turbo-go-sdk v0.0.0-20200316032753-8ec05236846c/go.mod h1:aKy1TU/sTQbhrJifz+0QktOTKfAP67IFUgN1LHktr7A=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20200326155922-81acd4cd0f43 h1:YS8jsCBbDwlY2B13Pe5YwICFWqeCB2QnodBscl6yQEY=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20200326155922-81acd4cd0f43/go.mod h1:aKy1TU/sTQbhrJifz+0QktOTKfAP67IFUgN1LHktr7A=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20200421152643-8b3f53587765 h1:HFv2si3FL+r+ly3+KA40rWwn7zdo1dHyt/7cdntgB2o=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20200421152643-8b3f53587765/go.mod h1:aKy1TU/sTQbhrJifz+0QktOTKfAP67IFUgN1LHktr7A=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 h1:nSQar3Y0E3VQF/VdZ8PTAilaXpER+d7ypdABCrpwMdg=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df h1:shvkWr0NAZkg4nPuE3XrKP0VuBPijjk3TfX6Y6acFNg=

--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -73,7 +73,7 @@ func (builder *containerDTOBuilder) BuildDTOs(pods []*api.Pod) ([]*proto.EntityD
 		podMId := util.PodMetricIdAPI(pod)
 		controllerUID, err := util.GetControllerUID(pod, builder.metricsSink)
 		if err != nil {
-			glog.Errorf("Error getting controller UID from pod %d, %v", pod.Name, err)
+			glog.Errorf("Error getting controller UID from pod %s, %v", pod.Name, err)
 		}
 		for i := range pod.Spec.Containers {
 			container := &(pod.Spec.Containers[i])

--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -71,7 +71,7 @@ func (builder *containerDTOBuilder) BuildDTOs(pods []*api.Pod) ([]*proto.EntityD
 		}
 		podId := string(pod.UID)
 		podMId := util.PodMetricIdAPI(pod)
-
+		controllerUID, _ := util.GetControllerUID(pod, builder.metricsSink)
 		for i := range pod.Spec.Containers {
 			container := &(pod.Spec.Containers[i])
 
@@ -109,6 +109,12 @@ func (builder *containerDTOBuilder) BuildDTOs(pods []*api.Pod) ([]*proto.EntityD
 			//3. set properties
 			properties := builder.getContainerProperties(pod, i)
 			ebuilder.WithProperties(properties)
+
+			//4. To connect Container to ContainerSpec entity, Container is LayeredOver the associated ContainerSpec.
+			// The platform will translate this into the following relation:
+			// ContainerSpec aggregates Containers
+			containerSpecId := util.ContainerSpecIdFunc(controllerUID, container.Name)
+			ebuilder.LayeredOver([]string{containerSpecId})
 
 			//ebuilder.Monitored(util.Monitored(pod))
 			ebuilder.WithPowerState(proto.EntityDTO_POWERED_ON)

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
@@ -61,8 +61,8 @@ func (builder *workloadControllerDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, er
 		// To connect WorkloadController to ContainerSpec entity, WorkloadController consistsOf the associated ContainerSpecs.
 		// The platform will translate this into the following relation:
 		// WorkloadController owns Containers
-		containerSpecs := builder.getContainerSpecs(kubeController)
-		entityDTOBuilder.ConsistsOf(containerSpecs)
+		containerSpecsIds := builder.getContainerSpecIds(kubeController)
+		entityDTOBuilder.ConsistsOf(containerSpecsIds)
 
 		// Create WorkloadControllerData to store controller type data
 		entityDTOBuilder.WorkloadControllerData(builder.createWorkloadControllerData(kubeController))
@@ -130,19 +130,19 @@ func (builder *workloadControllerDTOBuilder) getCommoditiesBought(kubeController
 }
 
 // Get a slice of containerSpec id from the given KubeController entity
-func (builder *workloadControllerDTOBuilder) getContainerSpecs(kubeController *repository.KubeController) []string {
+func (builder *workloadControllerDTOBuilder) getContainerSpecIds(kubeController *repository.KubeController) []string {
 	containerNameSet := make(map[string]struct{})
 	for _, pod := range kubeController.Pods {
 		for _, container := range pod.Spec.Containers {
 			containerNameSet[container.Name] = struct{}{}
 		}
 	}
-	var containerSpecs []string
+	var containerSpecIds []string
 	for containerName := range containerNameSet {
-		containerSpecID := discoveryUtil.ContainerSpecIdFunc(kubeController.UID, containerName)
-		containerSpecs = append(containerSpecs, containerSpecID)
+		containerSpecId := discoveryUtil.ContainerSpecIdFunc(kubeController.UID, containerName)
+		containerSpecIds = append(containerSpecIds, containerSpecId)
 	}
-	return containerSpecs
+	return containerSpecIds
 }
 
 func (builder *workloadControllerDTOBuilder) createWorkloadControllerData(kubeController *repository.KubeController) *proto.EntityDTO_WorkloadControllerData {

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/util"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	api "k8s.io/api/core/v1"
 	"testing"
 )
 
@@ -101,6 +102,39 @@ func TestBuildDTOs(t *testing.T) {
 			assert.EqualValues(t, expectedWorkloadControllerData2, workloadControllerData2)
 		}
 	}
+}
+
+func TestGetContainerSpecs(t *testing.T) {
+	kubeController := repository.NewKubeController("testCluster", "testNamespace", "test",
+		util.KindDeployment, "controllerUID")
+	pod1 := &api.Pod{
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name: "Foo",
+				},
+				{
+					Name: "Bar",
+				},
+			},
+		},
+	}
+	pod2 := &api.Pod{
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name: "Foo",
+				},
+				{
+					Name: "Bar",
+				},
+			},
+		},
+	}
+	kubeController.Pods = append(kubeController.Pods, pod1, pod2)
+	containerSpecs := testWorkloadControllerDTOBuilder.getContainerSpecs(kubeController)
+	expectedContainerSpecs := []string{"controllerUID/Foo", "controllerUID/Bar"}
+	assert.ElementsMatch(t, expectedContainerSpecs, containerSpecs)
 }
 
 func createKubeController(clustername, namespace, name, controllerType, uid string,

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
@@ -132,9 +132,9 @@ func TestGetContainerSpecs(t *testing.T) {
 		},
 	}
 	kubeController.Pods = append(kubeController.Pods, pod1, pod2)
-	containerSpecs := testWorkloadControllerDTOBuilder.getContainerSpecs(kubeController)
-	expectedContainerSpecs := []string{"controllerUID/Foo", "controllerUID/Bar"}
-	assert.ElementsMatch(t, expectedContainerSpecs, containerSpecs)
+	containerSpecIds := testWorkloadControllerDTOBuilder.getContainerSpecIds(kubeController)
+	expectedContainerSpecIds := []string{"controllerUID/Foo", "controllerUID/Bar"}
+	assert.ElementsMatch(t, expectedContainerSpecIds, containerSpecIds)
 }
 
 func createKubeController(clustername, namespace, name, controllerType, uid string,

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/commodity_dto_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/commodity_dto_builder.go
@@ -115,6 +115,14 @@ func (cb *CommodityDTOBuilder) Reservation(reservation float64) *CommodityDTOBui
 	return cb
 }
 
+func (cb *CommodityDTOBuilder) Active(active bool) *CommodityDTOBuilder {
+	if cb.err != nil {
+		return cb
+	}
+	cb.active = &active
+	return cb
+}
+
 func (cb *CommodityDTOBuilder) Resizable(resizable bool) *CommodityDTOBuilder {
 	if cb.err != nil {
 		return cb

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/entity_dto_builder.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/builder/entity_dto_builder.go
@@ -78,6 +78,8 @@ type EntityDTOBuilder struct {
 	notification          []*proto.NotificationDTO
 	keepStandalone        *bool
 	profileID             *string
+	layeredOver           []string
+	consistsOf            []string
 
 	// Action Eligibility related
 	actionEligibility *ActionEligibility
@@ -142,6 +144,8 @@ func (eb *EntityDTOBuilder) Create() (*proto.EntityDTO, error) {
 		ProviderPolicy:        eb.providerPolicy,
 		OwnedBy:               eb.ownedBy,
 		Notification:          eb.notification,
+		LayeredOver:           eb.layeredOver,
+		ConsistsOf:            eb.consistsOf,
 	}
 	if eb.storageData != nil {
 		entityDTO.EntityData = &proto.EntityDTO_StorageData_{eb.storageData}
@@ -342,6 +346,22 @@ func (eb *EntityDTOBuilder) ConsumerPolicy(cp *proto.EntityDTO_ConsumerPolicy) *
 		return eb
 	}
 	eb.consumerPolicy = cp
+	return eb
+}
+
+func (eb *EntityDTOBuilder) LayeredOver(layeredOver []string) *EntityDTOBuilder {
+	if eb.err != nil {
+		return eb
+	}
+	eb.layeredOver = layeredOver
+	return eb
+}
+
+func (eb *EntityDTOBuilder) ConsistsOf(consistsOf []string) *EntityDTOBuilder {
+	if eb.err != nil {
+		return eb
+	}
+	eb.consistsOf = consistsOf
 	return eb
 }
 


### PR DESCRIPTION
**Intent**:
Set up relations between ContainerSpec and Container, and WorkloadController and ContainerSpec in kubeturbo so that corresponding entities can be connected in the supply without commodities relations.

**Background**:
In the new container model, we have created 2 new entity types: WorkloadController and ContainerSpec. We want to have:
```
WorkloadController owns ContainerSpec
ContainerSpec aggregates Container replicas
```
so that the 3 entities can be connected in the supply chain. There are no commodities sold or bought between these entities.

The turbo SDK does not yet provide support for specifying these connections. We can make use of the same mechanism used by Cloud probes:
1. Set up `LayeredOver` and `ConsistsOf` relationships in the discovery
2. In a custom stitching stage, platform will translate these relationships into aggregate and own.

So we'll have
```
CONTAINER entities should be LayeredOver their associated CONTAINER_SPEC
  The platform will translate this into the following relation:
    CONTAINER_SPEC aggregates CONTAINER
WORKLOAD_CONTROLLER entities should have ConsistsOf relations to all their associated CONTAINER_SPEC entities
  The platform will translate this into the following relation:
    CONTROLLER owns CONTAINER_SPEC
```

**Implementation**:
1. The changes here in kubeturbo depend on the changes in turbo-go-sdk in this PR: https://github.com/turbonomic/turbo-go-sdk/pull/90
Update the vendors based on the changes in turbo-go-sdk.
Will update `go.mod` in kubeturbo accordingly after merging the changes in turbo-go-sdk.
2. In `container_dto_builder.go`, add corresponding containerSpecId to the "LayeredOver" of each Container.
3. In `workload_controller_entity_dto_builder.go`, add corresponding containerSpecIds to the "consistsOf" of WorkloadController.

**Unit test**:
Added new unit test `TestGetContainerSpecs` in `workload_controller_entity_dto_builder_test.go`

**Testing Done**:
In discovery dto file,
1) We have the Container with layeredOver (ContainerSpec):
```json
entityDTO {
  entityType: CONTAINER
  id: "6a6acdf9-71bf-11ea-bc07-0050568018c4-0"
  displayName: "default/request-cpu-usage-node-1-7f58c7b6d4-q8x5v/request-cpu-usage-node-1-1"
  ...
  layeredOver: "862d15f3-07bd-11ea-878a-005056803aed/request-cpu-usage-node-1-1"
```
2) The corresponding ContainerSpec:
```json
entityDTO {
  entityType: CONTAINER_SPEC
  id: "862d15f3-07bd-11ea-878a-005056803aed/request-cpu-usage-node-1-1"
  displayName: "request-cpu-usage-node-1-1"
  monitored: false
  actionEligibility {
  }
}
```
3) Then we have the corresponding WorkloadController with "consistsOf" of this ContainerSpec entity: 
```json
entityDTO {
  entityType: WORKLOAD_CONTROLLER
  id: "862d15f3-07bd-11ea-878a-005056803aed"
  displayName: "request-cpu-usage-node-1"
  ...
  consistsOf: "862d15f3-07bd-11ea-878a-005056803aed/request-cpu-usage-node-1-1"
```
In the supply chain, Containers connect to ContainerSpecs and ContainerSpecs connect to WorkloadController.
<img width="318" alt="Screen Shot 2020-04-17 at 16 57 22" src="https://user-images.githubusercontent.com/23689754/79615490-eca4d600-80d0-11ea-934e-3bfb8110a722.png">

(The changes to have Pod consume from WorkloadController will be posted in a following PR)