### PR TITLE
Node cpu frequency getter via an ephemeral pod

### DIFF
--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -2,8 +2,9 @@ package executor
 
 import (
 	"fmt"
-	"k8s.io/client-go/dynamic"
 	"math"
+
+	"k8s.io/client-go/dynamic"
 
 	"github.com/golang/glog"
 
@@ -131,10 +132,10 @@ func updateResourceAmount(podSpec *k8sapi.PodSpec, spec *containerResizeSpec) (b
 // Generate a resource.Quantity for CPU.
 // it will convert CPU unit from MHz to CPU.core time in milliSeconds
 // @newValue is from OpsMgr, in MHz
-// @cpuFrequency is from kubeletClient, in KHz
-func genCPUQuantity(newValue float64, cpuFrequency uint64) (resource.Quantity, error) {
-	tmp := newValue * 1000 * 1000 //to KHz and to milliSeconds
-	tmp = tmp / float64(cpuFrequency)
+// @nodeCpuFrequency is from kubeletClient, in MHz
+func genCPUQuantity(newValue float64, nodeCpuFrequency float64) (resource.Quantity, error) {
+	tmp := newValue * 1000 // to milliSeconds
+	tmp = tmp / nodeCpuFrequency
 	cpuTime := int(math.Ceil(tmp))
 	if cpuTime < 1 {
 		cpuTime = 1

--- a/pkg/action/executor/resize_container_util_test.go
+++ b/pkg/action/executor/resize_container_util_test.go
@@ -2,14 +2,15 @@ package executor
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/golang/glog"
 	k8sapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"testing"
 )
 
 func TestGenCPUQuantity(t *testing.T) {
-	nodeCPUfreq := uint64(2600000) //khz
+	nodeCPUfreq := float64(2600) //MHz
 	reqArray := []int{2600, 1300, 0, 5200}
 	expectArray := []int{1000, 500, 1, 2000}
 

--- a/pkg/discovery/monitoring/kubelet/config.go
+++ b/pkg/discovery/monitoring/kubelet/config.go
@@ -3,10 +3,14 @@ package kubelet
 import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
+	"k8s.io/client-go/kubernetes"
 )
 
 type KubeletMonitorConfig struct {
 	kubeletClient *kubeclient.KubeletClient
+	// k8s client used to fall back on, in case
+	// some kubelet apis are not available.
+	kubeClient *kubernetes.Clientset
 }
 
 // Implement MonitoringWorkerConfig interface.
@@ -17,8 +21,9 @@ func (c KubeletMonitorConfig) GetMonitoringSource() types.MonitoringSource {
 	return types.KubeletSource
 }
 
-func NewKubeletMonitorConfig(kclient *kubeclient.KubeletClient) *KubeletMonitorConfig {
+func NewKubeletMonitorConfig(kubeletClient *kubeclient.KubeletClient, kubeClient *kubernetes.Clientset) *KubeletMonitorConfig {
 	return &KubeletMonitorConfig{
-		kubeletClient: kclient,
+		kubeletClient: kubeletClient,
+		kubeClient:    kubeClient,
 	}
 }

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -11,8 +11,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
-
-	cadvisorapi "github.com/google/cadvisor/info/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
@@ -24,6 +23,9 @@ type KubeletMonitor struct {
 
 	kubeletClient *kubeclient.KubeletClient
 
+	// Backup k8s client for node cpufrequency
+	kubeClient *kubernetes.Clientset
+
 	metricSink *metrics.EntityMetricSink
 
 	stopCh chan struct{}
@@ -34,6 +36,7 @@ type KubeletMonitor struct {
 func NewKubeletMonitor(config *KubeletMonitorConfig) (*KubeletMonitor, error) {
 	return &KubeletMonitor{
 		kubeletClient: config.kubeletClient,
+		kubeClient:    config.kubeClient,
 		metricSink:    metrics.NewEntityMetricSink(),
 		stopCh:        make(chan struct{}, 1),
 	}, nil
@@ -98,21 +101,19 @@ func (m *KubeletMonitor) RetrieveResourceStat() error {
 // Retrieve resource metrics for the given node.
 func (m *KubeletMonitor) scrapeKubelet(node *api.Node) {
 	kc := m.kubeletClient
+
+	nodefreq, err := kc.GetNodeCpuFrequency(node)
+	if err != nil {
+		glog.Errorf("Failed to get resource metrics (cpufreq) from %s: %s", node.Name, err)
+		return
+	}
+	m.parseNodeCpuFreq(node, nodefreq)
+
 	ip, err := util.GetNodeIPForMonitor(node, types.KubeletSource)
 	if err != nil {
-		glog.Errorf("Failed to get resource metrics from %s: %s", node.Name, err)
+		glog.Errorf("Failed to get resource metrics summary from %s: %s", node.Name, err)
 		return
 	}
-
-	// get machine information
-	machineInfo, err := kc.GetMachineInfo(ip)
-	if err != nil {
-		glog.Errorf("Failed to get machine information from %s: %s", node.Name, err)
-		return
-	}
-	glog.V(4).Infof("Machine info of %s is %++v", node.Name, machineInfo)
-	m.parseNodeInfo(node, machineInfo)
-
 	// get summary information about the given node and the pods running on it.
 	summary, err := kc.GetSummary(ip)
 	if err != nil {
@@ -131,8 +132,7 @@ func (m *KubeletMonitor) scrapeKubelet(node *api.Node) {
 	glog.V(4).Infof("Finished scrape node %s.", node.Name)
 }
 
-func (m *KubeletMonitor) parseNodeInfo(node *api.Node, machineInfo *cadvisorapi.MachineInfo) {
-	cpuFrequencyMHz := util.MetricKiloToMega(float64(machineInfo.CpuFrequency))
+func (m *KubeletMonitor) parseNodeCpuFreq(node *api.Node, cpuFrequencyMHz float64) {
 	glog.V(4).Infof("node-%s cpuFrequency = %.2fMHz", node.Name, cpuFrequencyMHz)
 	cpuFrequencyMetric := metrics.NewEntityStateMetric(metrics.NodeType, util.NodeKeyFunc(node), metrics.CpuFrequency, cpuFrequencyMHz)
 	m.metricSink.AddNewMetricEntries(cpuFrequencyMetric)

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -7,7 +7,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
 	v1 "k8s.io/api/core/v1"
 )
@@ -72,12 +71,12 @@ func (p *ClusterProcessor) checkNodesWorker(work chan *v1.Node, done chan bool, 
 			glog.V(4).Infof("Node verifier worker %d finished. No more work.", index)
 			return
 		}
-		nodeCpuFrequency, err := checkNode(node, p.nodeScrapper)
+		err := checkNode(node, p.nodeScrapper)
 		if err != nil {
 			glog.Errorf("Failed to verify node %s: %v.", node.Name, err)
 		} else {
 			// Log the success and send the response to everybody
-			glog.V(2).Infof("Successfully verified node %s [cpu:%v MHz].", node.Name, nodeCpuFrequency)
+			glog.V(2).Infof("Successfully verified node %s.", node.Name)
 			done <- true
 			// Force return here. We are done and notified everybody.
 			glog.V(4).Infof("Node verifier worker %d finished. Successful verification.", index)
@@ -141,14 +140,14 @@ func (p *ClusterProcessor) connectToNodes() (bool, error) {
 	return false, fmt.Errorf("timeout when connecting to nodes")
 }
 
-// Checks the node connectivity be obtaining its CPU frequency
-func checkNode(node *v1.Node, kc kubeclient.KubeHttpClientInterface) (float64, error) {
+// Checks the node connectivity be querying the kubelet summary endpoint
+func checkNode(node *v1.Node, kc kubeclient.KubeHttpClientInterface) error {
 	ip := repository.ParseNodeIP(node, v1.NodeInternalIP)
-	cpuFreq, err := kc.GetMachineCpuFrequency(ip)
+	_, err := kc.GetSummary(ip)
 	if err != nil {
-		return 0.0, err
+		return err
 	}
-	return util.MetricKiloToMega(float64(cpuFreq)), nil
+	return nil
 }
 
 // Query the Kubernetes API Server to get the cluster nodes and namespaces and set in the cluster object

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -33,10 +33,10 @@ const (
 	TurboControllableAnnotation string = "kubeturbo.io/controllable"
 )
 
-type podEvent struct {
-	eType   string
-	reason  string
-	message string
+type PodEvent struct {
+	EType   string
+	Reason  string
+	Message string
 }
 
 // IsControllableFromAnnotation checks whether a Kubernetes object is controllable or not by its annotation.
@@ -321,12 +321,12 @@ func WaitForPodReady(client *client.Clientset, namespace, podName, nodeName stri
 	})
 	// log a list of unique events that belong to the pod
 	// warning events are logged in Error level, other events are logged in Info level
-	podEvents := getPodEvents(client, namespace, podName)
+	podEvents := GetPodEvents(client, namespace, podName)
 	for _, pe := range podEvents {
-		if pe.eType == api.EventTypeWarning {
-			glog.Errorf("Pod %s: %s", podName, pe.message)
+		if pe.EType == api.EventTypeWarning {
+			glog.Errorf("Pod %s: %s", podName, pe.Message)
 		} else {
-			glog.V(2).Infof("Pod %s: %s", podName, pe.message)
+			glog.V(2).Infof("Pod %s: %s", podName, pe.Message)
 		}
 	}
 	return err
@@ -402,8 +402,8 @@ func getPodWarnings(pod *api.Pod, podName string) (warnings []string) {
 
 // getPodEvents gets a list of unique events that belong to the given pod
 // These events can be very long, and will only be written to the log file
-func getPodEvents(kubeClient *client.Clientset, namespace, name string) (podEvents []podEvent) {
-	podEvents = []podEvent{}
+func GetPodEvents(kubeClient *client.Clientset, namespace, name string) (podEvents []PodEvent) {
+	podEvents = []PodEvent{}
 	// Get the pod
 	pod, err := kubeClient.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
@@ -423,10 +423,10 @@ func getPodEvents(kubeClient *client.Clientset, namespace, name string) (podEven
 			continue
 		}
 		visited[item.Reason] = true
-		podEvents = append(podEvents, podEvent{
-			eType:   item.Type,
-			reason:  item.Reason,
-			message: item.Message,
+		podEvents = append(podEvents, PodEvent{
+			EType:   item.Type,
+			Reason:  item.Reason,
+			Message: item.Message,
 		})
 	}
 	return

--- a/pkg/discovery/worker/k8s_discovery_worker_test.go
+++ b/pkg/discovery/worker/k8s_discovery_worker_test.go
@@ -1,15 +1,16 @@
 package worker
 
 import (
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
-	"testing"
-	"time"
 )
 
 func TestCalTimeOut(t *testing.T) {
@@ -46,7 +47,7 @@ func TestCalTimeOut(t *testing.T) {
 }
 
 func TestBuildDTOsWithMissingMetrics(t *testing.T) {
-	workerConfig := NewK8sDiscoveryWorkerConfig("UUID").WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil))
+	workerConfig := NewK8sDiscoveryWorkerConfig("UUID").WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil, nil))
 	worker, err := NewK8sDiscoveryWorker(workerConfig, "wid-1")
 	if err != nil {
 		t.Errorf("Error while creating discovery worker: %v", err)

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -122,7 +122,7 @@ func readK8sTAPServiceSpec(path string) (*K8sTAPServiceSpec, error) {
 
 func createProbeConfigOrDie(c *Config) *configs.ProbeConfig {
 	// Create Kubelet monitoring
-	kubeletMonitoringConfig := kubelet.NewKubeletMonitorConfig(c.KubeletClient)
+	kubeletMonitoringConfig := kubelet.NewKubeletMonitorConfig(c.KubeletClient, c.KubeClient)
 
 	// Create cluster monitoring
 	masterMonitoringConfig := master.NewClusterMonitorConfig(c.KubeClient, c.DynamicClient)

--- a/pkg/kubeclient/cpufrequency.go
+++ b/pkg/kubeclient/cpufrequency.go
@@ -1,0 +1,211 @@
+package kubeclient
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/golang/glog"
+)
+
+const (
+	kubeturboNamespace = "KUBETURBO_NAMESPACE"
+	DefaultCpuFreq     = float64(2000) //MHz
+)
+
+type NodeCpuFrequencyGetter struct {
+	kubeClient   *kubernetes.Clientset
+	node         *corev1.Node
+	busyboxImage string
+}
+
+func NewNodeCpuFrequencyGetter(kubeClient *kubernetes.Clientset, busyboxImage string) *NodeCpuFrequencyGetter {
+	return &NodeCpuFrequencyGetter{
+		kubeClient:   kubeClient,
+		busyboxImage: busyboxImage,
+	}
+}
+
+func (n *NodeCpuFrequencyGetter) GetFrequency(nodeName string) (float64, error) {
+	glog.V(4).Infof("Start query node frequency via pod for %s.", nodeName)
+
+	// TODO: See if retries are needed
+	namespace := os.Getenv(kubeturboNamespace)
+	job, err := n.createJob(nodeName, namespace)
+	if err != nil {
+		return 0, err
+	}
+
+	jobName := job.Name
+	defer n.waitForJobCleanup(jobName, namespace)
+
+	err = n.waitForJob(jobName, namespace)
+	if err != nil {
+		return 0, fmt.Errorf("wait for job failed, node: %s : %v", nodeName, err)
+	}
+
+	pod, err := n.getJobsPod(jobName, namespace)
+	if err != nil {
+		return 0, fmt.Errorf("get cpufreq job pod failed for node: %s", nodeName)
+	}
+
+	return n.getCpufreqFromPodLog(pod)
+
+}
+
+func (n *NodeCpuFrequencyGetter) getCpufreqFromPodLog(pod *corev1.Pod) (float64, error) {
+	req := n.kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+	logs, err := req.Stream()
+	if err != nil {
+		return 0, fmt.Errorf("error in opening stream")
+	}
+	defer logs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, logs)
+	if err != nil {
+		return 0, fmt.Errorf("error in copy pod logs")
+	}
+	line := buf.String()
+
+	str := strings.Split(line, ":")
+	if len(str) != 2 {
+		return 0, fmt.Errorf("invalid cpufreq logs from pod")
+	}
+
+	cpufreq, err := strconv.ParseFloat(strings.TrimSpace(str[1]), 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return cpufreq, nil
+
+}
+
+func (n *NodeCpuFrequencyGetter) waitForJob(jobName, namespace string) error {
+	err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
+		j, err := n.kubeClient.BatchV1().Jobs(namespace).Get(jobName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if j.Status.Succeeded == 1 {
+			return true, nil
+		}
+		if j.Status.Failed == 1 {
+			return false, fmt.Errorf("cpufreq job failed for job: %s/%s", namespace, jobName)
+		}
+
+		// Retry
+		return false, nil
+	})
+
+	if err == wait.ErrWaitTimeout {
+		// The job did not succeed/fail for 20 seconds, check pod errors if any.
+		pod, err := n.getJobsPod(jobName, namespace)
+		if err != nil {
+			return err
+		}
+		n.LogPodErrorEvents(jobName, pod)
+	}
+
+	return err
+}
+
+func (n *NodeCpuFrequencyGetter) LogPodErrorEvents(jobName string, pod *corev1.Pod) {
+	// log a list of unique error events that belong to this pod
+	podName := pod.Name
+	podNamespace := pod.Namespace
+	glog.Errorf("Error events on cpufreq pod: %s/%s", podNamespace, podName)
+	podEvents := util.GetPodEvents(n.kubeClient, podNamespace, podName)
+	for _, pe := range podEvents {
+		if pe.EType == corev1.EventTypeWarning {
+			glog.Errorf("%s/%s: %s", podNamespace, podName, pe.Message)
+		}
+	}
+}
+
+func (n *NodeCpuFrequencyGetter) waitForJobCleanup(jobName, namespace string) error {
+	return wait.PollImmediate(1*time.Second, 20*time.Second, func() (bool, error) {
+		deletePropagation := metav1.DeletePropagationBackground
+		deleteOptions := &metav1.DeleteOptions{PropagationPolicy: &deletePropagation}
+		err := n.kubeClient.BatchV1().Jobs(namespace).Delete(jobName, deleteOptions)
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			glog.Warning(fmt.Printf("Error deleting cpufreq job: %s/%s: %v.", namespace, jobName, err))
+		}
+
+		// Retry
+		return false, nil
+	})
+}
+
+func (n *NodeCpuFrequencyGetter) getJobsPod(podNamePrefix, namespace string) (*corev1.Pod, error) {
+	var pod *corev1.Pod
+	pods, err := n.kubeClient.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range pods.Items {
+		// A better option would be to check parent per pod, but this is faster
+		if strings.HasPrefix(p.Name, podNamePrefix) {
+			pod = &p
+			break
+		}
+	}
+	if pod == nil {
+		return nil, fmt.Errorf("find pod for job: %s/%s failed", namespace, podNamePrefix)
+	}
+
+	return pod, nil
+}
+
+func (n *NodeCpuFrequencyGetter) createJob(nodeName, namespace string) (*batchv1.Job, error) {
+	job, err := n.kubeClient.BatchV1().Jobs(namespace).Create(getCpuFreqJobDefinition(nodeName, n.busyboxImage))
+	if err != nil {
+		return nil, fmt.Errorf("error creating cpufreq job for node: %s : %v", nodeName, err)
+	}
+
+	return job, err
+}
+
+func getCpuFreqJobDefinition(nodeName, busyboxImage string) *batchv1.Job {
+	// There are no retries if the job fails it fails
+	backoffLimit := int32(0)
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubeturbo-cpufreq-" + strconv.FormatInt(time.Now().UnixNano(), 32),
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					NodeName:      nodeName,
+					RestartPolicy: "Never",
+					Containers: []corev1.Container{
+						{
+							Name:    "cpufreq",
+							Image:   busyboxImage,
+							Command: []string{`/bin/sh`},
+							Args:    []string{"-c", `cat /proc/cpuinfo | grep -m 1 'cpu MHz'`},
+						},
+					},
+				},
+			},
+			BackoffLimit: &backoffLimit,
+		},
+	}
+}

--- a/pkg/kubeclient/kubelet_client.go
+++ b/pkg/kubeclient/kubelet_client.go
@@ -3,19 +3,23 @@ package kubeclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
-	cadvisorapi "github.com/google/cadvisor/info/v1"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"io/ioutil"
-	"k8s.io/api/core/v1"
-	netutil "k8s.io/apimachinery/pkg/util/net"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/transport"
-	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/golang/glog"
+	cadvisorapi "github.com/google/cadvisor/info/v1"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	v1 "k8s.io/api/core/v1"
+	netutil "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
 
 const (
@@ -33,15 +37,16 @@ type KubeHttpClientInterface interface {
 	ExecuteRequestAndGetValue(host string, endpoint string, value interface{}) error
 	GetSummary(host string) (*stats.Summary, error)
 	GetMachineInfo(host string) (*cadvisorapi.MachineInfo, error)
-	GetMachineCpuFrequency(host string) (uint64, error)
+	GetNodeCpuFrequency(node *v1.Node) (float64, error)
 }
 
 // Cache structure.
 // TODO(MB): Make sure the nodes that are no longer discovered are being removed from the cache!
 type CacheEntry struct {
 	statsSummary *stats.Summary
-	machineInfo  *cadvisorapi.MachineInfo
-	used         bool
+	// nodes cpu frequency in MHz as expected by server
+	nodeCpuFreq *float64
+	used        bool
 }
 
 // Cleanup the cache.
@@ -75,11 +80,13 @@ func (client *KubeletClient) CleanupCache(nodes []*v1.Node) int {
 // Since http.Client is thread safe (https://golang.org/src/net/http/client.go)
 // KubeletClient is also thread-safe if concurrent goroutines won't change the fields.
 type KubeletClient struct {
-	client    *http.Client
-	scheme    string
-	port      int
-	cache     map[string]*CacheEntry
-	cacheLock sync.Mutex
+	client              *http.Client
+	scheme              string
+	port                int
+	cache               map[string]*CacheEntry
+	cacheLock           sync.Mutex
+	fallbkCpuFreqGetter *NodeCpuFrequencyGetter
+	defaultCpuFreq      float64
 }
 
 func (client *KubeletClient) ExecuteRequestAndGetValue(host string, endpoint string, value interface{}) error {
@@ -137,6 +144,10 @@ func (client *KubeletClient) GetSummary(host string) (*stats.Summary, error) {
 				return nil, err
 			}
 			glog.V(2).Infof("unable to retrieve machine[%s] summary: %v. Using cached value", host, err)
+			// TODO(irfanurrehman): Improve the node check [fn checknode()].
+			// This looks flawed. The same is also used as checknode;
+			// if ExecuteRequestAndGetValue() returns error, checknode should get error
+			// rather then a value from cache.
 			return entry.statsSummary, nil
 		} else {
 			glog.Errorf("failed to get machine[%s] summary: %v. No cache available", host, err)
@@ -150,7 +161,6 @@ func (client *KubeletClient) GetSummary(host string) (*stats.Summary, error) {
 	} else {
 		entry := &CacheEntry{
 			statsSummary: summary,
-			machineInfo:  nil,
 			used:         false,
 		}
 		client.cache[host] = entry
@@ -158,51 +168,82 @@ func (client *KubeletClient) GetSummary(host string) (*stats.Summary, error) {
 	return summary, err
 }
 
-func (client *KubeletClient) GetMachineInfo(host string) (*cadvisorapi.MachineInfo, error) {
-	// Get the data
-	var minfo cadvisorapi.MachineInfo
-	err := client.ExecuteRequestAndGetValue(host, specPath, &minfo)
-	// Lock and check cache
-	client.cacheLock.Lock()
-	defer client.cacheLock.Unlock()
-	entry, entryPresent := client.cache[host]
+// get node single-core Frequency, in MHz
+func (client *KubeletClient) GetNodeCpuFrequency(node *v1.Node) (float64, error) {
+	ip, err := util.GetNodeIPForMonitor(node, types.KubeletSource)
 	if err != nil {
-		if entryPresent {
-			entry.used = true
-			if entry.machineInfo == nil {
-				glog.V(2).Infof("unable to retrieve machine[%s] machine info: %v. The cached value unavailable", host, err)
-				return nil, err
-			}
-			glog.V(2).Infof("unable to retrieve machine[%s] machine info: %v. Using cached value", host, err)
-			return entry.machineInfo, nil
-		} else {
-			glog.Errorf("failed to get machine[%s] machine info: %v. No cache available", host, err)
-			return &minfo, err
+		glog.Errorf("Failed to IP for node %s: %s", node.Name, err)
+		return 0, err
+	}
+
+	// Get value from cache if exists
+	client.cacheLock.Lock()
+	entry, entryPresent := client.cache[ip]
+	if entryPresent {
+		if entry.nodeCpuFreq != nil {
+			nodeFreq := *entry.nodeCpuFreq
+			client.cacheLock.Unlock()
+			return nodeFreq, nil
 		}
 	}
-	// Fill in the cache
+	client.cacheLock.Unlock()
+
+	// We could not get a valid cpu frequency from cache, discover it.
+	var nodeFreq float64
+	minfo, err := client.GetMachineInfo(ip)
+	freqDiscovered := true
+	if err != nil {
+		glog.Errorf("Failed to get machine[%s] cpu.frequency from kubelet: %v. Will try pod based getter.", node.Name, err)
+		nodeIsActive := util.NodeIsReady(node) && util.NodeIsSchedulable(node)
+		if nodeIsActive {
+			nodeFreq, err = client.fallbkCpuFreqGetter.GetFrequency(node.Name)
+			if err != nil {
+				glog.Errorf("Failed to get cpufreq from getter %s: %s. Default value will be used.", node.Name, err)
+				freqDiscovered = false
+			}
+		} else {
+			freqDiscovered = false
+		}
+	} else {
+		nodeFreq = util.MetricKiloToMega(float64(minfo.CpuFrequency))
+	}
+
+	if !freqDiscovered {
+		// We probably could not discover the cpufreq by any means and default
+		// value is what we need to stick to. However, we might be able to discover
+		// a valid one in the next discovery cycle.
+
+		return client.defaultCpuFreq, nil
+	}
+
+	// We optimistically set a cpu frequency of last discovered node as default.
+	// Clusters more often then not have similar nodes.
+	client.defaultCpuFreq = nodeFreq
+
+	// Update cache
+	client.cacheLock.Lock()
+	defer client.cacheLock.Unlock()
 	if entryPresent {
-		entry.used = false
-		entry.machineInfo = &minfo
+		client.cache[ip].nodeCpuFreq = &nodeFreq
 	} else {
 		entry := &CacheEntry{
 			statsSummary: nil,
-			machineInfo:  &minfo,
-			used:         false,
+			nodeCpuFreq:  &nodeFreq,
 		}
-		client.cache[host] = entry
+		client.cache[ip] = entry
 	}
-	return &minfo, err
+
+	return nodeFreq, nil
 }
 
-// get machine single-core Frequency, in Khz
-func (client *KubeletClient) GetMachineCpuFrequency(host string) (uint64, error) {
-	minfo, err := client.GetMachineInfo(host)
+func (client *KubeletClient) GetMachineInfo(ip string) (*cadvisorapi.MachineInfo, error) {
+	var minfo cadvisorapi.MachineInfo
+	err := client.ExecuteRequestAndGetValue(ip, specPath, &minfo)
 	if err != nil {
-		glog.Errorf("failed to get machine[%s] cpu.frequency: %v", host, err)
-		return 0, err
+		return nil, err
 	}
-	return minfo.CpuFrequency, nil
+
+	return &minfo, nil
 }
 
 func (client *KubeletClient) HasCacheBeenUsed(host string) bool {
@@ -256,7 +297,7 @@ func (kc *KubeletConfig) Timeout(timeout int) *KubeletConfig {
 	return kc
 }
 
-func (kc *KubeletConfig) Create() (*KubeletClient, error) {
+func (kc *KubeletConfig) Create(fallbackClient *kubernetes.Clientset, busyboxImage string) (*KubeletClient, error) {
 	// 1. http transport
 	transport, err := makeTransport(kc.kubeConfig, kc.enableHttps, kc.tlsTimeOut, kc.forceSelfSignedCerts)
 	if err != nil {
@@ -275,10 +316,12 @@ func (kc *KubeletConfig) Create() (*KubeletClient, error) {
 
 	// 3. create a KubeletClient
 	return &KubeletClient{
-		client: c,
-		scheme: scheme,
-		port:   kc.port,
-		cache:  make(map[string]*CacheEntry),
+		client:              c,
+		scheme:              scheme,
+		port:                kc.port,
+		cache:               make(map[string]*CacheEntry),
+		fallbkCpuFreqGetter: NewNodeCpuFrequencyGetter(fallbackClient, busyboxImage),
+		defaultCpuFreq:      DefaultCpuFreq,
 	}, nil
 }
 

--- a/pkg/kubeclient/kubelet_client_test.go
+++ b/pkg/kubeclient/kubelet_client_test.go
@@ -1,10 +1,11 @@
 package kubeclient
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
-	"testing"
 )
 
 func constuctNodes(ip string) []*v1.Node {
@@ -67,7 +68,7 @@ func TestKubeletClientCacheNil(t *testing.T) {
 	kubeConf := &rest.Config{}
 	conf := NewKubeletConfig(kubeConf)
 
-	kc, _ := conf.Create()
+	kc, _ := conf.Create(nil, "busybox")
 	entry := &CacheEntry{}
 	kc.cache["host_1"] = entry
 	assert.False(t, kc.HasCacheBeenUsed("host_1"))


### PR DESCRIPTION
This code needs some cleanup and additional handling for `GetMachineCpuFrequency()`used by `ContainerResizer` but it gives the clear idea of what its trying to achieve.
It works on 1.18.