### PR TITLE
Populate shared utilization and usage values on VCPU and VMem commodities for ContainerSpec entity

### DIFF
--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -74,15 +74,16 @@ func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpec *reposi
 		commSoldBuilder := sdkbuilder.NewCommodityDTOBuilder(commodityType)
 
 		// Aggregate container replicas utilization data
-		currentMs := time.Now().UnixNano() / int64(time.Millisecond)
-		utilizationDataPoints, lastPointTimestampMs, intervalMs, err :=
-			builder.containerUtilizationDataAggregator.Aggregate(commodities, currentMs)
+		utilizationDataPoints, err := builder.containerUtilizationDataAggregator.Aggregate(commodities)
 		if err != nil {
 			glog.Errorf("Error aggregating commodity utilization data for ContainerSpec %s, %v",
 				containerSpec.ContainerSpecId, err)
 			continue
 		}
-		commSoldBuilder.UtilizationData(utilizationDataPoints, lastPointTimestampMs, intervalMs)
+		currentMs := time.Now().UnixNano() / int64(time.Millisecond)
+		// Currently we only collect one set of metrics data points from Kubernetes within a discovery cycle so the
+		// lastPointTimestampMs of utilizationData is current timestamp in milliseconds and intervalMs is 0.
+		commSoldBuilder.UtilizationData(utilizationDataPoints, currentMs, 0)
 
 		// Aggregate container replicas usage data (capacity, used and peak)
 		aggregatedCap, aggregatedUsed, aggregatedPeak, err :=

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
@@ -22,11 +22,11 @@ func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
 		ContainerCommodities: map[proto.CommodityDTO_CommodityType][]*proto.CommodityDTO{
 			cpuCommType: {
 				createCommodityDTO(proto.CommodityDTO_VCPU, 1.0, 1.0, 2.0),
-				createCommodityDTO(proto.CommodityDTO_VCPU, 2.0, 2.0, 3.0),
+				createCommodityDTO(proto.CommodityDTO_VCPU, 3.0, 3.0, 4.0),
 			},
 			memCommType: {
 				createCommodityDTO(proto.CommodityDTO_VMEM, 1.0, 1.0, 2.0),
-				createCommodityDTO(proto.CommodityDTO_VMEM, 2.0, 2.0, 3.0),
+				createCommodityDTO(proto.CommodityDTO_VMEM, 3.0, 3.0, 4.0),
 			},
 		},
 	}
@@ -41,7 +41,11 @@ func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
 	assert.Equal(t, 2, len(commodityDTOs))
 	for _, commodityDTO := range commodityDTOs {
 		assert.Equal(t, false, *commodityDTO.Active)
-		// TODO test utilizationData and usage data
+		// Parse values to int to avoid tolerance of float values
+		assert.Equal(t, 2, int(*commodityDTO.Used))
+		assert.Equal(t, 2, int(*commodityDTO.Peak))
+		assert.Equal(t, 3, int(*commodityDTO.Capacity))
+		assert.Equal(t, 2, len(commodityDTO.UtilizationData.Point))
 	}
 }
 

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
@@ -1,0 +1,84 @@
+package aggregation
+
+import (
+	"fmt"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"math"
+)
+
+var (
+	avgUsageDataStrategy = "avgUsageData"
+	maxUsageDataStrategy = "maxUsageData"
+
+	DefaultContainerUsageDataAggStrategy = avgUsageDataStrategy
+
+	// Map from the configured utilization data aggregation strategy to utilization data aggregator
+	ContainerUsageDataAggregators = map[string]ContainerUsageDataAggregator{
+		avgUsageDataStrategy: &avgUsageDataAggregator{aggregationStrategy: "average usage data strategy"},
+		maxUsageDataStrategy: &maxUsageDataAggregator{aggregationStrategy: "max usage data strategy"},
+	}
+)
+
+// ContainerUsageDataAggregator interface represents a type of container usage data aggregator
+type ContainerUsageDataAggregator interface {
+	// AggregationStrategy returns aggregation strategy of this data aggregator
+	AggregationStrategy() string
+	// Aggregate aggregates commodities usage data based on the given list of commodity DTOs of a commodity type and
+	// aggregation strategy, and returns aggregated capacity, used and peak values.
+	Aggregate(containerCommodities []*proto.CommodityDTO) (float64, float64, float64, error)
+}
+
+// ---------------- Average usage data aggregation strategy ----------------
+type avgUsageDataAggregator struct {
+	aggregationStrategy string
+}
+
+func (avgUsageDataAggregator *avgUsageDataAggregator) AggregationStrategy() string {
+	return avgUsageDataAggregator.aggregationStrategy
+}
+
+func (avgUsageDataAggregator *avgUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64, error) {
+	if len(commodities) == 0 {
+		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty",
+			avgUsageDataAggregator.AggregationStrategy())
+		return 0.0, 0.0, 0.0, err
+	}
+	capacitySum := 0.0
+	usedSum := 0.0
+	peakSum := 0.0
+	for _, commodity := range commodities {
+		capacitySum += *commodity.Capacity
+		usedSum += *commodity.Used
+		peakSum += *commodity.Peak
+	}
+	avgCapacity := capacitySum / float64(len(commodities))
+	avgUsed := usedSum / float64(len(commodities))
+	avgPeak := peakSum / float64(len(commodities))
+	return avgCapacity, avgUsed, avgPeak, nil
+}
+
+// ---------------- Max usage data aggregation strategy ----------------
+type maxUsageDataAggregator struct {
+	aggregationStrategy string
+}
+
+func (maxUsageDataAggregator *maxUsageDataAggregator) AggregationStrategy() string {
+	return maxUsageDataAggregator.aggregationStrategy
+}
+
+func (maxUsageDataAggregator *maxUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64, error) {
+	if len(commodities) == 0 {
+		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty",
+			maxUsageDataAggregator.AggregationStrategy())
+		return 0.0, 0.0, 0.0, err
+	}
+	maxCapacity := 0.0
+	maxUsed := 0.0
+	maxPeak := 0.0
+	for _, commodity := range commodities {
+		maxCapacity = math.Max(maxCapacity, *commodity.Capacity)
+		maxUsed = math.Max(maxUsed, *commodity.Used)
+		maxPeak = math.Max(maxPeak, *commodity.Peak)
+	}
+	return maxCapacity, maxUsed, maxPeak, nil
+}

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
@@ -6,12 +6,13 @@ import (
 	"math"
 )
 
-var (
-	avgUsageDataStrategy = "avgUsageData"
-	maxUsageDataStrategy = "maxUsageData"
-
+const (
+	avgUsageDataStrategy                 = "avgUsageData"
+	maxUsageDataStrategy                 = "maxUsageData"
 	DefaultContainerUsageDataAggStrategy = avgUsageDataStrategy
+)
 
+var (
 	// Map from the configured utilization data aggregation strategy to utilization data aggregator
 	ContainerUsageDataAggregators = map[string]ContainerUsageDataAggregator{
 		avgUsageDataStrategy: &avgUsageDataAggregator{aggregationStrategy: "average usage data strategy"},

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator_test.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator_test.go
@@ -1,0 +1,128 @@
+package aggregation
+
+import (
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"testing"
+)
+
+var (
+	cpuCommType     = proto.CommodityDTO_VCPU
+	testCommodities = []*proto.CommodityDTO{
+		createCommodityDTO(cpuCommType, 2.0, 1.0, 1.0),
+		createCommodityDTO(cpuCommType, 4.0, 3.0, 3.0),
+	}
+	emptyCommodities []*proto.CommodityDTO
+)
+
+func Test_avgUsageDataAggregator_Aggregate(t *testing.T) {
+	testCases := []struct {
+		name                string
+		aggregationStrategy string
+		commodities         []*proto.CommodityDTO
+		capacity            float64
+		used                float64
+		peak                float64
+		wantErr             bool
+	}{
+		{
+			name:                "test aggregate average usage data",
+			aggregationStrategy: "average usage data strategy",
+			commodities:         testCommodities,
+			capacity:            3.0,
+			used:                2.0,
+			peak:                2.0,
+			wantErr:             false,
+		},
+		{
+			name:                "test aggregate average usage data with empty commodities",
+			aggregationStrategy: "average usage data strategy",
+			commodities:         emptyCommodities,
+			capacity:            0.0,
+			used:                0.0,
+			peak:                0.0,
+			wantErr:             true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			avgUsageDataAggregator := &avgUsageDataAggregator{
+				aggregationStrategy: tt.aggregationStrategy,
+			}
+			aggregatedCap, aggregatedUsed, aggregatedPeak, err := avgUsageDataAggregator.Aggregate(tt.commodities)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if aggregatedCap != tt.capacity {
+				t.Errorf("Aggregate() aggregatedCap = %v, want %v", aggregatedCap, tt.capacity)
+			}
+			if aggregatedUsed != tt.used {
+				t.Errorf("Aggregate() aggregatedUsed = %v, want %v", aggregatedUsed, tt.used)
+			}
+			if aggregatedPeak != tt.peak {
+				t.Errorf("Aggregate() aggregatedPeak = %v, want %v", aggregatedPeak, tt.peak)
+			}
+		})
+	}
+}
+
+func Test_maxUsageDataAggregator_Aggregate(t *testing.T) {
+	testCases := []struct {
+		name                string
+		aggregationStrategy string
+		commodities         []*proto.CommodityDTO
+		capacity            float64
+		used                float64
+		peak                float64
+		wantErr             bool
+	}{
+		{
+			name:                "test aggregate max usage data",
+			aggregationStrategy: "max usage data strategy",
+			commodities:         testCommodities,
+			capacity:            4.0,
+			used:                3.0,
+			peak:                3.0,
+			wantErr:             false,
+		},
+		{
+			name:                "test aggregate max usage data with empty commodities",
+			aggregationStrategy: "average usage data strategy",
+			commodities:         emptyCommodities,
+			capacity:            0.0,
+			used:                0.0,
+			peak:                0.0,
+			wantErr:             true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			maxUsageDataAggregator := &maxUsageDataAggregator{
+				aggregationStrategy: tt.aggregationStrategy,
+			}
+			aggregatedCap, aggregatedUsed, aggregatedPeak, err := maxUsageDataAggregator.Aggregate(tt.commodities)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if aggregatedCap != tt.capacity {
+				t.Errorf("Aggregate() aggregatedCap = %v, want %v", aggregatedCap, tt.capacity)
+			}
+			if aggregatedUsed != tt.used {
+				t.Errorf("Aggregate() aggregatedUsed = %v, want %v", aggregatedUsed, tt.used)
+			}
+			if aggregatedPeak != tt.peak {
+				t.Errorf("Aggregate() aggregatedPeak = %v, want %v", aggregatedPeak, tt.peak)
+			}
+		})
+	}
+}
+
+func createCommodityDTO(commodityType proto.CommodityDTO_CommodityType, capacity, used, peak float64) *proto.CommodityDTO {
+	return &proto.CommodityDTO{
+		CommodityType: &commodityType,
+		Capacity:      &capacity,
+		Used:          &used,
+		Peak:          &peak,
+	}
+}

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
@@ -1,0 +1,92 @@
+package aggregation
+
+import (
+	"fmt"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"math"
+)
+
+var (
+	maxUtilizationDataStrategy = "maxUtilizationData"
+	allUtilizationDataStrategy = "allUtilizationData"
+
+	DefaultContainerUtilizationDataAggStrategy = maxUtilizationDataStrategy
+
+	// Map from the configured utilization data aggregation strategy to utilization data aggregator
+	ContainerUtilizationDataAggregators = map[string]ContainerUtilizationDataAggregator{
+		maxUtilizationDataStrategy: &maxUtilizationDataAggregator{aggregationStrategy: "max utilization data strategy"},
+		allUtilizationDataStrategy: &allUtilizationDataAggregator{aggregationStrategy: "all utilization data strategy"},
+	}
+)
+
+// ContainerUtilizationDataAggregator interface represents a type of container utilization data aggregator
+type ContainerUtilizationDataAggregator interface {
+	// AggregationStrategy returns aggregation strategy of this data aggregator
+	AggregationStrategy() string
+	// Aggregate aggregates commodities utilization data based on the given list of commodity DTOs of a commodity type
+	// and aggregation strategy, and returns aggregated utilization data which contains utilization data points, last
+	// point timestamp milliseconds and interval milliseconds
+	Aggregate(commodities []*proto.CommodityDTO, lastPointTimestampMs int64) ([]float64, int64, int32, error)
+}
+
+// ---------------- All utilization data aggregation strategy ----------------
+type allUtilizationDataAggregator struct {
+	aggregationStrategy string
+}
+
+func (allDataAggregator *allUtilizationDataAggregator) AggregationStrategy() string {
+	return allDataAggregator.aggregationStrategy
+}
+
+func (allDataAggregator *allUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO,
+	lastPointTimestampMs int64) ([]float64, int64, int32, error) {
+	if len(commodities) == 0 {
+		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty",
+			allDataAggregator.AggregationStrategy())
+		return []float64{}, 0, 0, err
+	}
+	var utilizationDataPoints []float64
+	for _, commodity := range commodities {
+		used := *commodity.Used
+		capacity := *commodity.Capacity
+		if capacity == 0.0 {
+			err := fmt.Errorf("error to aggregate %s commodities using %s : capacity is 0", commodity.CommodityType,
+				allDataAggregator.AggregationStrategy())
+			return []float64{}, 0, 0, err
+		}
+		utilization := used / capacity * 100
+		utilizationDataPoints = append(utilizationDataPoints, utilization)
+	}
+	return utilizationDataPoints, lastPointTimestampMs, 0, nil
+}
+
+// ---------------- Max utilization data aggregation strategy ----------------
+type maxUtilizationDataAggregator struct {
+	aggregationStrategy string
+}
+
+func (maxDataAggregator *maxUtilizationDataAggregator) AggregationStrategy() string {
+	return maxDataAggregator.aggregationStrategy
+}
+
+func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO,
+	lastPointTimestampMs int64) ([]float64, int64, int32, error) {
+	if len(commodities) == 0 {
+		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty",
+			maxDataAggregator.AggregationStrategy())
+		return []float64{}, 0, 0, err
+	}
+	maxUtilization := 0.0
+	for _, commodity := range commodities {
+		used := *commodity.Used
+		capacity := *commodity.Capacity
+		if capacity == 0.0 {
+			err := fmt.Errorf("error to aggregate %s commodities using %s : capacity is 0", commodity.CommodityType,
+				maxDataAggregator.AggregationStrategy())
+			return []float64{}, 0, 0, err
+		}
+		utilization := used / capacity * 100
+		maxUtilization = math.Max(utilization, maxUtilization)
+	}
+	return []float64{maxUtilization}, lastPointTimestampMs, 0, nil
+}

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
@@ -25,8 +25,7 @@ type ContainerUtilizationDataAggregator interface {
 	// AggregationStrategy returns aggregation strategy of this data aggregator
 	AggregationStrategy() string
 	// Aggregate aggregates commodities utilization data based on the given list of commodity DTOs of a commodity type
-	// and aggregation strategy, and returns aggregated utilization data which contains utilization data points, last
-	// point timestamp milliseconds and interval milliseconds
+	// and aggregation strategy, and returns aggregated utilization data points.
 	Aggregate(commodities []*proto.CommodityDTO) ([]float64, error)
 }
 

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator_test.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator_test.go
@@ -1,0 +1,111 @@
+package aggregation
+
+import (
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"reflect"
+	"testing"
+)
+
+func Test_allUtilizationDataAggregator_Aggregate(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		aggregationStrategy  string
+		commodities          []*proto.CommodityDTO
+		points               []float64
+		lastPointTimestampMs int64
+		intervalMs           int32
+		wantErr              bool
+	}{
+		{
+			name:                 "test aggregate all utilization data",
+			aggregationStrategy:  "all utilization data strategy",
+			commodities:          testCommodities,
+			points:               []float64{50.0, 75.0},
+			lastPointTimestampMs: 1588001640000,
+			intervalMs:           0,
+			wantErr:              false,
+		},
+		{
+			name:                 "test aggregate all utilization data with empty commodities",
+			aggregationStrategy:  "all utilization data strategy",
+			commodities:          emptyCommodities,
+			points:               []float64{},
+			lastPointTimestampMs: 0,
+			intervalMs:           0,
+			wantErr:              true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			allDataAggregator := &allUtilizationDataAggregator{
+				aggregationStrategy: tt.aggregationStrategy,
+			}
+			points, lastPointTimestampMs, intervalMs, err := allDataAggregator.Aggregate(tt.commodities, tt.lastPointTimestampMs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(points, tt.points) {
+				t.Errorf("Aggregate() got = %v, want %v", points, tt.points)
+			}
+			if lastPointTimestampMs != tt.lastPointTimestampMs {
+				t.Errorf("Aggregate() got1 = %v, want %v", lastPointTimestampMs, tt.lastPointTimestampMs)
+			}
+			if intervalMs != tt.intervalMs {
+				t.Errorf("Aggregate() got2 = %v, want %v", intervalMs, tt.intervalMs)
+			}
+		})
+	}
+}
+
+func Test_maxUtilizationDataAggregator_Aggregate(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		aggregationStrategy  string
+		commodities          []*proto.CommodityDTO
+		points               []float64
+		lastPointTimestampMs int64
+		intervalMs           int32
+		wantErr              bool
+	}{
+		{
+			name:                 "test aggregate max utilization data",
+			aggregationStrategy:  "max utilization data strategy",
+			commodities:          testCommodities,
+			points:               []float64{75.0},
+			lastPointTimestampMs: 1588001640000,
+			intervalMs:           0,
+			wantErr:              false,
+		},
+		{
+			name:                 "test aggregate all utilization data with empty commodities",
+			aggregationStrategy:  "all utilization data strategy",
+			commodities:          emptyCommodities,
+			points:               []float64{},
+			lastPointTimestampMs: 0,
+			intervalMs:           0,
+			wantErr:              true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			maxDataAggregator := &maxUtilizationDataAggregator{
+				aggregationStrategy: tt.aggregationStrategy,
+			}
+			points, lastPointTimestampMs, intervalMs, err := maxDataAggregator.Aggregate(tt.commodities, tt.lastPointTimestampMs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(points, tt.points) {
+				t.Errorf("Aggregate() got = %v, want %v", points, tt.points)
+			}
+			if lastPointTimestampMs != tt.lastPointTimestampMs {
+				t.Errorf("Aggregate() got1 = %v, want %v", lastPointTimestampMs, tt.lastPointTimestampMs)
+			}
+			if intervalMs != tt.intervalMs {
+				t.Errorf("Aggregate() got2 = %v, want %v", intervalMs, tt.intervalMs)
+			}
+		})
+	}
+}

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator_test.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator_test.go
@@ -8,31 +8,25 @@ import (
 
 func Test_allUtilizationDataAggregator_Aggregate(t *testing.T) {
 	testCases := []struct {
-		name                 string
-		aggregationStrategy  string
-		commodities          []*proto.CommodityDTO
-		points               []float64
-		lastPointTimestampMs int64
-		intervalMs           int32
-		wantErr              bool
+		name                string
+		aggregationStrategy string
+		commodities         []*proto.CommodityDTO
+		points              []float64
+		wantErr             bool
 	}{
 		{
-			name:                 "test aggregate all utilization data",
-			aggregationStrategy:  "all utilization data strategy",
-			commodities:          testCommodities,
-			points:               []float64{50.0, 75.0},
-			lastPointTimestampMs: 1588001640000,
-			intervalMs:           0,
-			wantErr:              false,
+			name:                "test aggregate all utilization data",
+			aggregationStrategy: "all utilization data strategy",
+			commodities:         testCommodities,
+			points:              []float64{50.0, 75.0},
+			wantErr:             false,
 		},
 		{
-			name:                 "test aggregate all utilization data with empty commodities",
-			aggregationStrategy:  "all utilization data strategy",
-			commodities:          emptyCommodities,
-			points:               []float64{},
-			lastPointTimestampMs: 0,
-			intervalMs:           0,
-			wantErr:              true,
+			name:                "test aggregate all utilization data with empty commodities",
+			aggregationStrategy: "all utilization data strategy",
+			commodities:         emptyCommodities,
+			points:              []float64{},
+			wantErr:             true,
 		},
 	}
 	for _, tt := range testCases {
@@ -40,19 +34,13 @@ func Test_allUtilizationDataAggregator_Aggregate(t *testing.T) {
 			allDataAggregator := &allUtilizationDataAggregator{
 				aggregationStrategy: tt.aggregationStrategy,
 			}
-			points, lastPointTimestampMs, intervalMs, err := allDataAggregator.Aggregate(tt.commodities, tt.lastPointTimestampMs)
+			points, err := allDataAggregator.Aggregate(tt.commodities)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(points, tt.points) {
 				t.Errorf("Aggregate() got = %v, want %v", points, tt.points)
-			}
-			if lastPointTimestampMs != tt.lastPointTimestampMs {
-				t.Errorf("Aggregate() got1 = %v, want %v", lastPointTimestampMs, tt.lastPointTimestampMs)
-			}
-			if intervalMs != tt.intervalMs {
-				t.Errorf("Aggregate() got2 = %v, want %v", intervalMs, tt.intervalMs)
 			}
 		})
 	}
@@ -60,31 +48,25 @@ func Test_allUtilizationDataAggregator_Aggregate(t *testing.T) {
 
 func Test_maxUtilizationDataAggregator_Aggregate(t *testing.T) {
 	testCases := []struct {
-		name                 string
-		aggregationStrategy  string
-		commodities          []*proto.CommodityDTO
-		points               []float64
-		lastPointTimestampMs int64
-		intervalMs           int32
-		wantErr              bool
+		name                string
+		aggregationStrategy string
+		commodities         []*proto.CommodityDTO
+		points              []float64
+		wantErr             bool
 	}{
 		{
-			name:                 "test aggregate max utilization data",
-			aggregationStrategy:  "max utilization data strategy",
-			commodities:          testCommodities,
-			points:               []float64{75.0},
-			lastPointTimestampMs: 1588001640000,
-			intervalMs:           0,
-			wantErr:              false,
+			name:                "test aggregate max utilization data",
+			aggregationStrategy: "max utilization data strategy",
+			commodities:         testCommodities,
+			points:              []float64{75.0},
+			wantErr:             false,
 		},
 		{
-			name:                 "test aggregate all utilization data with empty commodities",
-			aggregationStrategy:  "all utilization data strategy",
-			commodities:          emptyCommodities,
-			points:               []float64{},
-			lastPointTimestampMs: 0,
-			intervalMs:           0,
-			wantErr:              true,
+			name:                "test aggregate all utilization data with empty commodities",
+			aggregationStrategy: "all utilization data strategy",
+			commodities:         emptyCommodities,
+			points:              []float64{},
+			wantErr:             true,
 		},
 	}
 	for _, tt := range testCases {
@@ -92,19 +74,13 @@ func Test_maxUtilizationDataAggregator_Aggregate(t *testing.T) {
 			maxDataAggregator := &maxUtilizationDataAggregator{
 				aggregationStrategy: tt.aggregationStrategy,
 			}
-			points, lastPointTimestampMs, intervalMs, err := maxDataAggregator.Aggregate(tt.commodities, tt.lastPointTimestampMs)
+			points, err := maxDataAggregator.Aggregate(tt.commodities)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(points, tt.points) {
 				t.Errorf("Aggregate() got = %v, want %v", points, tt.points)
-			}
-			if lastPointTimestampMs != tt.lastPointTimestampMs {
-				t.Errorf("Aggregate() got1 = %v, want %v", lastPointTimestampMs, tt.lastPointTimestampMs)
-			}
-			if intervalMs != tt.intervalMs {
-				t.Errorf("Aggregate() got2 = %v, want %v", intervalMs, tt.intervalMs)
 			}
 		})
 	}


### PR DESCRIPTION
This is a continuous PR for https://github.com/turbonomic/kubeturbo/pull/408.

The intent here is to 
1. implement the `allUtilizationDataAggregator.Aggregate` and `maxUtilizationDataAggregator.Aggregate` functions in `container_utilization_data_aggregator.go` to populate shared utilization data on VCPU and VMem commodities for ContainerSpec entity.
2. implement the `avgUsageDataAggregator.Aggregate` and `maxUsageDataAggregator.Aggregate` functions in `container_usage_data_aggregator.go` to populate share used, peak and capacity data on VCPU and VMem commodities for ContainerSpec entity.

**Unit Tests**:
Create new unit tests to test the 4 functions.

**Testing Done**:
By default, we'll use "max utilization data strategy" to aggregate utilization data and "average usage data strategy" to aggregate usage data.
Tested with the changes https://github.com/turbonomic/kubeturbo/pull/408, an example of discovery DTO of ContainerSpec entity is:
```json
entityDTO {
  entityType: CONTAINER_SPEC
  id: "e933da8e-fb28-11e9-8fd6-005056803aed/openvswitch"
  displayName: "openvswitch"
  commoditiesSold {
    commodityType: VCPU
    used: 51.480816042460994
    capacity: 11987.000999999998
    peak: 51.480816042460994
    active: false
    utilizationData {
      point: 0.7080966750000001
      lastPointTimestampMs: 1588003737146
      intervalMs: 0
    }
  }
  commoditiesSold {
    commodityType: VMEM
    used: 65388.0
    capacity: 1.6266504E7
    peak: 65388.0
    active: false
    utilizationData {
      point: 0.5203962014667589
      lastPointTimestampMs: 1588003754218
      intervalMs: 0
    }
  }
  monitored: false
  actionEligibility {
  }
}
```

Note that the result is based on default "max utilization data strategy" and "average usage data strategy".

By programmatically changing the strategies to using "all utilization data strategy" to aggregate utilization data and "max usage data strategy" to aggregate usage data (capacity, used and peak), an example of discovery DTO of the same ContainerSpec entity is:
```json
entityDTO {
  entityType: CONTAINER_SPEC
  id: "e933da8e-fb28-11e9-8fd6-005056803aed/openvswitch"
  displayName: "openvswitch"
  commoditiesSold {
    commodityType: VCPU
    used: 54.239080467936
    capacity: 18646.446
    peak: 54.239080467936
    active: false
    utilizationData {
      point: 0.385514225
      point: 0.39761414999999994
      point: 0.5090428
      point: 0.30904732500000004
      point: 0.36527970000000004
      point: 0.1504104857142857
      lastPointTimestampMs: 1588008629978
      intervalMs: 0
    }
  }
  commoditiesSold {
    commodityType: VMEM
    used: 84636.0
    capacity: 1.6266604E7
    peak: 84636.0
    active: false
    utilizationData {
      point: 0.3749280426847966
      point: 0.37746084181882517
      point: 0.3730100006221342
      point: 0.3813949119312181
      point: 0.3845920238466727
      point: 0.5203224282598597
      lastPointTimestampMs: 1588008629978
      intervalMs: 0
    }
  }
  monitored: false
  actionEligibility {
  }
}
```