### PR TITLE
Update commodities bought and sold by containers and pods in the new container model

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -23,7 +23,7 @@ func Test_podEntityDTOBuilder_getPodCommoditiesBought_Error(t *testing.T) {
 }
 
 func Test_podEntityDTOBuilder_getPodCommoditiesBoughtFromQuota_Error(t *testing.T) {
-	if _, err := builder.getPodCommoditiesBoughtFromNamespace("quota1", &api.Pod{}, 100.0); err == nil {
+	if _, err := builder.getQuotaCommoditiesBought("quota1", &api.Pod{}, 100.0); err == nil {
 		t.Errorf("Error thrown expected")
 	}
 }

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -218,9 +218,13 @@ func (m *KubeletMonitor) parseContainerStats(pod *stats.PodStats) (float64, floa
 
 		//1. container Used
 		containerMId := util.ContainerMetricId(podMId, container.Name)
+		// Generate used metrics for VCPU and VMemory commodity
 		m.genUsedMetrics(metrics.ContainerType, containerMId, cpuUsed, memUsed)
+		// Generate used metrics for VCPURequest and VMemRequest commodity
+		m.genRequestUsedMetrics(metrics.ContainerType, containerMId, cpuUsed, memUsed)
 
-		glog.V(4).Infof("container[%s-%s] cpu/memory usage:%.3f, %.3f", pod.PodRef.Name, container.Name, cpuUsed, memUsed)
+		glog.V(4).Infof("container[%s-%s] cpu/memory/cpuRequest/memoryRequest usage:%.3f, %.3f, %.3f, %.3f",
+			pod.PodRef.Name, container.Name, cpuUsed, memUsed, cpuUsed, memUsed)
 
 		//2. app Used
 		appMId := util.ApplicationMetricId(containerMId)
@@ -234,6 +238,13 @@ func (m *KubeletMonitor) genUsedMetrics(etype metrics.DiscoveredEntityType, key 
 	cpuMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPU, metrics.Used, cpu)
 	memMetric := metrics.NewEntityResourceMetric(etype, key, metrics.Memory, metrics.Used, memory)
 	m.metricSink.AddNewMetricEntries(cpuMetric, memMetric)
+}
+
+// genRequestUsedMetrics generates used metrics for VCPURequest and VMemRequest commodity
+func (m *KubeletMonitor) genRequestUsedMetrics(etype metrics.DiscoveredEntityType, key string, cpu, memory float64) {
+	cpuRequestMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPURequest, metrics.Used, cpu)
+	memRequestMetric := metrics.NewEntityResourceMetric(etype, key, metrics.MemoryRequest, metrics.Used, memory)
+	m.metricSink.AddNewMetricEntries(cpuRequestMetric, memRequestMetric)
 }
 
 func (m *KubeletMonitor) genNumConsumersUsedMetrics(etype metrics.DiscoveredEntityType, key string) {

--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -25,20 +25,26 @@ var expectedMetrics = map[string]float64{
 	// Pod metrics
 	"Pod-default/mypod-CPU-Capacity":       2,
 	"Pod-default/mypod-Memory-Capacity":    8.388608e+06,
-	"Pod-default/mypod-CPU-Reservation":    0.26,
-	"Pod-default/mypod-Memory-Reservation": 262144,
 	"Pod-default/mypod-CPURequest-Used":    0.26,
 	"Pod-default/mypod-MemoryRequest-Used": 262144,
 
 	// Container metrics
-	"Container-default/mypod/twitter-cass-tweet-CPU-Capacity":       0.25,
-	"Container-default/mypod/twitter-cass-tweet-Memory-Capacity":    262144,
-	"Container-default/mypod/twitter-cass-tweet-CPU-Reservation":    0.25,
-	"Container-default/mypod/twitter-cass-tweet-Memory-Reservation": 262144,
-	"Container-default/mypod/istio-proxy-CPU-Capacity":              2,
-	"Container-default/mypod/istio-proxy-Memory-Capacity":           8.388608e+06,
-	"Container-default/mypod/istio-proxy-CPU-Reservation":           0.01,
-	"Container-default/mypod/istio-proxy-Memory-Reservation":        0,
+	"Container-default/mypod/twitter-cass-tweet-CPU-Capacity":            0.25,
+	"Container-default/mypod/twitter-cass-tweet-Memory-Capacity":         262144,
+	"Container-default/mypod/twitter-cass-tweet-CPURequest-Capacity":     0.25,
+	"Container-default/mypod/twitter-cass-tweet-MemoryRequest-Capacity":  262144,
+	"Container-default/mypod/istio-proxy-CPU-Capacity":                   2,
+	"Container-default/mypod/istio-proxy-Memory-Capacity":                8.388608e+06,
+	"Container-default/mypod/istio-proxy-CPURequest-Capacity":            0.01,
+	"Container-default/mypod/istio-proxy-MemoryRequest-Capacity":         0,
+	"Container-default/mypod/twitter-cass-tweet-CPULimitQuota-Used":      0.25,
+	"Container-default/mypod/twitter-cass-tweet-MemoryLimitQuota-Used":   262144,
+	"Container-default/mypod/twitter-cass-tweet-CPURequestQuota-Used":    0.25,
+	"Container-default/mypod/twitter-cass-tweet-MemoryRequestQuota-Used": 262144,
+	"Container-default/mypod/istio-proxy-CPULimitQuota-Used":             2,
+	"Container-default/mypod/istio-proxy-CPURequestQuota-Used":           0.01,
+	"Container-default/mypod/istio-proxy-MemoryLimitQuota-Used":          8.388608e+06,
+	"Container-default/mypod/istio-proxy-MemoryRequestQuota-Used":        0,
 }
 
 func genCPUQuantity(cores float32) resource.Quantity {
@@ -152,6 +158,6 @@ func TestGenNodeResourceMetrics(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to validate metric: %v", err)
 		}
-		assert.EqualValues(t, value, metric.GetValue())
+		assert.EqualValues(t, value, metric.GetValue(), fmt.Sprintf("Metric values are not equal for %s", name))
 	}
 }

--- a/pkg/discovery/repository/entity_metrics.go
+++ b/pkg/discovery/repository/entity_metrics.go
@@ -10,22 +10,18 @@ type PodMetrics struct {
 	Namespace string
 	NodeName  string
 	PodKey    string
-	// Compute resource used and capacity
-	ComputeUsed     map[metrics.ResourceType]float64
-	ComputeCapacity map[metrics.ResourceType]float64
-	// Amount of used quota resources bought from its resource quota provider
-	QuotaUsed map[metrics.ResourceType]float64
-	// TODO Yue add QuotaCapacity (map[metrics.ResourceType]float64) to store quota resource capacity for pod
+	// Quota resources used and capacity
+	QuotaUsed     map[metrics.ResourceType]float64
+	QuotaCapacity map[metrics.ResourceType]float64
 }
 
 func NewPodMetrics(podName, namespace, nodeName string) *PodMetrics {
 	return &PodMetrics{
-		PodName:         podName,
-		Namespace:       namespace,
-		NodeName:        nodeName,
-		QuotaUsed:       make(map[metrics.ResourceType]float64),
-		ComputeUsed:     make(map[metrics.ResourceType]float64),
-		ComputeCapacity: make(map[metrics.ResourceType]float64),
+		PodName:       podName,
+		Namespace:     namespace,
+		NodeName:      nodeName,
+		QuotaUsed:     make(map[metrics.ResourceType]float64),
+		QuotaCapacity: make(map[metrics.ResourceType]float64),
 	}
 }
 

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -274,14 +274,13 @@ func (worker *k8sDiscoveryWorker) addPodAllocationMetrics(podMetricsCollection P
 						allocationUsedMetric.GetUID(), podMetrics.PodName, usedValue)
 				}
 
-				// TODO Yue: update logic here to add new metrics for quota capacity instead of updating compute capacity
-				for resourceType, capValue := range podMetrics.ComputeCapacity {
-					computeCapMetric := metrics.NewEntityResourceMetric(etype,
+				for resourceType, capValue := range podMetrics.QuotaCapacity {
+					allocationCapMetric := metrics.NewEntityResourceMetric(etype,
 						podKey, resourceType,
 						metrics.Capacity, capValue)
-					worker.sink.AddNewMetricEntries(computeCapMetric)
-					glog.V(4).Infof("Updated %s capacity for pod %s: %f.",
-						computeCapMetric.GetUID(), podMetrics.PodName, capValue)
+					worker.sink.AddNewMetricEntries(allocationCapMetric)
+					glog.V(4).Infof("Created %s capacity for pod %s: %f.",
+						allocationCapMetric.GetUID(), podMetrics.PodName, capValue)
 				}
 			}
 		}

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -246,6 +246,12 @@ func (f *SupplyChainFactory) buildPodSupplyBuilder() (*proto.TemplateDTO, error)
 	podSupplyChainNodeBuilder = podSupplyChainNodeBuilder.
 		Sells(vCpuTemplateComm). //sells to containers
 		Sells(vMemTemplateComm).
+		Sells(vCpuRequestTemplateComm).
+		Sells(vMemRequestTemplateComm).
+		Sells(cpuLimitQuotaTemplateCommWithKey).
+		Sells(memLimitQuotaTemplateCommWithKey).
+		Sells(cpuRequestQuotaTemplateCommWithKey).
+		Sells(memRequestQuotaTemplateCommWithKey).
 		Sells(vmpmAccessTemplateComm).
 		Provider(proto.EntityDTO_VIRTUAL_MACHINE, proto.Provider_HOSTING).
 		Buys(vCpuTemplateComm).
@@ -254,6 +260,11 @@ func (f *SupplyChainFactory) buildPodSupplyBuilder() (*proto.TemplateDTO, error)
 		Buys(vMemRequestTemplateComm).
 		Buys(numPodNumConsumersTemplateComm).
 		Buys(vStorageTemplateComm).
+		Provider(proto.EntityDTO_WORKLOAD_CONTROLLER, proto.Provider_HOSTING).
+		Buys(cpuLimitQuotaTemplateCommWithKey).
+		Buys(memLimitQuotaTemplateCommWithKey).
+		Buys(cpuRequestQuotaTemplateCommWithKey).
+		Buys(memRequestQuotaTemplateCommWithKey).
 		Provider(proto.EntityDTO_NAMESPACE, proto.Provider_HOSTING).
 		Buys(cpuLimitQuotaTemplateCommWithKey).
 		Buys(memLimitQuotaTemplateCommWithKey).
@@ -309,10 +320,18 @@ func (f *SupplyChainFactory) buildContainer() (*proto.TemplateDTO, error) {
 	builder := supplychain.NewSupplyChainNodeBuilder(proto.EntityDTO_CONTAINER).
 		Sells(vCpuTemplateComm).
 		Sells(vMemTemplateComm).
+		Sells(vCpuRequestTemplateComm).
+		Sells(vMemRequestTemplateComm).
 		Sells(applicationTemplateCommWithKey).
 		Provider(proto.EntityDTO_CONTAINER_POD, proto.Provider_HOSTING).
 		Buys(vCpuTemplateComm).
 		Buys(vMemTemplateComm).
+		Buys(vCpuRequestTemplateComm).
+		Buys(vMemRequestTemplateComm).
+		Buys(cpuLimitQuotaTemplateCommWithKey).
+		Buys(memLimitQuotaTemplateCommWithKey).
+		Buys(cpuRequestQuotaTemplateCommWithKey).
+		Buys(memRequestQuotaTemplateCommWithKey).
 		Buys(vmpmAccessTemplateComm)
 
 	return builder.Create()


### PR DESCRIPTION
**Intent**:
The intent is to update commodities bought and sold by containers and pods in the new container supply chain model so that Market analysis will take into consideration resource requests and namespace quota.

**Background**:
The commodities sold and bought by containers and pods are shown as follows:
1. Commodities sold by Container:
![Screen Shot 2020-04-20 at 15 35 53](https://user-images.githubusercontent.com/23689754/79792308-af348880-831c-11ea-832d-870a106cd932.png)
2. Commodities bought by Container from Pod:
![Screen Shot 2020-04-20 at 15 36 54](https://user-images.githubusercontent.com/23689754/79792385-ca9f9380-831c-11ea-9961-bf0652e34703.png)
3. Commodities sold by Pod:
![Screen Shot 2020-04-20 at 15 37 37](https://user-images.githubusercontent.com/23689754/79792438-e4d97180-831c-11ea-9eb3-980eb78ab33f.png)
4. Commodities bought by Pod from WorkloadController (or Namespace):
![Screen Shot 2020-04-20 at 15 39 38](https://user-images.githubusercontent.com/23689754/79792625-397cec80-831d-11ea-99b3-b74f907b3dad.png)

**Implementation**:
1. New commodities bought and sold by containers and pods are modified based on the yellow changes in the 4 screenshots above in `container_dto_builder.go` and `pod_entity_dto_builder.go`
2. Collect resource quota capacity for Pods in `metrics_collector.go` and save quota capacity metrics in metrics sink in `k8s_discovery_worker.go`
3. Update `supply_chain_factory.go`

**Unit Test**:
Update unit tests

**Testing Done**:
Added kubeturbo target with the changes.

1. Container is selling `VCPURequest` and `VMemRequest`commodities (if CPU and memory request is set on container):
```json
entityDTO {
  entityType: CONTAINER
  id: "b51223c9-1c27-11ea-bd96-005056803564-0"
  displayName: "openshift-sdn/sdn-tcgkp/sdn"
  ...
  commoditiesSold {
    commodityType: VCPU_REQUEST
    used: 17.206399621865998
    capacity: 266.3778
    peak: 17.206399621865998
    resizable: true
  }
  commoditiesSold {
    commodityType: VMEM_REQUEST
    used: 93836.0
    capacity: 204800.0
    peak: 93836.0
    resizable: true
  }
```
and buying `VCPURequest`, `VMemRequest`, `VCPURequestQuota`, `VMemRequestQuota` from pod (if CPU and memory requests are set):
```json
entityDTO {
  entityType: CONTAINER
  id: "b51223c9-1c27-11ea-bd96-005056803564-0"
  displayName: "openshift-sdn/sdn-tcgkp/sdn"
  ...
  commoditiesBought {
    providerId: "b51223c9-1c27-11ea-bd96-005056803564"
    bought {
      commodityType: VCPU_REQUEST
      used: 266.3778
      peak: 266.3778
      resizable: true
    }
    bought {
      commodityType: VCPU_REQUEST_QUOTA
      used: 266.3778
      peak: 266.3778
      resizable: true
    }
    bought {
      commodityType: VMEM_REQUEST
      used: 204800.0
      peak: 204800.0
      resizable: true
    }
    bought {
      commodityType: VMEM_REQUEST_QUOTA
      used: 204800.0
      peak: 204800.0
      resizable: true
    }
    ...
    providerType: CONTAINER_POD
  }
```
2. If CPU/memory limits are not set on container, it doesn't buy `VCPULimitQuota`, `VMemLimitQuota` commodities from Pod.
3. Pod is selling `VCPURequest`, `VMemRequest`, `VCPULimitQuota`, `VMemLimitQuota`, `VCPURequestQuota`, `VMemRequestQuota`:
```json
entityDTO {
  entityType: CONTAINER_POD
  id: "2e97e28b-200a-11ea-bd96-005056803564"
  displayName: "testing/sc-testing-747cbdbfc-7rc9s"
  ...
  commoditiesSold {
    commodityType: VCPU_REQUEST
    used: 2397.4002
    capacity: 18646.446
    peak: 2397.4002
    resizable: false
  }
  commoditiesSold {
    commodityType: VMEM_REQUEST
    used: 921600.0
    capacity: 1.6163668E7
    peak: 921600.0
    resizable: false
  }
  commoditiesSold {
    commodityType: VCPU_LIMIT_QUOTA
    used: 5061.178199999999
    capacity: 5327.556
    peak: 5061.178199999999
    resizable: false
  }
  commoditiesSold {
    commodityType: VMEM_LIMIT_QUOTA
    used: 1945600.0
    capacity: 2097152.0
    peak: 1945600.0
    resizable: false
  }
  commoditiesSold {
    commodityType: VCPU_REQUEST_QUOTA
    used: 2397.4002
    capacity: 2663.778
    peak: 2397.4002
    resizable: false
  }
  commoditiesSold {
    commodityType: VMEM_REQUEST_QUOTA
    used: 921600.0
    capacity: 1048576.0
    peak: 921600.0
    resizable: false
  }
```
where
* Used values are aggregated from container limits/requests
* Capacity values of VCPU/VMem requests are node Allocatable
* Capacity values of `VCPULimitQuota`, `VMemLimitQuota`, `VCPURequestQuota`, `VMemRequestQuota` are from Namespace quota.
4. Pod is buying `VCPULimitQuota`, `VMemLimitQuota`, `VCPURequestQuota`, `VMemRequestQuota` commodities from WorkloadController with movable as false if not bare pod:
```json
entityDTO {
  entityType: CONTAINER_POD
  id: "2e97e28b-200a-11ea-bd96-005056803564"
  displayName: "testing/sc-testing-747cbdbfc-7rc9s"
  ...
  commoditiesBought {
    providerId: "1d187381-0ba6-11ea-878a-005056803aed"
    bought {
      commodityType: VCPU_LIMIT_QUOTA
      key: "1d187381-0ba6-11ea-878a-005056803aed"
      used: 5061.178199999999
      peak: 5061.178199999999
    }
    bought {
      commodityType: VMEM_LIMIT_QUOTA
      key: "1d187381-0ba6-11ea-878a-005056803aed"
      used: 1945600.0
      peak: 1945600.0
    }
    bought {
      commodityType: VCPU_REQUEST_QUOTA
      key: "1d187381-0ba6-11ea-878a-005056803aed"
      used: 2397.4002
      peak: 2397.4002
    }
    bought {
      commodityType: VMEM_REQUEST_QUOTA
      key: "1d187381-0ba6-11ea-878a-005056803aed"
      used: 921600.0
      peak: 921600.0
    }
    providerType: WORKLOAD_CONTROLLER
    actionEligibility {
      movable: false
    }
  }
```
5. Pod connects to WorkloadController in the supply chain:
<img width="276" alt="Screen Shot 2020-04-20 at 16 07 53" src="https://user-images.githubusercontent.com/23689754/79795046-53b8c980-8321-11ea-842e-61e6c938f44a.png">
(The changes to support connections between Container, ContainerSpec and WorkloadController are in this PR https://github.com/turbonomic/kubeturbo/pull/404)