### PR TITLE
Set ContainerSpec commodities resizable as true in new container model

### DIFF
--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -97,7 +97,13 @@ func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpec *reposi
 		commSoldBuilder.Peak(aggregatedPeak)
 		commSoldBuilder.Used(aggregatedUsed)
 
-		// ContainerSpec sells inactive commodities
+		// Commodities sold by ContainerSpec entities have resizable flag as true so as to update resizable flag to
+		// the commodities sold by corresponding Container entities in the server side when taking historical percentile
+		// utilization data into consideration for resizing.
+		commSoldBuilder.Resizable(true)
+
+		// Commodities sold by ContainerSpec entities are inactive because they won't be analyzed directly in Market
+		// analysis engine.
 		commSoldBuilder.Active(false)
 		commSold, err := commSoldBuilder.Create()
 		if err != nil {

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
@@ -41,6 +41,7 @@ func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
 	assert.Equal(t, 2, len(commodityDTOs))
 	for _, commodityDTO := range commodityDTOs {
 		assert.Equal(t, false, *commodityDTO.Active)
+		assert.Equal(t, true, *commodityDTO.Resizable)
 		// Parse values to int to avoid tolerance of float values
 		assert.Equal(t, 2, int(*commodityDTO.Used))
 		assert.Equal(t, 2, int(*commodityDTO.Peak))


### PR DESCRIPTION
**Problem**:
In testing changes for the new container model, we noticed an unexpectedly large reduction in the number of resize actions we were getting on containers vs with the old container model.

It turns out that with the new container model, we expected the probe to be able to send ContainerSpec commodities without setting the resizable flag on the commodities it was selling. Then the resizable flag might be set at a later point in the topology-processor if it had insufficient data to meet the minimum observation period. This value could then be transferred onto containers only if it was set.

However, we see that in practice the topology-processor blindly copies the resizable value from SDK DTO onto TopologyDTO even when it is not set, resulting in the transfer of the default value of false. As a result, we cannot rely on this value being unset later in the pipeline and we have to:
1. Have the probe set resizable=true on ContainerSpec commodities.
2. update the logic that copies this flag from ContainerSpec commodities onto Container commodities to only override the Container resizable value when the Container value is unset or true.

**Implementation**:
The changes here are setting ContainerSpec commodities resizable as true during discovery in kubeturbo.
Further changes will be made in the server side by @dblinn.

**Testing Done**:
Tested the kubeturbo changes along with the new changes in the server side.

* **Before the fix**, with new container model we have much less resize actions than using the old model:
<img width="617" alt="Screen Shot 2020-04-29 at 09 06 17" src="https://user-images.githubusercontent.com/23689754/80648865-f1f21100-8a3e-11ea-874e-acca7a2682b2.png">

* **After the fix**, with new container model we have more reasonable number of resize actions:
![Screen Shot 2020-04-29 at 17 12 12](https://user-images.githubusercontent.com/23689754/80648943-13eb9380-8a3f-11ea-8a81-1dff94e87ace.png)
