### PR TITLE
Set inactive commodities sold by ContainerSpec entities

### DIFF
--- a/pkg/discovery/dtofactory/container_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_dto_builder_test.go
@@ -2,9 +2,64 @@ package dtofactory
 
 import (
 	"fmt"
-	podutil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"reflect"
 	"testing"
+)
+
+var (
+	namespace        = "namespace"
+	controllerUID    = "controller-UID"
+	podName          = "pod"
+	podUID           = "pod-UID"
+	nodeName         = "node"
+	containerNameFoo = "foo"
+	containerNameBar = "bar"
+	cpuUsed          = 1.0
+	cpuCap           = 2.0
+	memUsed          = 2.0
+	memCap           = 3.0
+	nodeCpuFrequency = 2048.0
+
+	cpuCommType = proto.CommodityDTO_VCPU
+	memCommType = proto.CommodityDTO_VMEM
+
+	testPod = &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(podUID),
+		},
+		Spec: api.PodSpec{
+			NodeName: nodeName,
+		},
+	}
+
+	containerFooCPUUsed = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameFoo), metrics.CPU, metrics.Used, cpuUsed)
+	containerFooCPUCap = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameFoo), metrics.CPU, metrics.Capacity, cpuCap)
+	containerFooMemUsed = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameFoo), metrics.Memory, metrics.Used, memUsed)
+	containerFooMemCap = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameFoo), metrics.Memory, metrics.Capacity, memCap)
+	containerBarCPUUsed = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameBar), metrics.CPU, metrics.Used, cpuUsed)
+	containerBarCPUCap = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameBar), metrics.CPU, metrics.Capacity, cpuCap)
+	containerBarMemUsed = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameBar), metrics.Memory, metrics.Used, memUsed)
+	containerBarMemCap = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameBar), metrics.Memory, metrics.Capacity, memCap)
+	testCPUFrequency = metrics.NewEntityStateMetric(metrics.NodeType, nodeName, metrics.CpuFrequency, nodeCpuFrequency)
+	ownerUIDMetric   = metrics.NewEntityStateMetric(metrics.PodType, util.PodKeyFunc(testPod), metrics.OwnerUID, controllerUID)
 )
 
 func TestPodFlags(t *testing.T) {
@@ -44,7 +99,7 @@ func TestPodFlags(t *testing.T) {
 	}
 
 	for i, pod := range pods {
-		controllable := podutil.Controllable(pod)
+		controllable := util.Controllable(pod)
 		if controllable != expectedResult[i].Controllable {
 			t.Errorf("Pod %d Controllable: expected %v, got %v", i,
 				expectedResult[i].Controllable, controllable)
@@ -55,9 +110,117 @@ func TestPodFlags(t *testing.T) {
 func dumpPodFlags(pods []*api.Pod) {
 	// This code dumps the attributes of the saved topology
 	for i, pod := range pods {
-		parentKind, _, _, _ := podutil.GetPodParentInfo(pod)
+		parentKind, _, _, _ := util.GetPodParentInfo(pod)
 		fmt.Printf("Pod %d: controllable = %v, parentKind = %s\n", i,
-			podutil.Controllable(pod),
+			util.Controllable(pod),
 			parentKind)
 	}
+}
+
+func Test_containerDTOBuilder_BuildDTOs_layeredOver(t *testing.T) {
+	containerFoo := mockContainer(containerNameFoo)
+	containerBar := mockContainer(containerNameBar)
+	testPod.OwnerReferences = []metav1.OwnerReference{mockOwnerReference()}
+	testPod.Spec.Containers = []api.Container{
+		containerFoo,
+		containerBar,
+	}
+
+	containerDTOBuilder := NewContainerDTOBuilder(mockMetricsSink())
+	containerDTOs, _, err := containerDTOBuilder.BuildDTOs([]*api.Pod{testPod})
+
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(containerDTOs))
+	for _, containerDTO := range containerDTOs {
+		if *containerDTO.DisplayName == util.ContainerNameFunc(testPod, &containerFoo) {
+			assert.ElementsMatch(t, []string{util.ContainerSpecIdFunc(controllerUID, containerNameFoo)}, containerDTO.LayeredOver)
+		} else if *containerDTO.DisplayName == util.ContainerNameFunc(testPod, &containerBar) {
+			assert.ElementsMatch(t, []string{util.ContainerSpecIdFunc(controllerUID, containerNameBar)}, containerDTO.LayeredOver)
+		}
+	}
+}
+
+func Test_containerDTOBuilder_BuildDTOs_withContainerSpec(t *testing.T) {
+	// Test Pod with OwnerReference (deployed by K8s controller)
+	testPod.OwnerReferences = []metav1.OwnerReference{mockOwnerReference()}
+	testPod.Spec.Containers = []api.Container{
+		mockContainer(containerNameFoo),
+	}
+
+	containerDTOBuilder := NewContainerDTOBuilder(mockMetricsSink())
+	_, containerSpecs, err := containerDTOBuilder.BuildDTOs([]*api.Pod{testPod})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(containerSpecs))
+
+	cpuUsedFreq := cpuUsed * nodeCpuFrequency
+	cpuPeakFreq := cpuUsed * nodeCpuFrequency
+	cpuCapFreq := cpuCap * nodeCpuFrequency
+	commIsResizable := false
+	expectedContainerSpec := &repository.ContainerSpec{
+		Namespace:         namespace,
+		ControllerUID:     controllerUID,
+		ContainerSpecName: containerNameFoo,
+		ContainerSpecId:   "controller-UID/foo",
+		ContainerReplicas: 1,
+		ContainerCommodities: map[proto.CommodityDTO_CommodityType][]*proto.CommodityDTO{
+			cpuCommType: {{
+				CommodityType: &cpuCommType,
+				Used:          &cpuUsedFreq,
+				Peak:          &cpuPeakFreq,
+				Capacity:      &cpuCapFreq,
+				Resizable:     &commIsResizable,
+			},
+			},
+			memCommType: {{
+				CommodityType: &memCommType,
+				Used:          &memUsed,
+				Peak:          &memUsed,
+				Capacity:      &memCap,
+				Resizable:     &commIsResizable,
+			},
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedContainerSpec, containerSpecs[0]) {
+		t.Errorf("Test case failed: BuildDTOs_withoutContainerSpec:\nexpected:\n%++v\nactual:\n%++v",
+			expectedContainerSpec, containerSpecs[0])
+	}
+}
+
+func Test_containerDTOBuilder_BuildDTOs_withoutContainerSpec(t *testing.T) {
+	// Test Pod with nil OwnerReference (bare pod deployed without K8s controller)
+	testPod.OwnerReferences = nil
+	testPod.Spec.Containers = []api.Container{
+		mockContainer(containerNameFoo),
+	}
+
+	containerDTOBuilder := NewContainerDTOBuilder(mockMetricsSink())
+
+	_, containerSpecs, err := containerDTOBuilder.BuildDTOs([]*api.Pod{testPod})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(containerSpecs))
+}
+
+func mockOwnerReference() (r metav1.OwnerReference) {
+	isController := true
+	return metav1.OwnerReference{
+		Kind:       "Deployment",
+		Name:       "api",
+		UID:        types.UID(controllerUID),
+		Controller: &isController,
+	}
+}
+
+func mockContainer(name string) api.Container {
+	container := api.Container{
+		Name: name,
+	}
+	return container
+}
+
+func mockMetricsSink() *metrics.EntityMetricSink {
+	metricsSink = metrics.NewEntityMetricSink()
+	metricsSink.AddNewMetricEntries(containerFooCPUUsed, containerFooMemUsed, containerFooCPUCap, containerFooMemCap,
+		containerBarCPUUsed, containerBarCPUCap, containerBarMemUsed, containerBarMemCap, testCPUFrequency, ownerUIDMetric)
+	return metricsSink
 }

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -43,7 +43,7 @@ func (builder *containerSpecDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, error) 
 		entityDTOBuilder.DisplayName(containerSpec.ContainerSpecName)
 		commoditiesSold, err := builder.getCommoditiesSold(containerSpec)
 		if err != nil {
-			glog.Errorf("Error to create commodities sold by ContainerSpec %s, %v", containerSpecId, err)
+			glog.Errorf("Error creating commodities sold by ContainerSpec %s, %v", containerSpecId, err)
 			continue
 		}
 		entityDTOBuilder.SellsCommodities(commoditiesSold)
@@ -78,7 +78,7 @@ func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpec *reposi
 		utilizationDataPoints, lastPointTimestampMs, intervalMs, err :=
 			builder.containerUtilizationDataAggregator.Aggregate(commodities, currentMs)
 		if err != nil {
-			glog.Errorf("Error to aggregate commodity utilization data for ContainerSpec %s, %v",
+			glog.Errorf("Error aggregating commodity utilization data for ContainerSpec %s, %v",
 				containerSpec.ContainerSpecId, err)
 			continue
 		}
@@ -88,7 +88,7 @@ func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpec *reposi
 		aggregatedCap, aggregatedUsed, aggregatedPeak, err :=
 			builder.containerUsageDataAggregator.Aggregate(commodities)
 		if err != nil {
-			glog.Errorf("Error to aggregate commodity usage data for ContainerSpec %s, %v",
+			glog.Errorf("Error aggregating commodity usage data for ContainerSpec %s, %v",
 				containerSpec.ContainerSpecId, err)
 			continue
 		}

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
@@ -1,90 +1,55 @@
 package dtofactory
 
 import (
-	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
-	api "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"reflect"
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"testing"
 )
 
-var (
-	controllerUID = "controller-UID"
-	namespace     = "namespace"
-)
-
-func TestGetControllerIdToPodmap(t *testing.T) {
-	containerFoo1 := mockContainer("foo")
-	containerBar1 := mockContainer("bar")
-	pod1 := &api.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      "pod1",
-			UID:       "pod1-UID",
-			OwnerReferences: []metav1.OwnerReference{
-				mockOwnerReference(),
+func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
+	namespace := "namespace"
+	controllerUID := "controllerUID"
+	containerSpecName := "containerSpecName"
+	containerSpecId := "containerSpecId"
+	containerSpecs := repository.ContainerSpec{
+		Namespace:         namespace,
+		ControllerUID:     controllerUID,
+		ContainerSpecName: containerSpecName,
+		ContainerSpecId:   containerSpecId,
+		ContainerReplicas: 2,
+		ContainerCommodities: map[proto.CommodityDTO_CommodityType][]*proto.CommodityDTO{
+			cpuCommType: {
+				createCommodityDTO(proto.CommodityDTO_VCPU, 1.0, 1.0, 2.0),
+				createCommodityDTO(proto.CommodityDTO_VCPU, 2.0, 2.0, 3.0),
 			},
-		},
-		Spec: api.PodSpec{
-			Containers: []api.Container{
-				containerFoo1,
-				containerBar1,
-			},
-		},
-	}
-	containerFoo2 := mockContainer("foo")
-	containerBar2 := mockContainer("bar")
-	pod2 := &api.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      "pod2",
-			UID:       "pod2-UID",
-			OwnerReferences: []metav1.OwnerReference{
-				mockOwnerReference(),
-			},
-		},
-		Spec: api.PodSpec{
-			Containers: []api.Container{
-				containerFoo2,
-				containerBar2,
+			memCommType: {
+				createCommodityDTO(proto.CommodityDTO_VMEM, 1.0, 1.0, 2.0),
+				createCommodityDTO(proto.CommodityDTO_VMEM, 2.0, 2.0, 3.0),
 			},
 		},
 	}
-	pods := []*api.Pod{pod1, pod2}
-	ownerUIDMetric1 := metrics.NewEntityStateMetric(metrics.PodType, util.PodKeyFunc(pod1), metrics.OwnerUID, controllerUID)
-	ownerUIDMetric2 := metrics.NewEntityStateMetric(metrics.PodType, util.PodKeyFunc(pod2), metrics.OwnerUID, controllerUID)
 
-	containerSpecDTOBuilder := NewContainerSpecDTOBuilder(metrics.NewEntityMetricSink())
-	containerSpecDTOBuilder.metricsSink.AddNewMetricEntries(ownerUIDMetric1, ownerUIDMetric2)
-
-	controllerUIDToContainersMap := containerSpecDTOBuilder.getControllerUIDToContainersMap(pods)
-	expectedControllerUIDToContainersMap := map[string]map[string]struct{}{
-		controllerUID: {
-			"foo": struct{}{},
-			"bar": struct{}{},
-		},
+	builder := &containerSpecDTOBuilder{
+		containerSpecMap:                   map[string]*repository.ContainerSpec{containerSpecId: &containerSpecs},
+		containerUtilizationDataAggregator: aggregation.ContainerUtilizationDataAggregators[aggregation.DefaultContainerUtilizationDataAggStrategy],
+		containerUsageDataAggregator:       aggregation.ContainerUsageDataAggregators[aggregation.DefaultContainerUsageDataAggStrategy],
 	}
-	if !reflect.DeepEqual(expectedControllerUIDToContainersMap, controllerUIDToContainersMap) {
-		t.Errorf("Test case failed: controllerIdToPodMap:\nexpected:\n%++v\nactual:\n%++v",
-			expectedControllerUIDToContainersMap, controllerUIDToContainersMap)
+	commodityDTOs, err := builder.getCommoditiesSold(&containerSpecs)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(commodityDTOs))
+	for _, commodityDTO := range commodityDTOs {
+		assert.Equal(t, false, *commodityDTO.Active)
+		// TODO test utilizationData and usage data
 	}
 }
 
-func mockOwnerReference() (r metav1.OwnerReference) {
-	isController := true
-	return metav1.OwnerReference{
-		Kind:       "Deployment",
-		Name:       "api",
-		UID:        types.UID(controllerUID),
-		Controller: &isController,
+func createCommodityDTO(commodityType proto.CommodityDTO_CommodityType, used, peak, capacity float64) *proto.CommodityDTO {
+	return &proto.CommodityDTO{
+		CommodityType: &commodityType,
+		Used:          &used,
+		Peak:          &peak,
+		Capacity:      &capacity,
 	}
-}
-
-func mockContainer(name string) api.Container {
-	container := api.Container{
-		Name: name,
-	}
-	return container
 }

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -255,7 +255,7 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 	// replicas. ContainerSpec is an entity type which represents a certain type of container replicas deployed by a
 	// K8s controller.
 	// TODO use DefaultContainerUtilizationDataAggStrategy and DefaultContainerUsageDataAggStrategy here. Will make
-	// utilizationDataAggStrategy and usageDataAggStrategy configurable through configMap.
+	// utilizationDataAggStrategy and usageDataAggStrategy configurable through arguments when starting kubeturbo.
 	containerSpecDiscoveryWorker := worker.NewK8sContainerSpecDiscoveryWorker()
 	containerSpecDtos, err := containerSpecDiscoveryWorker.Do(containerSpecs, aggregation.DefaultContainerUtilizationDataAggStrategy,
 		aggregation.DefaultContainerUsageDataAggStrategy)

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"fmt"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
 	"strings"
 	"time"
 
@@ -227,7 +228,7 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 	// Discover pods and create DTOs for nodes, namespaces, controllers, pods, containers, application.
 	// Collect the kubePod, kubeNamespace metrics, groups and kubeControllers from all the discovery workers
 	workerCount := dc.dispatcher.Dispatch(nodes, clusterSummary)
-	entityDTOs, podEntitiesMap, namespaceMetricsList, entityGroupList, kubeControllerList := dc.resultCollector.Collect(workerCount)
+	entityDTOs, podEntitiesMap, namespaceMetricsList, entityGroupList, kubeControllerList, containerSpecs := dc.resultCollector.Collect(workerCount)
 
 	// Namespace discovery worker to create namespace DTOs
 	stitchType := dc.config.probeConfig.StitchingPropertyType
@@ -248,6 +249,21 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 	} else {
 		glog.V(2).Infof("There are %d WorkloadController entityDTOs.", len(workloadControllerDtos))
 		entityDTOs = append(entityDTOs, workloadControllerDtos...)
+	}
+
+	// K8s container spec discovery worker to create ContainerSpec DTOs by aggregating commodities data of container
+	// replicas. ContainerSpec is an entity type which represents a certain type of container replicas deployed by a
+	// K8s controller.
+	// TODO use DefaultContainerUtilizationDataAggStrategy and DefaultContainerUsageDataAggStrategy here. Will make
+	// utilizationDataAggStrategy and usageDataAggStrategy configurable through configMap.
+	containerSpecDiscoveryWorker := worker.NewK8sContainerSpecDiscoveryWorker()
+	containerSpecDtos, err := containerSpecDiscoveryWorker.Do(containerSpecs, aggregation.DefaultContainerUtilizationDataAggStrategy,
+		aggregation.DefaultContainerUsageDataAggStrategy)
+	if err != nil {
+		glog.Errorf("Failed to discover ContainerSpecs from current Kubernetes cluster with the new discovery framework: %s", err)
+	} else {
+		glog.V(2).Infof("There are %d ContainerSpec entityDTOs", len(containerSpecDtos))
+		entityDTOs = append(entityDTOs, containerSpecDtos...)
 	}
 
 	// Service DTOs

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"bytes"
 	"fmt"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"strings"
 
 	"github.com/golang/glog"
@@ -264,6 +265,31 @@ func parseResourceValue(computeResourceType metrics.ResourceType, resourceList v
 }
 
 // =================================================================================================
+// ContainerSpec models the shared portion of individual container replicas defined by the controller that manages the
+// pods where the containers run.
+type ContainerSpec struct {
+	Namespace         string
+	ControllerUID     string
+	ContainerSpecName string
+	ContainerSpecId   string
+	// Container replicas number
+	ContainerReplicas int32
+	// Map from commodity type to list of commodity DTOs of this commodity type sold by container replicas of the
+	// same ContainerSpec entity
+	ContainerCommodities map[proto.CommodityDTO_CommodityType][]*proto.CommodityDTO
+}
+
+func NewContainerSpec(namespace, controllerUID, containerName, containerSpecId string) *ContainerSpec {
+	return &ContainerSpec{
+		Namespace:            namespace,
+		ControllerUID:        controllerUID,
+		ContainerSpecName:    containerName,
+		ContainerSpecId:      containerSpecId,
+		ContainerReplicas:    1,
+		ContainerCommodities: make(map[proto.CommodityDTO_CommodityType][]*proto.CommodityDTO),
+	}
+}
+
 // K8s controller in the cluster
 type KubeController struct {
 	*KubeEntity

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -74,6 +74,7 @@ type TaskResult struct {
 	entityGroups     []*repository.EntityGroup
 	podEntities      []*repository.KubePod
 	kubeControllers  []*repository.KubeController
+	containerSpecs   []*repository.ContainerSpec
 }
 
 func NewTaskResult(workerID string, state TaskResultState) *TaskResult {
@@ -111,6 +112,10 @@ func (r *TaskResult) KubeControllers() []*repository.KubeController {
 	return r.kubeControllers
 }
 
+func (r *TaskResult) ContainerSpecs() []*repository.ContainerSpec {
+	return r.containerSpecs
+}
+
 func (r *TaskResult) Err() error {
 	return r.err
 }
@@ -142,5 +147,10 @@ func (r *TaskResult) WithEntityGroups(entityGroups []*repository.EntityGroup) *T
 
 func (r *TaskResult) WithKubeControllers(kubeControllers []*repository.KubeController) *TaskResult {
 	r.kubeControllers = kubeControllers
+	return r
+}
+
+func (r *TaskResult) WithContainerSpecs(containerSpecs []*repository.ContainerSpec) *TaskResult {
+	r.containerSpecs = containerSpecs
 	return r
 }

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
@@ -1,0 +1,55 @@
+package aggregation
+
+import (
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+var (
+	avgUsageDataStrategy = "avgUsageData"
+	maxUsageDataStrategy = "maxUsageData"
+
+	DefaultContainerUsageDataAggStrategy = avgUsageDataStrategy
+
+	// Map from the configured utilization data aggregation strategy to utilization data aggregator
+	ContainerUsageDataAggregators = map[string]ContainerUsageDataAggregator{
+		avgUsageDataStrategy: &avgUsageDataAggregator{aggregationStrategy: "average usage data strategy"},
+		maxUsageDataStrategy: &maxUsageDataAggregator{aggregationStrategy: "max usage data strategy"},
+	}
+)
+
+// ContainerUsageDataAggregator interface represents a type of container usage data aggregator
+type ContainerUsageDataAggregator interface {
+	// AggregationStrategy returns aggregation strategy of this data aggregator
+	AggregationStrategy() string
+	// Aggregate aggregates commodities usage data based on the given list of commodity DTOs of a commodity type and
+	// aggregation strategy, and returns aggregated capacity, used and peak values.
+	Aggregate(containerCommodities []*proto.CommodityDTO) (float64, float64, float64)
+}
+
+// ---------------- Average usage data aggregation strategy ----------------
+type avgUsageDataAggregator struct {
+	aggregationStrategy string
+}
+
+func (avgUsageDataAggregator *avgUsageDataAggregator) AggregationStrategy() string {
+	return avgUsageDataAggregator.aggregationStrategy
+}
+
+func (avgUsageDataAggregator *avgUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64) {
+	// TODO aggregate average utilization data
+	return 0.0, 0.0, 0.0
+}
+
+// ---------------- Max usage data aggregation strategy ----------------
+type maxUsageDataAggregator struct {
+	aggregationStrategy string
+}
+
+func (maxUsageDataAggregator *maxUsageDataAggregator) AggregationStrategy() string {
+	return maxUsageDataAggregator.aggregationStrategy
+}
+
+func (maxUsageDataAggregator *maxUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64) {
+	// TODO aggregate max utilization data
+	return 0.0, 0.0, 0.0
+}

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
@@ -23,7 +23,7 @@ type ContainerUsageDataAggregator interface {
 	AggregationStrategy() string
 	// Aggregate aggregates commodities usage data based on the given list of commodity DTOs of a commodity type and
 	// aggregation strategy, and returns aggregated capacity, used and peak values.
-	Aggregate(containerCommodities []*proto.CommodityDTO) (float64, float64, float64)
+	Aggregate(containerCommodities []*proto.CommodityDTO) (float64, float64, float64, error)
 }
 
 // ---------------- Average usage data aggregation strategy ----------------
@@ -35,9 +35,9 @@ func (avgUsageDataAggregator *avgUsageDataAggregator) AggregationStrategy() stri
 	return avgUsageDataAggregator.aggregationStrategy
 }
 
-func (avgUsageDataAggregator *avgUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64) {
+func (avgUsageDataAggregator *avgUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64, error) {
 	// TODO aggregate average utilization data
-	return 0.0, 0.0, 0.0
+	return 0.0, 0.0, 0.0, nil
 }
 
 // ---------------- Max usage data aggregation strategy ----------------
@@ -49,7 +49,7 @@ func (maxUsageDataAggregator *maxUsageDataAggregator) AggregationStrategy() stri
 	return maxUsageDataAggregator.aggregationStrategy
 }
 
-func (maxUsageDataAggregator *maxUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64) {
+func (maxUsageDataAggregator *maxUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64, error) {
 	// TODO aggregate max utilization data
-	return 0.0, 0.0, 0.0
+	return 0.0, 0.0, 0.0, nil
 }

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
@@ -8,7 +8,7 @@ var (
 	maxUtilizationDataStrategy = "maxUtilizationData"
 	allUtilizationDataStrategy = "allUtilizationData"
 
-	DefaultContainerUtilizationDataAggStrategy = maxUtilizationDataStrategy
+	DefaultContainerUtilizationDataAggStrategy = allUtilizationDataStrategy
 
 	// Map from the configured utilization data aggregation strategy to utilization data aggregator
 	ContainerUtilizationDataAggregators = map[string]ContainerUtilizationDataAggregator{

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
@@ -1,0 +1,56 @@
+package aggregation
+
+import (
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+var (
+	maxUtilizationDataStrategy = "maxUtilizationData"
+	allUtilizationDataStrategy = "allUtilizationData"
+
+	DefaultContainerUtilizationDataAggStrategy = maxUtilizationDataStrategy
+
+	// Map from the configured utilization data aggregation strategy to utilization data aggregator
+	ContainerUtilizationDataAggregators = map[string]ContainerUtilizationDataAggregator{
+		maxUtilizationDataStrategy: &maxUtilizationDataAggregator{aggregationStrategy: "max utilization data strategy"},
+		allUtilizationDataStrategy: &allUtilizationDataAggregator{aggregationStrategy: "all utilization data strategy"},
+	}
+)
+
+// ContainerUtilizationDataAggregator interface represents a type of container utilization data aggregator
+type ContainerUtilizationDataAggregator interface {
+	// AggregationStrategy returns aggregation strategy of this data aggregator
+	AggregationStrategy() string
+	// Aggregate aggregates commodities utilization data based on the given list of commodity DTOs of a commodity type
+	// and aggregation strategy, and returns aggregated utilization data which contains utilization data points, last
+	// point timestamp milliseconds and interval milliseconds
+	Aggregate(commodities []*proto.CommodityDTO) ([]float64, int64, int32)
+}
+
+// ---------------- All utilization data aggregation strategy ----------------
+type allUtilizationDataAggregator struct {
+	aggregationStrategy string
+}
+
+func (allDataAggregator *allUtilizationDataAggregator) AggregationStrategy() string {
+	return allDataAggregator.aggregationStrategy
+}
+
+func (allDataAggregator *allUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO) ([]float64, int64, int32) {
+	// TODO aggregate all utilization data
+	return []float64{}, 0, 0
+}
+
+// ---------------- Max utilization data aggregation strategy ----------------
+type maxUtilizationDataAggregator struct {
+	aggregationStrategy string
+}
+
+func (maxDataAggregator *maxUtilizationDataAggregator) AggregationStrategy() string {
+	return maxDataAggregator.aggregationStrategy
+}
+
+func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO) ([]float64, int64, int32) {
+	// TODO aggregate max utilization data
+	return []float64{}, 0, 0
+}

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
@@ -24,7 +24,7 @@ type ContainerUtilizationDataAggregator interface {
 	// Aggregate aggregates commodities utilization data based on the given list of commodity DTOs of a commodity type
 	// and aggregation strategy, and returns aggregated utilization data which contains utilization data points, last
 	// point timestamp milliseconds and interval milliseconds
-	Aggregate(commodities []*proto.CommodityDTO) ([]float64, int64, int32)
+	Aggregate(commodities []*proto.CommodityDTO, lastPointTimestampMs int64) ([]float64, int64, int32, error)
 }
 
 // ---------------- All utilization data aggregation strategy ----------------
@@ -36,9 +36,10 @@ func (allDataAggregator *allUtilizationDataAggregator) AggregationStrategy() str
 	return allDataAggregator.aggregationStrategy
 }
 
-func (allDataAggregator *allUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO) ([]float64, int64, int32) {
+func (allDataAggregator *allUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO,
+	lastPointTimestampMs int64) ([]float64, int64, int32, error) {
 	// TODO aggregate all utilization data
-	return []float64{}, 0, 0
+	return []float64{}, 0, 0, nil
 }
 
 // ---------------- Max utilization data aggregation strategy ----------------
@@ -50,7 +51,8 @@ func (maxDataAggregator *maxUtilizationDataAggregator) AggregationStrategy() str
 	return maxDataAggregator.aggregationStrategy
 }
 
-func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO) ([]float64, int64, int32) {
+func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO,
+	lastPointTimestampMs int64) ([]float64, int64, int32, error) {
 	// TODO aggregate max utilization data
-	return []float64{}, 0, 0
+	return []float64{}, 0, 0, nil
 }

--- a/pkg/discovery/worker/container_spec_discovery_worker.go
+++ b/pkg/discovery/worker/container_spec_discovery_worker.go
@@ -1,0 +1,87 @@
+package worker
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	agg "github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+// Converts K8s ContainerSpec objects to entity DTOs
+type k8sContainerSpecDiscoveryWorker struct{}
+
+func NewK8sContainerSpecDiscoveryWorker() *k8sContainerSpecDiscoveryWorker {
+	return &k8sContainerSpecDiscoveryWorker{}
+}
+
+// ContainerSpec discovery worker collects ContainerSpecs discovered by different discovery workers.
+// It merges the commodities data of container replicas belonging to the same ContainerSpec but discovered by different
+// discovery workers, and aggregates container utilization and usage data based on the specified aggregation strategies.
+// Then it creates entity DTOs for the ContainerSpecs with the aggregated commodities data of container replicas to be
+// sent to the Turbonomic server.
+func (worker *k8sContainerSpecDiscoveryWorker) Do(containerSpecs []*repository.ContainerSpec,
+	utilizationDataAggStrategy, usageDataAggStrategy string) ([]*proto.EntityDTO, error) {
+	// Get data aggregators based on the given data aggregation strategies
+	utilizationDataAggregator, usageDataAggregator := worker.getContainerDataAggregator(utilizationDataAggStrategy, usageDataAggStrategy)
+	// Create containerSpecs map from ContainerSpec ID to ContainerSpec with merge commodities data of container replicas
+	containerSpecMap := worker.createContainerSpecMap(containerSpecs)
+	containerSpecEntityDTOBuilder := dtofactory.NewContainerSpecDTOBuilder(containerSpecMap, utilizationDataAggregator,
+		usageDataAggregator)
+	containerSpecEntityDTOs, err := containerSpecEntityDTOBuilder.BuildDTOs()
+	if err != nil {
+		return nil, fmt.Errorf("error while creating ContainerSpec entityDTOs: %v", err)
+	}
+	return containerSpecEntityDTOs, nil
+}
+
+// getContainerDataAggregator returns utilization and usage data aggregator based on the given utilization and usage data
+// aggregation strategies. If given data aggregation strategies are not supported, use default strategies.
+func (worker *k8sContainerSpecDiscoveryWorker) getContainerDataAggregator(utilizationDataAggStrategy,
+	usageDataAggStrategy string) (agg.ContainerUtilizationDataAggregator, agg.ContainerUsageDataAggregator) {
+	utilizationDataAggregator, exists := agg.ContainerUtilizationDataAggregators[utilizationDataAggStrategy]
+	if !exists {
+		glog.Errorf("Container utilization data aggregation strategy %s is not supported. Use default % strategy",
+			utilizationDataAggStrategy, agg.DefaultContainerUtilizationDataAggStrategy)
+		utilizationDataAggregator = agg.ContainerUtilizationDataAggregators[agg.DefaultContainerUtilizationDataAggStrategy]
+	}
+	glog.Infof("ContainerSpec will aggregate Containers utilization data by %s", utilizationDataAggregator.AggregationStrategy())
+
+	usageDataAggregator, exists := agg.ContainerUsageDataAggregators[usageDataAggStrategy]
+	if !exists {
+		glog.Errorf("Container usage data aggregation strategy %s is not supported. Use default % strategy",
+			utilizationDataAggStrategy, agg.DefaultContainerUsageDataAggStrategy)
+		usageDataAggregator = agg.ContainerUsageDataAggregators[agg.DefaultContainerUsageDataAggStrategy]
+	}
+	glog.Infof("ContainerSpec will aggregate Containers usage data by %s", usageDataAggregator.AggregationStrategy())
+	return utilizationDataAggregator, usageDataAggregator
+}
+
+// createContainerSpecMap creates map from ContainerSpec ID to ContainerSpec entity with merged VCPU and VMem commodity
+// DTOs of container replicas.
+func (worker *k8sContainerSpecDiscoveryWorker) createContainerSpecMap(containerSpecList []*repository.ContainerSpec) map[string]*repository.ContainerSpec {
+	// Map from ContainerSpec ID to ContainerSpec object
+	containerSpecMap := make(map[string]*repository.ContainerSpec)
+	for _, containerSpec := range containerSpecList {
+		containerSpecId := containerSpec.ContainerSpecId
+		existingContainerSpec, exists := containerSpecMap[containerSpecId]
+		if !exists {
+			containerSpecMap[containerSpecId] = containerSpec
+		} else {
+			// Append commodity DTOs of the same commodity type of container replicas
+			for commodityType, existingCommodities := range existingContainerSpec.ContainerCommodities {
+				commodities, exists := containerSpec.ContainerCommodities[commodityType]
+				if !exists {
+					glog.Errorf("%s commodities do not exist for ContainerSpec %s", commodityType, containerSpec.ContainerSpecId)
+					continue
+				}
+				existingCommodities = append(existingCommodities, commodities...)
+				existingContainerSpec.ContainerCommodities[commodityType] = existingCommodities
+			}
+			// Increment number of container replicas
+			existingContainerSpec.ContainerReplicas++
+		}
+	}
+	return containerSpecMap
+}

--- a/pkg/discovery/worker/container_spec_discovery_worker_test.go
+++ b/pkg/discovery/worker/container_spec_discovery_worker_test.go
@@ -1,0 +1,105 @@
+package worker
+
+import (
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	agg "github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"gotest.tools/assert"
+	"reflect"
+	"testing"
+)
+
+func Test_k8sContainerSpecDiscoveryWorker_getContainerDataAggregator(t *testing.T) {
+	worker := &k8sContainerSpecDiscoveryWorker{}
+	utilizationDataAggregator, usageDataAggregator := worker.getContainerDataAggregator("allUtilizationData", "maxUsageData")
+	assert.Equal(t, agg.ContainerUtilizationDataAggregators["allUtilizationData"], utilizationDataAggregator)
+	assert.Equal(t, agg.ContainerUsageDataAggregators["maxUsageData"], usageDataAggregator)
+}
+
+func Test_k8sContainerSpecDiscoveryWorker_getContainerDataAggregator_defaultStrategy(t *testing.T) {
+	worker := &k8sContainerSpecDiscoveryWorker{}
+	utilizationDataAggregator, usageDataAggregator := worker.getContainerDataAggregator("testUtilizationDataStrategy", "testUsageDataStrategy")
+	// If input utilizationDataAggStrategy and usageDataAggStrategy are not support, use default data aggregators
+	assert.Equal(t, agg.ContainerUtilizationDataAggregators[agg.DefaultContainerUtilizationDataAggStrategy], utilizationDataAggregator)
+	assert.Equal(t, agg.ContainerUsageDataAggregators[agg.DefaultContainerUsageDataAggStrategy], usageDataAggregator)
+}
+
+func Test_k8sContainerSpecDiscoveryWorker_createContainerSpecMap(t *testing.T) {
+	namespace := "namespace"
+	controllerUID := "controllerUID"
+	containerSpecName := "containerSpecName"
+	containerSpecId := "containerSpecId"
+	cpuCommType := proto.CommodityDTO_VCPU
+	memCommType := proto.CommodityDTO_VMEM
+	cpuComm1 := createCommodityDTO(cpuCommType, 1.0, 1.0, 2.0)
+	memComm1 := createCommodityDTO(memCommType, 1.0, 1.0, 2.0)
+	cpuComm2 := createCommodityDTO(cpuCommType, 2.0, 2.0, 3.0)
+	memComm2 := createCommodityDTO(memCommType, 2.0, 2.0, 3.0)
+
+	// containerSpec1 and containerSpec2 collect of the same ContainerSpec entity from 2 container replicas
+	containerSpec1 := &repository.ContainerSpec{
+		Namespace:         namespace,
+		ControllerUID:     controllerUID,
+		ContainerSpecName: containerSpecName,
+		ContainerSpecId:   containerSpecId,
+		ContainerReplicas: 1,
+		ContainerCommodities: map[proto.CommodityDTO_CommodityType][]*proto.CommodityDTO{
+			cpuCommType: {
+				cpuComm1,
+			},
+			memCommType: {
+				memComm1,
+			},
+		},
+	}
+	containerSpec2 := &repository.ContainerSpec{
+		Namespace:         namespace,
+		ControllerUID:     controllerUID,
+		ContainerSpecName: containerSpecName,
+		ContainerSpecId:   containerSpecId,
+		ContainerReplicas: 1,
+		ContainerCommodities: map[proto.CommodityDTO_CommodityType][]*proto.CommodityDTO{
+			cpuCommType: {
+				cpuComm2,
+			},
+			memCommType: {
+				memComm2,
+			},
+		},
+	}
+
+	expectedContainerSpec := repository.ContainerSpec{
+		Namespace:         namespace,
+		ControllerUID:     controllerUID,
+		ContainerSpecName: containerSpecName,
+		ContainerSpecId:   containerSpecId,
+		ContainerReplicas: 2,
+		ContainerCommodities: map[proto.CommodityDTO_CommodityType][]*proto.CommodityDTO{
+			cpuCommType: {
+				cpuComm1,
+				cpuComm2,
+			},
+			memCommType: {
+				memComm1,
+				memComm2,
+			},
+		},
+	}
+
+	worker := &k8sContainerSpecDiscoveryWorker{}
+	containerSpecMap := worker.createContainerSpecMap([]*repository.ContainerSpec{containerSpec1, containerSpec2})
+	containerSpec := *containerSpecMap[containerSpecId]
+	if !reflect.DeepEqual(expectedContainerSpec, containerSpec) {
+		t.Errorf("Test case failed: createContainerSpecMap:\nexpected:\n%++v\nactual:\n%++v",
+			expectedContainerSpec, containerSpec)
+	}
+}
+
+func createCommodityDTO(commodityType proto.CommodityDTO_CommodityType, used, peak, capacity float64) *proto.CommodityDTO {
+	return &proto.CommodityDTO{
+		CommodityType: &commodityType,
+		Used:          &used,
+		Peak:          &peak,
+		Capacity:      &capacity,
+	}
+}

--- a/pkg/discovery/worker/container_spec_discovery_worker_test.go
+++ b/pkg/discovery/worker/container_spec_discovery_worker_test.go
@@ -1,10 +1,10 @@
 package worker
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	agg "github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-	"gotest.tools/assert"
 	"reflect"
 	"testing"
 )

--- a/pkg/discovery/worker/container_spec_discovery_worker_test.go
+++ b/pkg/discovery/worker/container_spec_discovery_worker_test.go
@@ -11,14 +11,14 @@ import (
 
 func Test_k8sContainerSpecDiscoveryWorker_getContainerDataAggregator(t *testing.T) {
 	worker := &k8sContainerSpecDiscoveryWorker{}
-	utilizationDataAggregator, usageDataAggregator := worker.getContainerDataAggregator("allUtilizationData", "maxUsageData")
+	utilizationDataAggregator, usageDataAggregator := worker.getContainerDataAggregators("allUtilizationData", "maxUsageData")
 	assert.Equal(t, agg.ContainerUtilizationDataAggregators["allUtilizationData"], utilizationDataAggregator)
 	assert.Equal(t, agg.ContainerUsageDataAggregators["maxUsageData"], usageDataAggregator)
 }
 
 func Test_k8sContainerSpecDiscoveryWorker_getContainerDataAggregator_defaultStrategy(t *testing.T) {
 	worker := &k8sContainerSpecDiscoveryWorker{}
-	utilizationDataAggregator, usageDataAggregator := worker.getContainerDataAggregator("testUtilizationDataStrategy", "testUsageDataStrategy")
+	utilizationDataAggregator, usageDataAggregator := worker.getContainerDataAggregators("testUtilizationDataStrategy", "testUsageDataStrategy")
 	// If input utilizationDataAggStrategy and usageDataAggStrategy are not support, use default data aggregators
 	assert.Equal(t, agg.ContainerUtilizationDataAggregators[agg.DefaultContainerUtilizationDataAggStrategy], utilizationDataAggregator)
 	assert.Equal(t, agg.ContainerUsageDataAggregators[agg.DefaultContainerUsageDataAggStrategy], usageDataAggregator)

--- a/pkg/discovery/worker/controller_discovery_worker.go
+++ b/pkg/discovery/worker/controller_discovery_worker.go
@@ -69,8 +69,6 @@ func (worker *K8sControllerDiscoveryWorker) Do(kubeControllers []*repository.Kub
 				resource.Used += usedValue
 			}
 			// Update the pod lists of the existing KubeController
-			// TODO yue will use the pods of each KubeController to create ContainerSpec entity DTOs to simplify the logic
-			// in container_spec_entity_dto_builder.go
 			existingKubeController.Pods = append(existingKubeController.Pods, kubeController.Pods...)
 		}
 

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -293,6 +293,8 @@ func (worker *k8sDiscoveryWorker) addPodAllocationMetrics(podMetricsCollection P
 
 // ================================================================================================
 // Build DTOs for nodes, pods, containers
+// And return a slice of ContainerSpec objects sent by this discovery worker to be used to build ContainerSpec entityDTOs
+// in the new discovery framework in k8s_discovery_client
 func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.EntityDTO, []*api.Pod, []*repository.ContainerSpec, error) {
 	var result []*proto.EntityDTO
 

--- a/pkg/discovery/worker/k8s_discovery_worker_test.go
+++ b/pkg/discovery/worker/k8s_discovery_worker_test.go
@@ -61,7 +61,7 @@ func TestBuildDTOsWithMissingMetrics(t *testing.T) {
 
 	currTask := task.NewTask().WithNodes([]*api.Node{node}).WithPods([]*api.Pod{pod})
 
-	_, _, err = worker.buildDTOs(currTask)
+	_, _, _, err = worker.buildDTOs(currTask)
 	if err != nil {
 		t.Errorf("Error while building DTOs: %v", err)
 	}

--- a/pkg/discovery/worker/result_collector.go
+++ b/pkg/discovery/worker/result_collector.go
@@ -28,13 +28,14 @@ func (rc *ResultCollector) ResultPool() chan *task.TaskResult {
 }
 
 func (rc *ResultCollector) Collect(count int) ([]*proto.EntityDTO, map[string]*repository.KubePod,
-	[]*repository.NamespaceMetrics, []*repository.EntityGroup, []*repository.KubeController) {
+	[]*repository.NamespaceMetrics, []*repository.EntityGroup, []*repository.KubeController, []*repository.ContainerSpec) {
 	discoveryResult := []*proto.EntityDTO{}
 	namespaceMetrics := []*repository.NamespaceMetrics{}
 	entityGroupList := []*repository.EntityGroup{}
 	discoveryErrorString := []string{}
 	podEntitiesMap := make(map[string]*repository.KubePod)
 	var kubeControllerList []*repository.KubeController
+	var containerSpecs []*repository.ContainerSpec
 	glog.V(2).Infof("Waiting for results from %d workers.", count)
 
 	stopChan := make(chan struct{})
@@ -62,6 +63,8 @@ func (rc *ResultCollector) Collect(count int) ([]*proto.EntityDTO, map[string]*r
 					}
 					// K8s controller data from different workers
 					kubeControllerList = append(kubeControllerList, result.KubeControllers()...)
+					// ContainerSpecs with individual container replica commodities data from different discovery workers
+					containerSpecs = append(containerSpecs, result.ContainerSpecs()...)
 				}
 				wg.Done()
 			}
@@ -76,5 +79,5 @@ func (rc *ResultCollector) Collect(count int) ([]*proto.EntityDTO, map[string]*r
 		glog.Errorf("One or more discovery worker failed: %s", strings.Join(discoveryErrorString, "\t\t"))
 	}
 
-	return discoveryResult, podEntitiesMap, namespaceMetrics, entityGroupList, kubeControllerList
+	return discoveryResult, podEntitiesMap, namespaceMetrics, entityGroupList, kubeControllerList, containerSpecs
 }

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -347,7 +347,9 @@ func (f *SupplyChainFactory) addVMStitchingProperty(extLinkBuilder *supplychain.
 
 func (f *SupplyChainFactory) buildContainerSpecSupplyBuilder() (*proto.TemplateDTO, error) {
 	containerSpecSupplyChainNodeBuilder := supplychain.NewSupplyChainNodeBuilder(proto.EntityDTO_CONTAINER_SPEC)
-	// TODO set up commodities sold by ContainerSpec here
+	containerSpecSupplyChainNodeBuilder = containerSpecSupplyChainNodeBuilder.
+		Sells(vCpuTemplateComm).
+		Sells(vMemTemplateComm)
 	return containerSpecSupplyChainNodeBuilder.Create()
 }
 


### PR DESCRIPTION
**Intent and Background**:
The VCPU and VMem commodities sold by ContainerSpecs are designed to model the shared utilization and usage data among all container replicas specified by the ContainerSpec. The shared utilization and usage data can be persisted in the platform so that even when the ephemeral replicas come and go, they can be supplied with that history.

The intent is to set VCPU and VMem commodities sold by ContainerSpec entities and implement a framework to define the container utilization and usage data aggregation.

**Implementation**:
1. Defined `ContainerSpec` type to model the shared portion of individual container replicas defined by the controller that manages the pods where the containers run.
2. Create ContainerSpecs with individual container replica commodity DTOs in `container_dto_builder.go` run by each discovery worker
3. Collect all ContainerSpecs with ContainerSpecs from different discovery workers in `result_collector.go`
4. In `container_spec_discovery_worker.go`, merge the commodities data of container replicas belonging to the same ContainerSpec but discovered by different discovery workers
5. In `container_spec_entity_dto_builder.go`, create inactive commodities sold by ContainerSpec and aggregate container utilization and usage data with the default data aggregator and then return ContainerSpec entity DTOs.
6. Create utilization and usage data aggregator using strategy pattern. 
6.1  In `container_utilization_data_aggregator.go`, there're `allUtilizationDataAggregator` and `maxUtilizationDataAggregator` to aggregate container utilization data based on the given commodity DTOs of a commodity Type from a set of container replicas for a ContainerSpec entity.
6.2 In `container_usage_data_aggregator.go`, there're `avgUsageDataAggregator` and `maxUsageDataAggregator` to aggregate container usage data (capacity, used and peak) based on the given commodity DTOs of a commodity type from a set of container replicas for a ContainerSpec entity 

The corresponding `Aggregate` function to populate the utilization and usage data will be implemented in a different story. Will post a following PR for this.

**Unit Tests**:
Update and create new unit tests. And all unit tests are passed

**Testing Done**:
Add a kubeturbo target with the changes, ContainerSpec entities can be correctly created with such discovery dto:
```json
entityDTO {
  entityType: CONTAINER_SPEC
  id: "e9384cfc-70e7-11ea-bda6-005056803aed/kubeturbo"
  displayName: "kubeturbo"
  commoditiesSold {
    commodityType: VCPU
    used: 0.0
    capacity: 0.0
    peak: 0.0
    active: false
    utilizationData {
      lastPointTimestampMs: 0
      intervalMs: 0
    }
  }
  commoditiesSold {
    commodityType: VMEM
    used: 0.0
    capacity: 0.0
    peak: 0.0
    active: false
    utilizationData {
      lastPointTimestampMs: 0
      intervalMs: 0
    }
  }
  monitored: false
  actionEligibility {
  }
}
```
There's no data point in utilizationData yet. The utilizationData, used, peak and capacity values will be populated in a different story.