### PR TITLE
Make container utilization and usage data aggregation strategies configurable

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	agg "github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -99,6 +100,11 @@ type VMTServer struct {
 
 	// The Cluster API namespace
 	ClusterAPINamespace string
+
+	// Strategy to aggregate Container utilization data on ContainerSpec entity
+	containerUtilizationDataAggStrategy string
+	// Strategy to aggregate Container usage data on ContainerSpec entity
+	containerUsageDataAggStrategy string
 }
 
 // NewVMTServer creates a new VMTServer with default parameters
@@ -132,6 +138,8 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.ValidationTimeout, "validation-timeout-sec", defaultValidationTimeout, "The validation timeout in seconds")
 	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=* to allow all")
 	fs.StringVar(&s.ClusterAPINamespace, "cluster-api-namespace", "default", "The Cluster API namespace.")
+	fs.StringVar(&s.containerUtilizationDataAggStrategy, "cnt-utilization-data-agg-strategy", agg.DefaultContainerUtilizationDataAggStrategy, "Container utilization data aggregation strategy")
+	fs.StringVar(&s.containerUsageDataAggStrategy, "cnt-usage-data-agg-strategy", agg.DefaultContainerUsageDataAggStrategy, "Container usage data aggregation strategy")
 }
 
 // create an eventRecorder to send events to Kubernetes APIserver
@@ -273,7 +281,9 @@ func (s *VMTServer) Run() {
 		WithValidationTimeout(s.ValidationTimeout).
 		WithValidationWorkers(s.ValidationWorkers).
 		WithSccSupport(s.sccSupport).
-		WithCAPINamespace(s.ClusterAPINamespace)
+		WithCAPINamespace(s.ClusterAPINamespace).
+		WithContainerUtilizationDataAggStrategy(s.containerUtilizationDataAggStrategy).
+		WithContainerUsageDataAggStrategy(s.containerUsageDataAggStrategy)
 	glog.V(3).Infof("Finished creating turbo configuration: %+v", vmtConfig)
 
 	// The KubeTurbo TAP service

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
@@ -22,8 +22,7 @@ var (
 
 // ContainerUsageDataAggregator interface represents a type of container usage data aggregator
 type ContainerUsageDataAggregator interface {
-	// AggregationStrategy returns aggregation strategy of this data aggregator
-	AggregationStrategy() string
+	String() string
 	// Aggregate aggregates commodities usage data based on the given list of commodity DTOs of a commodity type and
 	// aggregation strategy, and returns aggregated capacity, used and peak values.
 	Aggregate(containerCommodities []*proto.CommodityDTO) (float64, float64, float64, error)
@@ -34,14 +33,13 @@ type avgUsageDataAggregator struct {
 	aggregationStrategy string
 }
 
-func (avgUsageDataAggregator *avgUsageDataAggregator) AggregationStrategy() string {
+func (avgUsageDataAggregator *avgUsageDataAggregator) String() string {
 	return avgUsageDataAggregator.aggregationStrategy
 }
 
 func (avgUsageDataAggregator *avgUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64, error) {
 	if len(commodities) == 0 {
-		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty",
-			avgUsageDataAggregator.AggregationStrategy())
+		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty", avgUsageDataAggregator)
 		return 0.0, 0.0, 0.0, err
 	}
 	capacitySum := 0.0
@@ -63,14 +61,13 @@ type maxUsageDataAggregator struct {
 	aggregationStrategy string
 }
 
-func (maxUsageDataAggregator *maxUsageDataAggregator) AggregationStrategy() string {
+func (maxUsageDataAggregator *maxUsageDataAggregator) String() string {
 	return maxUsageDataAggregator.aggregationStrategy
 }
 
 func (maxUsageDataAggregator *maxUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64, error) {
 	if len(commodities) == 0 {
-		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty",
-			maxUsageDataAggregator.AggregationStrategy())
+		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty", maxUsageDataAggregator)
 		return 0.0, 0.0, 0.0, err
 	}
 	maxCapacity := 0.0

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
@@ -22,8 +22,7 @@ var (
 
 // ContainerUtilizationDataAggregator interface represents a type of container utilization data aggregator
 type ContainerUtilizationDataAggregator interface {
-	// AggregationStrategy returns aggregation strategy of this data aggregator
-	AggregationStrategy() string
+	String() string
 	// Aggregate aggregates commodities utilization data based on the given list of commodity DTOs of a commodity type
 	// and aggregation strategy, and returns aggregated utilization data points.
 	Aggregate(commodities []*proto.CommodityDTO) ([]float64, error)
@@ -34,14 +33,13 @@ type allUtilizationDataAggregator struct {
 	aggregationStrategy string
 }
 
-func (allDataAggregator *allUtilizationDataAggregator) AggregationStrategy() string {
+func (allDataAggregator *allUtilizationDataAggregator) String() string {
 	return allDataAggregator.aggregationStrategy
 }
 
 func (allDataAggregator *allUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO) ([]float64, error) {
 	if len(commodities) == 0 {
-		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty",
-			allDataAggregator.AggregationStrategy())
+		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty", allDataAggregator)
 		return []float64{}, err
 	}
 	var utilizationDataPoints []float64
@@ -50,7 +48,7 @@ func (allDataAggregator *allUtilizationDataAggregator) Aggregate(commodities []*
 		capacity := *commodity.Capacity
 		if capacity == 0.0 {
 			err := fmt.Errorf("error to aggregate %s commodities using %s : capacity is 0", commodity.CommodityType,
-				allDataAggregator.AggregationStrategy())
+				allDataAggregator)
 			return []float64{}, err
 		}
 		utilization := used / capacity * 100
@@ -64,14 +62,13 @@ type maxUtilizationDataAggregator struct {
 	aggregationStrategy string
 }
 
-func (maxDataAggregator *maxUtilizationDataAggregator) AggregationStrategy() string {
+func (maxDataAggregator *maxUtilizationDataAggregator) String() string {
 	return maxDataAggregator.aggregationStrategy
 }
 
 func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO) ([]float64, error) {
 	if len(commodities) == 0 {
-		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty",
-			maxDataAggregator.AggregationStrategy())
+		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty", maxDataAggregator)
 		return []float64{}, err
 	}
 	maxUtilization := 0.0
@@ -80,7 +77,7 @@ func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(commodities []*
 		capacity := *commodity.Capacity
 		if capacity == 0.0 {
 			err := fmt.Errorf("error to aggregate %s commodities using %s : capacity is 0", commodity.CommodityType,
-				maxDataAggregator.AggregationStrategy())
+				maxDataAggregator)
 			return []float64{}, err
 		}
 		utilization := used / capacity * 100

--- a/pkg/discovery/worker/container_spec_discovery_worker.go
+++ b/pkg/discovery/worker/container_spec_discovery_worker.go
@@ -46,7 +46,7 @@ func (worker *k8sContainerSpecDiscoveryWorker) getContainerDataAggregators(utili
 			utilizationDataAggStrategy, agg.DefaultContainerUtilizationDataAggStrategy)
 		utilizationDataAggregator = agg.ContainerUtilizationDataAggregators[agg.DefaultContainerUtilizationDataAggStrategy]
 	}
-	glog.Infof("ContainerSpec will aggregate Containers utilization data by '%s'", utilizationDataAggregator.AggregationStrategy())
+	glog.Infof("ContainerSpec will aggregate Containers utilization data by '%s'", utilizationDataAggregator)
 
 	usageDataAggregator, exists := agg.ContainerUsageDataAggregators[usageDataAggStrategy]
 	if !exists {
@@ -54,7 +54,7 @@ func (worker *k8sContainerSpecDiscoveryWorker) getContainerDataAggregators(utili
 			usageDataAggStrategy, agg.DefaultContainerUsageDataAggStrategy)
 		usageDataAggregator = agg.ContainerUsageDataAggregators[agg.DefaultContainerUsageDataAggStrategy]
 	}
-	glog.Infof("ContainerSpec will aggregate Containers usage data by '%s'", usageDataAggregator.AggregationStrategy())
+	glog.Infof("ContainerSpec will aggregate Containers usage data by '%s'", usageDataAggregator)
 	return utilizationDataAggregator, usageDataAggregator
 }
 

--- a/pkg/discovery/worker/container_spec_discovery_worker.go
+++ b/pkg/discovery/worker/container_spec_discovery_worker.go
@@ -42,19 +42,19 @@ func (worker *k8sContainerSpecDiscoveryWorker) getContainerDataAggregators(utili
 	usageDataAggStrategy string) (agg.ContainerUtilizationDataAggregator, agg.ContainerUsageDataAggregator) {
 	utilizationDataAggregator, exists := agg.ContainerUtilizationDataAggregators[utilizationDataAggStrategy]
 	if !exists {
-		glog.Errorf("Container utilization data aggregation strategy %s is not supported. Use default % strategy",
+		glog.Errorf("Container utilization data aggregation strategy '%s' is not supported. Use default '%s' strategy",
 			utilizationDataAggStrategy, agg.DefaultContainerUtilizationDataAggStrategy)
 		utilizationDataAggregator = agg.ContainerUtilizationDataAggregators[agg.DefaultContainerUtilizationDataAggStrategy]
 	}
-	glog.Infof("ContainerSpec will aggregate Containers utilization data by %s", utilizationDataAggregator.AggregationStrategy())
+	glog.Infof("ContainerSpec will aggregate Containers utilization data by '%s'", utilizationDataAggregator.AggregationStrategy())
 
 	usageDataAggregator, exists := agg.ContainerUsageDataAggregators[usageDataAggStrategy]
 	if !exists {
-		glog.Errorf("Container usage data aggregation strategy %s is not supported. Use default % strategy",
+		glog.Errorf("Container usage data aggregation strategy '%s' is not supported. Use default '%s' strategy",
 			usageDataAggStrategy, agg.DefaultContainerUsageDataAggStrategy)
 		usageDataAggregator = agg.ContainerUsageDataAggregators[agg.DefaultContainerUsageDataAggStrategy]
 	}
-	glog.Infof("ContainerSpec will aggregate Containers usage data by %s", usageDataAggregator.AggregationStrategy())
+	glog.Infof("ContainerSpec will aggregate Containers usage data by '%s'", usageDataAggregator.AggregationStrategy())
 	return utilizationDataAggregator, usageDataAggregator
 }
 

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -153,7 +153,8 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	registrationClientConfig := registration.NewRegistrationClientConfig(config.StitchingPropType, config.VMPriority, config.VMIsBase)
 
 	probeConfig := createProbeConfigOrDie(config)
-	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig, config.ValidationWorkers, config.ValidationTimeoutSec)
+	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig, config.ValidationWorkers,
+		config.ValidationTimeoutSec, config.containerUtilizationDataAggStrategy, config.containerUsageDataAggStrategy)
 
 	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.KubeClient, config.KubeletClient, config.DynamicClient, config.SccSupport)
 

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -33,6 +33,11 @@ type Config struct {
 
 	SccSupport    []string
 	CAPINamespace string
+
+	// Strategy to aggregate Container utilization data on ContainerSpec entity
+	containerUtilizationDataAggStrategy string
+	// Strategy to aggregate Container usage data on ContainerSpec entity
+	containerUsageDataAggStrategy string
 }
 
 func NewVMTConfig2() *Config {
@@ -110,5 +115,15 @@ func (c *Config) WithSccSupport(sccSupport []string) *Config {
 
 func (c *Config) WithCAPINamespace(CAPINamespace string) *Config {
 	c.CAPINamespace = CAPINamespace
+	return c
+}
+
+func (c *Config) WithContainerUtilizationDataAggStrategy(containerUtilizationDataAggStrategy string) *Config {
+	c.containerUtilizationDataAggStrategy = containerUtilizationDataAggStrategy
+	return c
+}
+
+func (c *Config) WithContainerUsageDataAggStrategy(containerUsageDataAggStrategy string) *Config {
+	c.containerUsageDataAggStrategy = containerUsageDataAggStrategy
 	return c
 }


### PR DESCRIPTION
**Background**:
We aggregate the Containers utilization and usage data to ContainerSpec entities so as to take the historical utilization and usage data into account when resizing Containers.

1. The utilization data are aggregated and persisted to be used in the resize algorithm with respect to 95th percentile utilization. We have 2 different strategies to aggregate utilization data:
* all utilization data of container replicas, which is the default aggregation strategy;
* max utilization data of container replicas.
2. The usage data (used, peak and capacity) are aggregated and persisted for the normal resize algorithm with respect to the moving average usage. We also have 2 different strategies to aggregate usage data:
* average usage data of container replicas, which is the default aggregation strategy;
* max usage data of container replicas.

For testing purpose, we want to make the 2 sets of aggregation strategies configurable so that we can see if we need to adjust the default ones.

**Implementation**:
Since the configurable is mainly for testing purpose and we don't want to expose this to customers, we want to make use of the arguments when starting kubeturbo server. 

I added 2 arguments `cnt-utilization-data-agg-strategy` and `cnt-usage-data-agg-strategy` with default values. They are stored in `DiscoveryClientConfig` and will be finally used in `k8s_discovery_client.go` when creating ContainerSpec entity DTOs.

So
* By default, without specifying `cnt-utilization-data-agg-strategy` and `cnt-usage-data-agg-strategy` arguments, we'll use default aggregation strategies ("allUtilizationData" and "avgUsageData");
* When specifying supported strategies on `cnt-utilization-data-agg-strategy` and `cnt-usage-data-agg-strategy`, we'll use the corresponding strategies;
* When specifying unsupported strategies, we'll use default ones.

**Testing Done**:
1. Started kubeturbo without specifying these 2 arguments. Default strategies were used with the following log messages:
```
I0428 21:15:20.908744       1 container_spec_discovery_worker.go:49] ContainerSpec will aggregate Containers utilization data by 'all utilization data strategy'
I0428 21:15:20.908762       1 container_spec_discovery_worker.go:57] ContainerSpec will aggregate Containers usage data by 'average usage data strategy'
```
and corresponding proper data were collected.

2. Started kubeturbo by specifying supported strategies under the args in the deployment yaml like:
```
args:
    - --cnt-utilization-data-agg-strategy=maxUtilizationData
    - --cnt-usage-data-agg-strategy=maxUsageData
```
Then corresponding strategies were configured with following log messages:
```
I0428 21:19:52.155428       1 container_spec_discovery_worker.go:49] ContainerSpec will aggregate Containers utilization data by 'max utilization data strategy'
I0428 21:19:52.155452       1 container_spec_discovery_worker.go:57] ContainerSpec will aggregate Containers usage data by 'max usage data strategy'
```

3. Started kubeturbo by specifying unsupported strategies under the args in the deployment yaml like:
```
args:
    - --cnt-utilization-data-agg-strategy=test
    - --cnt-usage-data-agg-strategy=test
```
Default strategies were used with following messages:
```
E0428 21:18:08.956463       1 container_spec_discovery_worker.go:45] Container utilization data aggregation strategy 'test' is not supported. Use default 'allUtilizationData' strategy
I0428 21:18:08.956479       1 container_spec_discovery_worker.go:49] ContainerSpec will aggregate Containers utilization data by 'all utilization data strategy'
E0428 21:18:08.956489       1 container_spec_discovery_worker.go:53] Container usage data aggregation strategy 'test' is not supported. Use default 'avgUsageData' strategy
I0428 21:18:08.956506       1 container_spec_discovery_worker.go:57] ContainerSpec will aggregate Containers usage data by 'average usage data strategy'
```