### PR TITLE
Add reservation values back to commodities bought by container and pod

### DIFF
--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -265,6 +265,8 @@ func (m *ClusterMonitor) genPodMetrics(pod *api.Pod, nodeCPUCapacity, nodeMemCap
 	podCPURequest, podMemRequest := m.genContainerMetrics(pod, cpuCapacity, memCapacity)
 	//2.2 Generate capacity metric for CPURequest and MemRequest. Pod requests capacity is node Allocatable
 	m.genRequestCapacityMetrics(metrics.PodType, podMId, nodeCPUAllocatable, nodeMemAllocatable)
+	// TODO remove genReservationMetrics once we have full support to resize requests commodities
+	m.genReservationMetrics(metrics.PodType, podMId, podCPURequest, podMemRequest)
 	//2.3 Generate used metric for CPURequest and MemRequest
 	m.genRequestUsedMetrics(metrics.PodType, podMId, podCPURequest, podMemRequest)
 
@@ -315,6 +317,8 @@ func (m *ClusterMonitor) genContainerMetrics(pod *api.Pod, podCPU, podMem float6
 		m.genRequestCapacityMetrics(metrics.ContainerType, containerMId, cpuRequest, memRequest)
 		// Generate resource request quota metrics with used value as CPU/memory resource request capacity
 		m.genRequestQuotaUsedMetrics(metrics.ContainerType, containerMId, cpuRequest, memRequest)
+		// TODO remove genReservationMetrics once we have full support to resize requests commodities
+		m.genReservationMetrics(metrics.ContainerType, containerMId, cpuRequest, memRequest)
 
 		totalCPURequest += cpuRequest
 		totalMemRequest += memRequest
@@ -372,6 +376,15 @@ func (m *ClusterMonitor) genLimitQuotaUsedMetrics(etype metrics.DiscoveredEntity
 func (m *ClusterMonitor) genRequestQuotaUsedMetrics(etype metrics.DiscoveredEntityType, key string, cpu, memory float64) {
 	cpuMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPURequestQuota, metrics.Used, cpu)
 	memMetric := metrics.NewEntityResourceMetric(etype, key, metrics.MemoryRequestQuota, metrics.Used, memory)
+	m.sink.AddNewMetricEntries(cpuMetric, memMetric)
+}
+
+// TODO remove this function of generating reservation (request) metrics on VCPU and VMemory commodities once we implement
+// the full support to resize requests commodities
+// genReservationMetrics generates reservation (equivalent of request) metrics for VCPU and VMemory commodity
+func (m *ClusterMonitor) genReservationMetrics(etype metrics.DiscoveredEntityType, key string, cpu, memory float64) {
+	cpuMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPU, metrics.Reservation, cpu)
+	memMetric := metrics.NewEntityResourceMetric(etype, key, metrics.Memory, metrics.Reservation, memory)
 	m.sink.AddNewMetricEntries(cpuMetric, memMetric)
 }
 


### PR DESCRIPTION
We used to generate resizing reservation action to model resizing of requests. In new container model, we plan to generate resizing requests action based on the requests commodities so reservation values on VCPU and VMem commodities bought by Container and Pod have been removed from probe discovery in a previous review.

However proper market analysis support for resizing requests commodities won't be available until 7.22.1. To avoid regression issue of missing resizing reservation in 7.22.0 release, we decide to put the reservation values back in kubeturbo.

**Testing Done**:
After the changes, reservation values on VCPU and VMem bought by Container and Pod are set, for example, in the following discovery dto of a Container:
```json
entityDTO {
  entityType: CONTAINER
  id: "1782c430-fb2e-11e9-97cf-005056803564-1"
  displayName: "openshift-monitoring/node-exporter-z2qph/kube-rbac-proxy"
  ...
    commoditiesBought {
    providerId: "1782c430-fb2e-11e9-97cf-005056803564"
    bought {
      commodityType: VCPU
      used: 0.30341230553399995
      reservation: 26.63778
      peak: 0.30341230553399995
      resizable: true
    }
    bought {
      commodityType: VMEM
      used: 12392.0
      reservation: 20480.0
      peak: 12392.0
      resizable: true
    }
```
```json
entityDTO {
  entityType: CONTAINER_POD
  id: "2d8877bf-1c28-11ea-bd96-005056803564"
  displayName: "openshift-sdn/ovs-z7g8c"
  ...
  commoditiesBought {
    providerId: "2f10110c-fb29-11e9-9b78-0050568018c4"
    bought {
      commodityType: VCPU
      used: 63.942296727191994
      reservation: 266.3778
      peak: 63.942296727191994
    }
    bought {
      commodityType: VMEM
      used: 85156.0
      reservation: 307200.0
      peak: 85156.0
    }
```
And "resizing down reservation" actions can be regenerated:
<img width="1295" alt="Screen Shot 2020-04-30 at 09 36 56" src="https://user-images.githubusercontent.com/23689754/80719418-75584480-8ac9-11ea-97ce-8bb822f63d1a.png">

And these resizing reservation actions are exactly the same as those generated in the old model.