### PR TITLE
Use milicore values in place of Mhz for cpu commodities

### DIFF
--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -67,13 +67,8 @@ func (r *ContainerResizer) getNodeCPUFrequency(host string) (float64, error) {
 	return r.kubeletClient.GetNodeCpuFrequency(node)
 }
 
-func (r *ContainerResizer) setCPUQuantity(cpuMhz float64, host string, rlist k8sapi.ResourceList) error {
-	nodeCpuFrequency, err := r.getNodeCPUFrequency(host)
-	if err != nil {
-		return fmt.Errorf("failed to get node[%s] cpu frequency: %v", host, err)
-	}
-
-	cpuQuantity, err := genCPUQuantity(cpuMhz, nodeCpuFrequency)
+func (r *ContainerResizer) setCPUQuantity(milicores float64, host string, rlist k8sapi.ResourceList) error {
+	cpuQuantity, err := genCPUMilicoreQuantity(milicores)
 	if err != nil {
 		return fmt.Errorf("failed to generate CPU quantity: %v", err)
 	}
@@ -85,7 +80,7 @@ func (r *ContainerResizer) setCPUQuantity(cpuMhz float64, host string, rlist k8s
 func (r *ContainerResizer) buildResourceList(pod *k8sapi.Pod, cType proto.CommodityDTO_CommodityType,
 	amount float64, result k8sapi.ResourceList) error {
 	switch cType {
-	case proto.CommodityDTO_VCPU:
+	case proto.CommodityDTO_VCPU_MILICORE:
 		host := pod.Spec.NodeName
 		err := r.setCPUQuantity(amount, host, result)
 		if err != nil {

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -136,11 +136,15 @@ func updateResourceAmount(podSpec *k8sapi.PodSpec, spec *containerResizeSpec) (b
 func genCPUQuantity(newValue float64, nodeCpuFrequency float64) (resource.Quantity, error) {
 	tmp := newValue * 1000 // to milliSeconds
 	tmp = tmp / nodeCpuFrequency
-	cpuTime := int(math.Ceil(tmp))
-	if cpuTime < 1 {
-		cpuTime = 1
+	return genCPUMilicoreQuantity(tmp)
+}
+
+func genCPUMilicoreQuantity(miliValue float64) (resource.Quantity, error) {
+	miliValueWhole := int(math.Ceil(miliValue))
+	if miliValueWhole < 1 {
+		miliValueWhole = 1
 	}
-	return resource.ParseQuantity(fmt.Sprintf("%dm", cpuTime))
+	return resource.ParseQuantity(fmt.Sprintf("%dm", miliValueWhole))
 }
 
 // generate a resource.Quantity for Memory

--- a/pkg/discovery/dtofactory/container_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_dto_builder_test.go
@@ -2,6 +2,9 @@ package dtofactory
 
 import (
 	"fmt"
+	"reflect"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
@@ -10,8 +13,6 @@ import (
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
-	"testing"
 )
 
 var (
@@ -28,7 +29,7 @@ var (
 	memCap           = 3.0
 	nodeCpuFrequency = 2048.0
 
-	cpuCommType = proto.CommodityDTO_VCPU
+	cpuCommType = proto.CommodityDTO_VCPU_MILICORE
 	memCommType = proto.CommodityDTO_VMEM
 
 	testPod = &api.Pod{
@@ -43,17 +44,17 @@ var (
 	}
 
 	containerFooCPUUsed = metrics.NewEntityResourceMetric(metrics.ContainerType,
-		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameFoo), metrics.CPU, metrics.Used, cpuUsed)
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameFoo), metrics.CPUMili, metrics.Used, cpuUsed)
 	containerFooCPUCap = metrics.NewEntityResourceMetric(metrics.ContainerType,
-		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameFoo), metrics.CPU, metrics.Capacity, cpuCap)
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameFoo), metrics.CPUMili, metrics.Capacity, cpuCap)
 	containerFooMemUsed = metrics.NewEntityResourceMetric(metrics.ContainerType,
 		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameFoo), metrics.Memory, metrics.Used, memUsed)
 	containerFooMemCap = metrics.NewEntityResourceMetric(metrics.ContainerType,
 		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameFoo), metrics.Memory, metrics.Capacity, memCap)
 	containerBarCPUUsed = metrics.NewEntityResourceMetric(metrics.ContainerType,
-		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameBar), metrics.CPU, metrics.Used, cpuUsed)
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameBar), metrics.CPUMili, metrics.Used, cpuUsed)
 	containerBarCPUCap = metrics.NewEntityResourceMetric(metrics.ContainerType,
-		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameBar), metrics.CPU, metrics.Capacity, cpuCap)
+		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameBar), metrics.CPUMili, metrics.Capacity, cpuCap)
 	containerBarMemUsed = metrics.NewEntityResourceMetric(metrics.ContainerType,
 		util.ContainerMetricId(util.PodMetricIdAPI(testPod), containerNameBar), metrics.Memory, metrics.Used, memUsed)
 	containerBarMemCap = metrics.NewEntityResourceMetric(metrics.ContainerType,
@@ -152,9 +153,9 @@ func Test_containerDTOBuilder_BuildDTOs_withContainerSpec(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(containerSpecs))
 
-	cpuUsedFreq := cpuUsed * nodeCpuFrequency
-	cpuPeakFreq := cpuUsed * nodeCpuFrequency
-	cpuCapFreq := cpuCap * nodeCpuFrequency
+	cpuUsedFreq := cpuUsed
+	cpuPeakFreq := cpuUsed
+	cpuCapFreq := cpuCap
 	commIsResizable := false
 	expectedContainerSpec := &repository.ContainerSpec{
 		Namespace:         namespace,

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -1,17 +1,18 @@
 package dtofactory
 
 import (
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-	"time"
 )
 
 var (
 	ContainerSpecCommoditiesSold = []proto.CommodityDTO_CommodityType{
-		proto.CommodityDTO_VCPU,
+		proto.CommodityDTO_VCPU_MILICORE,
 		proto.CommodityDTO_VMEM,
 	}
 )

--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -14,7 +14,7 @@ import (
 var (
 	// This map maps resource type to commodity types defined in ProtoBuf.
 	rTypeMapping = map[metrics.ResourceType]proto.CommodityDTO_CommodityType{
-		metrics.CPU:                proto.CommodityDTO_VCPU,
+		metrics.CPUMili:            proto.CommodityDTO_VCPU_MILICORE,
 		metrics.Memory:             proto.CommodityDTO_VMEM,
 		metrics.CPURequest:         proto.CommodityDTO_VCPU_REQUEST,
 		metrics.MemoryRequest:      proto.CommodityDTO_VMEM_REQUEST,
@@ -136,11 +136,6 @@ func (builder generalBuilder) getSoldResourceCommodityWithKey(entityType metrics
 	cType, exist := rTypeMapping[resourceType]
 	if !exist {
 		return nil, fmt.Errorf("unsupported commodity type %s", resourceType)
-	}
-
-	// check for the unit converter for cpu resources
-	if metrics.IsCPUType(resourceType) && converter == nil {
-		return nil, fmt.Errorf("missing cpu converter")
 	}
 
 	commSoldBuilder := sdkbuilder.NewCommodityDTOBuilder(cType)
@@ -267,11 +262,6 @@ func (builder generalBuilder) getResourceCommodityBoughtWithKey(entityType metri
 	cType, exist := rTypeMapping[resourceType]
 	if !exist {
 		return nil, fmt.Errorf("unsupported commodity type %s", resourceType)
-	}
-
-	// check for the unit converter for cpu resources
-	if metrics.IsCPUType(resourceType) && converter == nil {
-		return nil, fmt.Errorf("missing cpu converter")
 	}
 
 	commBoughtBuilder := sdkbuilder.NewCommodityDTOBuilder(cType)

--- a/pkg/discovery/dtofactory/general_builder_test.go
+++ b/pkg/discovery/dtofactory/general_builder_test.go
@@ -2,10 +2,11 @@ package dtofactory
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-	"testing"
 )
 
 var (
@@ -14,24 +15,22 @@ var (
 
 	metricsSink = metrics.NewEntityMetricSink()
 
-	cpuUsed_pod1 = metrics.NewEntityResourceMetric(metrics.PodType, pod1, metrics.CPU, metrics.Used, 1.0)
+	cpuUsed_pod1 = metrics.NewEntityResourceMetric(metrics.PodType, pod1, metrics.CPUMili, metrics.Used, 1.0)
 	memUsed_pod1 = metrics.NewEntityResourceMetric(metrics.PodType, pod1, metrics.Memory, metrics.Used, 8010812.000000/8)
 
-	cpuCap_pod1 = metrics.NewEntityResourceMetric(metrics.PodType, pod1, metrics.CPU, metrics.Capacity, 2.0)
+	cpuCap_pod1 = metrics.NewEntityResourceMetric(metrics.PodType, pod1, metrics.CPUMili, metrics.Capacity, 2.0)
 	memCap_pod1 = metrics.NewEntityResourceMetric(metrics.PodType, pod1, metrics.Memory, metrics.Capacity, 8010812.000000/4)
 
-	cpuCap_node1  = metrics.NewEntityResourceMetric(metrics.NodeType, node1, metrics.CPU, metrics.Capacity, 4.0)
-	cpuUsed_node1 = metrics.NewEntityResourceMetric(metrics.NodeType, node1, metrics.CPU, metrics.Used, 2.0)
+	cpuCap_node1  = metrics.NewEntityResourceMetric(metrics.NodeType, node1, metrics.CPUMili, metrics.Capacity, 4.0)
+	cpuUsed_node1 = metrics.NewEntityResourceMetric(metrics.NodeType, node1, metrics.CPUMili, metrics.Used, 2.0)
 
 	memCap_node1  = metrics.NewEntityResourceMetric(metrics.NodeType, node1, metrics.Memory, metrics.Capacity, 8010812.000000)
 	memUsed_node1 = metrics.NewEntityResourceMetric(metrics.NodeType, node1, metrics.Memory, metrics.Used, 8010812.000000/4)
 
 	cpuFrequency = 2048.0
 	cpuConverter = NewConverter().Set(
-		func(input float64) float64 {
-			return input * cpuFrequency
-		},
-		metrics.CPU)
+		nil,
+		metrics.CPUMili)
 )
 
 func TestBuildCPUSold(t *testing.T) {
@@ -43,14 +42,14 @@ func TestBuildCPUSold(t *testing.T) {
 	}
 
 	eType := metrics.PodType
-	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPU, "", cpuConverter, nil)
+	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPUMili, "", nil, nil)
 	fmt.Printf("%++v\n", commSold)
 	fmt.Printf("%++v\n", err)
 	assert.Nil(t, err)
 	assert.NotNil(t, commSold)
-	assert.Equal(t, proto.CommodityDTO_VCPU, commSold.GetCommodityType())
-	capacityValue := cpuConverter.Convert(metrics.CPU, cpuCap_pod1.GetValue().(float64))
-	usedValue := cpuConverter.Convert(metrics.CPU, cpuUsed_pod1.GetValue().(float64))
+	assert.Equal(t, proto.CommodityDTO_VCPU_MILICORE, commSold.GetCommodityType())
+	capacityValue := cpuCap_pod1.GetValue().(float64)
+	usedValue := cpuUsed_pod1.GetValue().(float64)
 	assert.Equal(t, usedValue, commSold.GetUsed())
 	assert.Equal(t, capacityValue, commSold.GetCapacity())
 }
@@ -95,7 +94,7 @@ func TestBuildCPUSoldWithMissingCap(t *testing.T) {
 	dtoBuilder := &generalBuilder{
 		metricsSink: metricsSink,
 	}
-	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPU, "", cpuConverter, nil)
+	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPUMili, "", nil, nil)
 	assert.Nil(t, commSold)
 	assert.NotNil(t, err)
 }
@@ -108,19 +107,7 @@ func TestBuildCPUSoldWithMissingUsed(t *testing.T) {
 	dtoBuilder := &generalBuilder{
 		metricsSink: metricsSink,
 	}
-	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPU, "", cpuConverter, nil)
-	assert.Nil(t, commSold)
-	assert.NotNil(t, err)
-}
-
-func TestBuildCPUSoldWithMissingConverter(t *testing.T) {
-	eType := metrics.PodType
-	metricsSink = metrics.NewEntityMetricSink()
-	metricsSink.AddNewMetricEntries(cpuUsed_pod1, cpuCap_pod1)
-	dtoBuilder := &generalBuilder{
-		metricsSink: metricsSink,
-	}
-	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPU, "", nil, nil)
+	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPUMili, "", nil, nil)
 	assert.Nil(t, commSold)
 	assert.NotNil(t, err)
 }
@@ -150,8 +137,8 @@ func TestBuildCommSold(t *testing.T) {
 	}
 
 	eType := metrics.PodType
-	resourceTypesList := []metrics.ResourceType{metrics.CPU, metrics.Memory}
-	commSoldList, err := dtoBuilder.getResourceCommoditiesSold(eType, pod1, resourceTypesList, cpuConverter, nil)
+	resourceTypesList := []metrics.ResourceType{metrics.CPUMili, metrics.Memory}
+	commSoldList, err := dtoBuilder.getResourceCommoditiesSold(eType, pod1, resourceTypesList, nil, nil)
 	commMap := make(map[proto.CommodityDTO_CommodityType]*proto.CommodityDTO)
 
 	for _, commSold := range commSoldList {
@@ -176,8 +163,8 @@ func TestBuildCommBought(t *testing.T) {
 	}
 
 	eType := metrics.PodType
-	resourceTypesList := []metrics.ResourceType{metrics.CPU, metrics.Memory}
-	commBoughtList, err := dtoBuilder.getResourceCommoditiesBought(eType, pod1, resourceTypesList, cpuConverter, nil)
+	resourceTypesList := []metrics.ResourceType{metrics.CPUMili, metrics.Memory}
+	commBoughtList, err := dtoBuilder.getResourceCommoditiesBought(eType, pod1, resourceTypesList, nil, nil)
 	commMap := make(map[proto.CommodityDTO_CommodityType]*proto.CommodityDTO)
 
 	for _, commBought := range commBoughtList {

--- a/pkg/discovery/dtofactory/namespace_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/namespace_entity_dto_builder_test.go
@@ -2,6 +2,8 @@ package dtofactory
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
@@ -10,7 +12,6 @@ import (
 	k8sres "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
 )
 
 const CPUFrequency float64 = 2663.778000
@@ -137,7 +138,7 @@ func makeKubeNamespaces() []*repository.KubeNamespace {
 	var kubeQuotas []*repository.KubeNamespace
 	resourceMap := make(map[metrics.ResourceType]float64)
 	for _, node := range TestNodes {
-		resourceMap[metrics.CPU] = resourceMap[metrics.CPU] + node.cpuCap
+		resourceMap[metrics.CPUMili] = resourceMap[metrics.CPUMili] + node.cpuCap
 		resourceMap[metrics.Memory] = resourceMap[metrics.Memory] + node.memCap
 		resourceMap[metrics.CPURequest] = resourceMap[metrics.CPURequest] + node.cpuCap
 		resourceMap[metrics.MemoryRequest] = resourceMap[metrics.MemoryRequest] + node.memCap

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -22,7 +22,7 @@ const (
 
 var (
 	nodeResourceCommoditiesSold = []metrics.ResourceType{
-		metrics.CPU,
+		metrics.CPUMili,
 		metrics.Memory,
 		metrics.CPURequest,
 		metrics.MemoryRequest,
@@ -40,10 +40,10 @@ var (
 
 	// List of commodities and a boolean indicating if the commodity should be resized
 	resizableCommodities = map[proto.CommodityDTO_CommodityType]bool{
-		proto.CommodityDTO_VCPU:         false,
-		proto.CommodityDTO_VMEM:         false,
-		proto.CommodityDTO_VCPU_REQUEST: false,
-		proto.CommodityDTO_VMEM_REQUEST: false,
+		proto.CommodityDTO_VCPU_MILICORE: false,
+		proto.CommodityDTO_VMEM:          false,
+		proto.CommodityDTO_VCPU_REQUEST:  false,
+		proto.CommodityDTO_VMEM_REQUEST:  false,
 	}
 )
 
@@ -163,19 +163,9 @@ func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node) ([]*
 	var commoditiesSold []*proto.CommodityDTO
 	// get cpu frequency
 	key := util.NodeKeyFunc(node)
-	cpuFrequency, err := builder.getNodeCPUFrequency(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cpu frequency from sink for node %s: %s", key, err)
-	}
-	// cpu and cpu request needs to be converted from number of cores to frequency.
-	converter := NewConverter().Set(
-		func(input float64) float64 {
-			return input * cpuFrequency
-		},
-		metrics.CPU, metrics.CPURequest)
 
 	// Resource Commodities
-	resourceCommoditiesSold, err := builder.getResourceCommoditiesSold(metrics.NodeType, key, nodeResourceCommoditiesSold, converter, nil)
+	resourceCommoditiesSold, err := builder.getResourceCommoditiesSold(metrics.NodeType, key, nodeResourceCommoditiesSold, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -3,11 +3,12 @@ package dtofactory
 import (
 	"testing"
 
+	"reflect"
+
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 )
 
 var builder = &podEntityDTOBuilder{
@@ -23,7 +24,7 @@ func Test_podEntityDTOBuilder_getPodCommoditiesBought_Error(t *testing.T) {
 }
 
 func Test_podEntityDTOBuilder_getPodCommoditiesBoughtFromQuota_Error(t *testing.T) {
-	if _, err := builder.getQuotaCommoditiesBought("quota1", &api.Pod{}, 100.0); err == nil {
+	if _, err := builder.getQuotaCommoditiesBought("quota1", &api.Pod{}); err == nil {
 		t.Errorf("Error thrown expected")
 	}
 }
@@ -72,8 +73,8 @@ func Test_podEntityDTOBuilder_createContainerPodData(t *testing.T) {
 	}
 }
 
-func testGetCommoditiesWithError(t *testing.T, f func(pod *api.Pod, cpuFrequency float64) ([]*proto.CommodityDTO, error)) {
-	if _, err := f(&api.Pod{}, 100.0); err == nil {
+func testGetCommoditiesWithError(t *testing.T, f func(pod *api.Pod) ([]*proto.CommodityDTO, error)) {
+	if _, err := f(&api.Pod{}); err == nil {
 		t.Errorf("Error thrown expected")
 	}
 }

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -21,6 +21,7 @@ const (
 
 const (
 	CPU                ResourceType = "CPU"
+	CPUMili            ResourceType = "VCPUMili"
 	Memory             ResourceType = "Memory"
 	CPURequest         ResourceType = "CPURequest"
 	MemoryRequest      ResourceType = "MemoryRequest"
@@ -45,7 +46,7 @@ const (
 var (
 	// Mapping of Kubernetes API Server resource names to the compute resource types
 	KubeComputeResourceTypes = map[v1.ResourceName][]ResourceType{
-		v1.ResourceCPU:    {CPU, CPURequest},
+		v1.ResourceCPU:    {CPUMili, CPURequest},
 		v1.ResourceMemory: {Memory, MemoryRequest},
 	}
 
@@ -59,7 +60,7 @@ var (
 
 	// Mapping of quota to compute resources
 	QuotaToComputeMap = map[ResourceType]ResourceType{
-		CPULimitQuota:      CPU,
+		CPULimitQuota:      CPUMili,
 		MemoryLimitQuota:   Memory,
 		CPURequestQuota:    CPURequest,
 		MemoryRequestQuota: MemoryRequest,

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
@@ -72,7 +72,7 @@ func createPodStat(podname string) *stats.PodStats {
 
 func checkPodMetrics(sink *metrics.EntityMetricSink, podMId string, pod *stats.PodStats) error {
 	etype := metrics.PodType
-	resources := []metrics.ResourceType{metrics.CPU, metrics.Memory}
+	resources := []metrics.ResourceType{metrics.CPUMili, metrics.Memory}
 
 	for _, res := range resources {
 		mid := metrics.GenerateEntityResourceMetricUID(etype, podMId, res, metrics.Used)
@@ -83,11 +83,11 @@ func checkPodMetrics(sink *metrics.EntityMetricSink, podMId string, pod *stats.P
 
 		value := tmp.GetValue().(float64)
 		expected := float64(0.0)
-		if res == metrics.CPU {
+		if res == metrics.CPUMili {
 			for _, c := range pod.Containers {
 				expected += float64(*c.CPU.UsageNanoCores)
 			}
-			expected = util.MetricNanoToUnit(expected)
+			expected = util.MetricNanoToMili(expected)
 		} else {
 			for _, c := range pod.Containers {
 				expected += float64(*c.Memory.WorkingSetBytes)
@@ -107,7 +107,7 @@ func checkPodMetrics(sink *metrics.EntityMetricSink, podMId string, pod *stats.P
 
 func checkContainerMetrics(sink *metrics.EntityMetricSink, containerMId string, container *stats.ContainerStats) error {
 	etype := metrics.ContainerType
-	resources := []metrics.ResourceType{metrics.CPU, metrics.Memory}
+	resources := []metrics.ResourceType{metrics.CPUMili, metrics.Memory}
 
 	for _, res := range resources {
 		mid := metrics.GenerateEntityResourceMetricUID(etype, containerMId, res, metrics.Used)
@@ -118,9 +118,9 @@ func checkContainerMetrics(sink *metrics.EntityMetricSink, containerMId string, 
 
 		value := tmp.GetValue().(float64)
 		expected := float64(0.0)
-		if res == metrics.CPU {
+		if res == metrics.CPUMili {
 			expected += float64(*container.CPU.UsageNanoCores)
-			expected = util.MetricNanoToUnit(expected)
+			expected = util.MetricNanoToMili(expected)
 		} else {
 			expected += float64(*container.Memory.WorkingSetBytes)
 			expected = util.Base2BytesToKilobytes(expected)
@@ -137,7 +137,7 @@ func checkContainerMetrics(sink *metrics.EntityMetricSink, containerMId string, 
 
 func checkApplicationMetrics(sink *metrics.EntityMetricSink, appMId string, container *stats.ContainerStats) error {
 	etype := metrics.ApplicationType
-	resources := []metrics.ResourceType{metrics.CPU, metrics.Memory}
+	resources := []metrics.ResourceType{metrics.CPUMili, metrics.Memory}
 
 	for _, res := range resources {
 		mid := metrics.GenerateEntityResourceMetricUID(etype, appMId, res, metrics.Used)
@@ -148,9 +148,9 @@ func checkApplicationMetrics(sink *metrics.EntityMetricSink, appMId string, cont
 
 		value := tmp.GetValue().(float64)
 		expected := float64(0.0)
-		if res == metrics.CPU {
+		if res == metrics.CPUMili {
 			expected += float64(*container.CPU.UsageNanoCores)
-			expected = util.MetricNanoToUnit(expected)
+			expected = util.MetricNanoToMili(expected)
 		} else {
 			expected += float64(*container.Memory.WorkingSetBytes)
 			expected = util.Base2BytesToKilobytes(expected)

--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -15,34 +15,34 @@ import (
 
 var expectedMetrics = map[string]float64{
 	// Node metrics
-	"Node-mynode-CPU-Capacity":           2,
+	"Node-mynode-VCPUMili-Capacity":      2000,
 	"Node-mynode-Memory-Capacity":        8.388608e+06,
-	"Node-mynode-CPURequest-Capacity":    1.9,
+	"Node-mynode-CPURequest-Capacity":    1900,
 	"Node-mynode-MemoryRequest-Capacity": 7.340032e+06,
-	"Node-mynode-CPURequest-Used":        0.26,
+	"Node-mynode-CPURequest-Used":        260,
 	"Node-mynode-MemoryRequest-Used":     262144,
 
 	// Pod metrics
-	"Pod-default/mypod-CPU-Capacity":       2,
+	"Pod-default/mypod-VCPUMili-Capacity":  2000,
 	"Pod-default/mypod-Memory-Capacity":    8.388608e+06,
-	"Pod-default/mypod-CPURequest-Used":    0.26,
+	"Pod-default/mypod-CPURequest-Used":    260,
 	"Pod-default/mypod-MemoryRequest-Used": 262144,
 
 	// Container metrics
-	"Container-default/mypod/twitter-cass-tweet-CPU-Capacity":            0.25,
+	"Container-default/mypod/twitter-cass-tweet-VCPUMili-Capacity":       250,
 	"Container-default/mypod/twitter-cass-tweet-Memory-Capacity":         262144,
-	"Container-default/mypod/twitter-cass-tweet-CPURequest-Capacity":     0.25,
+	"Container-default/mypod/twitter-cass-tweet-CPURequest-Capacity":     250,
 	"Container-default/mypod/twitter-cass-tweet-MemoryRequest-Capacity":  262144,
-	"Container-default/mypod/istio-proxy-CPU-Capacity":                   2,
+	"Container-default/mypod/istio-proxy-VCPUMili-Capacity":              2000,
 	"Container-default/mypod/istio-proxy-Memory-Capacity":                8.388608e+06,
-	"Container-default/mypod/istio-proxy-CPURequest-Capacity":            0.01,
+	"Container-default/mypod/istio-proxy-CPURequest-Capacity":            10,
 	"Container-default/mypod/istio-proxy-MemoryRequest-Capacity":         0,
-	"Container-default/mypod/twitter-cass-tweet-CPULimitQuota-Used":      0.25,
+	"Container-default/mypod/twitter-cass-tweet-CPULimitQuota-Used":      250,
 	"Container-default/mypod/twitter-cass-tweet-MemoryLimitQuota-Used":   262144,
-	"Container-default/mypod/twitter-cass-tweet-CPURequestQuota-Used":    0.25,
+	"Container-default/mypod/twitter-cass-tweet-CPURequestQuota-Used":    250,
 	"Container-default/mypod/twitter-cass-tweet-MemoryRequestQuota-Used": 262144,
-	"Container-default/mypod/istio-proxy-CPULimitQuota-Used":             2,
-	"Container-default/mypod/istio-proxy-CPURequestQuota-Used":           0.01,
+	"Container-default/mypod/istio-proxy-CPULimitQuota-Used":             2000,
+	"Container-default/mypod/istio-proxy-CPURequestQuota-Used":           10,
 	"Container-default/mypod/istio-proxy-MemoryLimitQuota-Used":          8.388608e+06,
 	"Container-default/mypod/istio-proxy-MemoryRequestQuota-Used":        0,
 }

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -129,7 +129,7 @@ func TestComputeClusterResources(t *testing.T) {
 	}
 	// Among all nodes, one of the nodes is not schedulable, so the capacity should be 3 * node capacity
 	assert.Equal(t, int32(24032436), int32(resourceMap["Memory"].Capacity))
-	assert.Equal(t, int8(12), int8(resourceMap["CPU"].Capacity))
+	assert.Equal(t, int32(12000), int32(resourceMap["VCPUMili"].Capacity))
 
 	kubeCluster = repository.NewKubeCluster(testClusterName, createMockNodes(allocatableCpuOnlyMap, schedulableNodeMap))
 	resourceMap = kubeCluster.ClusterResources

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -3,8 +3,9 @@ package repository
 import (
 	"bytes"
 	"fmt"
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"strings"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
@@ -248,11 +249,9 @@ func (nodeEntity *KubeNode) String() string {
 }
 
 func parseResourceValue(computeResourceType metrics.ResourceType, resourceList v1.ResourceList) float64 {
-	if computeResourceType == metrics.CPU ||
+	if computeResourceType == metrics.CPUMili ||
 		computeResourceType == metrics.CPURequest {
-		ctnCpuCapacityMilliCore := resourceList.Cpu().MilliValue()
-		cpuCapacityCore := util.MetricMilliToUnit(float64(ctnCpuCapacityMilliCore))
-		return cpuCapacityCore
+		return float64(resourceList.Cpu().MilliValue())
 	}
 
 	if computeResourceType == metrics.Memory ||

--- a/pkg/discovery/repository/kube_cluster_test.go
+++ b/pkg/discovery/repository/kube_cluster_test.go
@@ -19,15 +19,17 @@ var TestNodes = []struct {
 	memCap  float64
 	cluster string
 }{
-	{"node1", 4.0, 819200, "cluster1"},
-	{"node2", 5.0, 614400, "cluster1"},
-	{"node3", 6.0, 409600, "cluster1"},
+	{"node1", 4000.0, 819200, "cluster1"},
+	{"node2", 5000.0, 614400, "cluster1"},
+	{"node3", 6000.0, 409600, "cluster1"},
 }
 
 func TestKubeNode(t *testing.T) {
 	for _, testNode := range TestNodes {
 		resourceList := v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse(fmt.Sprint(testNode.cpuCap)),
+			// We query cpu capacity as milicores from node properties.
+			// What we set here is cpu cores.
+			v1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", int(testNode.cpuCap/1000))),
 			v1.ResourceMemory: resource.MustParse(fmt.Sprint(testNode.memCap)),
 		}
 
@@ -43,7 +45,7 @@ func TestKubeNode(t *testing.T) {
 
 		kubenode := NewKubeNode(n1, testNode.cluster)
 
-		resource, _ := kubenode.GetComputeResource(metrics.CPU)
+		resource, _ := kubenode.GetComputeResource(metrics.CPUMili)
 		assert.Equal(t, resource.Capacity, testNode.cpuCap)
 		resource, _ = kubenode.GetComputeResource(metrics.Memory)
 		assert.Equal(t, resource.Capacity, testNode.memCap/1024)
@@ -53,7 +55,7 @@ func TestKubeNode(t *testing.T) {
 		resource, _ = kubenode.GetComputeResource(metrics.MemoryLimitQuota)
 		assert.Nil(t, resource)
 
-		resource, _ = kubenode.GetAllocationResource(metrics.CPU)
+		resource, _ = kubenode.GetAllocationResource(metrics.CPUMili)
 		assert.Nil(t, resource)
 		resource, _ = kubenode.GetAllocationResource(metrics.Memory)
 		assert.Nil(t, resource)

--- a/pkg/discovery/repository/kube_entity_test.go
+++ b/pkg/discovery/repository/kube_entity_test.go
@@ -1,9 +1,10 @@
 package repository
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
-	"testing"
 )
 
 var TestEntities = []struct {
@@ -21,7 +22,7 @@ var TestSoldResources = []struct {
 	resourceType metrics.ResourceType
 	capacity     float64
 }{
-	{metrics.CPU, 200},
+	{metrics.CPUMili, 200},
 	{metrics.Memory, 2},
 	{metrics.MemoryLimitQuota, 1},
 	{metrics.CPULimitQuota, 100},
@@ -32,8 +33,8 @@ var TestProvider = []struct {
 	providerId     string
 	boughtResource map[metrics.ResourceType]float64
 }{
-	{metrics.NodeType, "node1", map[metrics.ResourceType]float64{metrics.CPU: 500, metrics.Memory: 3}},
-	{metrics.NodeType, "node2", map[metrics.ResourceType]float64{metrics.CPU: 500, metrics.Memory: 3}},
+	{metrics.NodeType, "node1", map[metrics.ResourceType]float64{metrics.CPUMili: 500, metrics.Memory: 3}},
+	{metrics.NodeType, "node2", map[metrics.ResourceType]float64{metrics.CPUMili: 500, metrics.Memory: 3}},
 	{metrics.NodeType, "node3", map[metrics.ResourceType]float64{metrics.CPULimitQuota: 500}},
 }
 

--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -218,7 +218,7 @@ func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_Re
 	capacityOnlyPropertyNames := []string{builder.PropertyCapacity}
 	replacementEntityMetaDataBuilder.PatchSellingWithProperty(proto.CommodityDTO_CLUSTER, capacityOnlyPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_VMPM_ACCESS, capacityOnlyPropertyNames).
-		PatchSellingWithProperty(proto.CommodityDTO_VCPU, vcpuUsedAndCapacityPropertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_VCPU_MILICORE, vcpuUsedAndCapacityPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_VMEM, usedAndCapacityPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_VCPU_REQUEST, usedAndCapacityPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_VMEM_REQUEST, usedAndCapacityPropertyNames).

--- a/pkg/discovery/util/const.go
+++ b/pkg/discovery/util/const.go
@@ -28,6 +28,10 @@ func MetricNanoToUnit(val float64) float64 {
 	return val / METRICGIGA
 }
 
+func MetricNanoToMili(val float64) float64 {
+	return val / METRICMEGA
+}
+
 func Base2BytesToKilobytes(val float64) float64 {
 	return val / BASE2KILO
 }

--- a/pkg/discovery/util/resource.go
+++ b/pkg/discovery/util/resource.go
@@ -25,12 +25,11 @@ func GetPodResourceLimits(pod *api.Pod) (cpuCapacity float64, memCapacity float6
 	return
 }
 
-// CPU returned is in core; Memory is in Kb
-func GetCpuAndMemoryValues(resource api.ResourceList) (cpuCapacityCore, memoryCapacityKiloBytes float64) {
+// CPU returned is in milicore; Memory is in Kb
+func GetCpuAndMemoryValues(resource api.ResourceList) (cpuCapacityMilicore, memoryCapacityKiloBytes float64) {
+	cpuCapacityMilicore = float64(resource.Cpu().MilliValue())
 	ctnMemoryCapacityBytes := resource.Memory().Value()
-	ctnCpuCapacityMilliCore := resource.Cpu().MilliValue()
 	memoryCapacityKiloBytes = Base2BytesToKilobytes(float64(ctnMemoryCapacityBytes))
-	cpuCapacityCore = MetricMilliToUnit(float64(ctnCpuCapacityMilliCore))
 
 	return
 }

--- a/pkg/discovery/worker/metrics_collector_test.go
+++ b/pkg/discovery/worker/metrics_collector_test.go
@@ -174,24 +174,24 @@ var (
 	metricsSink = metrics.NewEntityMetricSink()
 	etype       = metrics.PodType
 	// Pod in ns1 on n1
-	metric_cpuUsed_pod_n1_ns1        = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n1), metrics.CPU, metrics.Used, cpuUsed_pod_n1_ns1)
-	metric_cpuCap_pod_n1_ns1         = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n1), metrics.CPU, metrics.Capacity, nodeCpuCap)
+	metric_cpuUsed_pod_n1_ns1        = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n1), metrics.CPUMili, metrics.Used, cpuUsed_pod_n1_ns1)
+	metric_cpuCap_pod_n1_ns1         = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n1), metrics.CPUMili, metrics.Capacity, nodeCpuCap)
 	metric_cpuRequestUsed_pod_n1_ns1 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n1), metrics.CPURequest, metrics.Used, cpuRequestUsed_pod_n1_ns1)
 	metric_cpuRequestCap_pod_n1_ns1  = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n1), metrics.CPURequest, metrics.Capacity, nodeCpuCap)
 	// Pod in ns1 on n2
-	metric_cpuUsed_pod_n2_ns1        = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n2), metrics.CPU, metrics.Used, cpuUsed_pod_n2_ns1)
+	metric_cpuUsed_pod_n2_ns1        = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n2), metrics.CPUMili, metrics.Used, cpuUsed_pod_n2_ns1)
 	metric_cpuRequestUsed_pod_n2_ns1 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns1_n2), metrics.CPURequest, metrics.Used, cpuRequestUsed_pod_n2_ns1)
 	// Pod in ns2 on n1
-	metric_cpuUsed_pod_n1_ns2        = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns2_n1), metrics.CPU, metrics.Used, cpuUsed_pod_n1_ns2)
-	metric_cpuCap_pod_n1_ns2         = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns2_n1), metrics.CPU, metrics.Capacity, nodeCpuCap)
+	metric_cpuUsed_pod_n1_ns2        = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns2_n1), metrics.CPUMili, metrics.Used, cpuUsed_pod_n1_ns2)
+	metric_cpuCap_pod_n1_ns2         = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns2_n1), metrics.CPUMili, metrics.Capacity, nodeCpuCap)
 	metric_cpuRequestUsed_pod_n1_ns2 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns2_n1), metrics.CPURequest, metrics.Used, cpuRequestUsed_pod_n1_ns2)
 	metric_cpuRequestCap_pod_n1_ns2  = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod_ns2_n1), metrics.CPURequest, metrics.Capacity, nodeCpuCap)
 
 	// Pod1 and Pod2 in ns3 on n1
-	metric_cpuUsed_pod1_n1_ns3        = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod1_ns3_n1), metrics.CPU, metrics.Used, cpuUsed_pod1_n1_ns3)
-	metric_cpuCap_pod1_n1_ns3         = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod1_ns3_n1), metrics.CPU, metrics.Capacity, nodeCpuCap)
-	metric_cpuUsed_pod2_n1_ns3        = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod2_ns3_n1), metrics.CPU, metrics.Used, cpuUsed_pod2_n1_ns3)
-	metric_cpuCap_pod2_n1_ns3         = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod2_ns3_n1), metrics.CPU, metrics.Capacity, nodeCpuCap)
+	metric_cpuUsed_pod1_n1_ns3        = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod1_ns3_n1), metrics.CPUMili, metrics.Used, cpuUsed_pod1_n1_ns3)
+	metric_cpuCap_pod1_n1_ns3         = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod1_ns3_n1), metrics.CPUMili, metrics.Capacity, nodeCpuCap)
+	metric_cpuUsed_pod2_n1_ns3        = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod2_ns3_n1), metrics.CPUMili, metrics.Used, cpuUsed_pod2_n1_ns3)
+	metric_cpuCap_pod2_n1_ns3         = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod2_ns3_n1), metrics.CPUMili, metrics.Capacity, nodeCpuCap)
 	metric_cpuRequestUsed_pod1_n1_ns3 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod1_ns3_n1), metrics.CPURequest, metrics.Used, cpuRequestUsed_pod1_n1_ns3)
 	metric_cpuRequestCap_pod1_n1_ns3  = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod1_ns3_n1), metrics.CPURequest, metrics.Capacity, nodeCpuCap)
 	metric_cpuRequestUsed_pod2_n1_ns3 = metrics.NewEntityResourceMetric(etype, util.PodKeyFunc(pod2_ns3_n1), metrics.CPURequest, metrics.Used, cpuRequestUsed_pod2_n1_ns3)

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	vCpuType               = proto.CommodityDTO_VCPU
+	vCpuType               = proto.CommodityDTO_VCPU_MILICORE
 	vMemType               = proto.CommodityDTO_VMEM
 	vCpuRequestType        = proto.CommodityDTO_VCPU_REQUEST
 	vMemRequestType        = proto.CommodityDTO_VMEM_REQUEST
@@ -214,7 +214,7 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 	return mergedEntityMetadataBuilder.
 		PatchSoldMetadata(proto.CommodityDTO_CLUSTER, fieldsCapactiy).
 		PatchSoldMetadata(proto.CommodityDTO_VMPM_ACCESS, fieldsCapactiy).
-		PatchSoldMetadata(proto.CommodityDTO_VCPU, fieldsUsedCapacityPeak).
+		PatchSoldMetadata(proto.CommodityDTO_VCPU_MILICORE, fieldsUsedCapacityPeak).
 		PatchSoldMetadata(proto.CommodityDTO_VMEM, fieldsUsedCapacityPeak).
 		PatchSoldMetadata(proto.CommodityDTO_VCPU_REQUEST, fieldsUsedCapacity).
 		PatchSoldMetadata(proto.CommodityDTO_VMEM_REQUEST, fieldsUsedCapacity).


### PR DESCRIPTION
It uses the newly introduced commodity `VCPU_MILICORE` as in https://github.com/turbonomic/turbo-go-sdk/pull/98.
I think the sdk pr will need to be merged before the CI here can pass. 