### PR TITLE
Fix the incorrectly created WorkloadController when Pod owner reference is Node and missing historical data for ContainerSpec

### DIFF
--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -105,8 +105,8 @@ func (builder *containerDTOBuilder) BuildDTOs(pods []*api.Pod) ([]*proto.EntityD
 		podId := string(pod.UID)
 		podMId := util.PodMetricIdAPI(pod)
 		controllerUID := ""
-		if pod.OwnerReferences != nil {
-			// Get controllerUID only if Pod is deployed by a K8s controller (pod.OwnerReferences != nil).
+		if util.HasController(pod) {
+			// Get controllerUID only if Pod is deployed by a K8s controller.
 			controllerUID, err = util.GetControllerUID(pod, builder.metricsSink)
 			if err != nil {
 				glog.Errorf("Error getting controller UID from pod %s, %v", pod.Name, err)

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -102,9 +102,8 @@ func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpec *reposi
 		// utilization data into consideration for resizing.
 		commSoldBuilder.Resizable(true)
 
-		// Commodities sold by ContainerSpec entities are inactive because they won't be analyzed directly in Market
-		// analysis engine.
-		commSoldBuilder.Active(false)
+		// Commodities sold by ContainerSpec entities are active so that they can be stored in database in Turbo server.
+		commSoldBuilder.Active(true)
 		commSold, err := commSoldBuilder.Create()
 		if err != nil {
 			glog.Errorf("Failed to build commodity sold %s: %v", commodityType, err)

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
@@ -40,7 +40,7 @@ func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(commodityDTOs))
 	for _, commodityDTO := range commodityDTOs {
-		assert.Equal(t, false, *commodityDTO.Active)
+		assert.Equal(t, true, *commodityDTO.Active)
 		assert.Equal(t, true, *commodityDTO.Resizable)
 		// Parse values to int to avoid tolerance of float values
 		assert.Equal(t, 2, int(*commodityDTO.Used))

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -121,7 +121,7 @@ func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod) ([]*proto.E
 		entityDTOBuilder.BuysCommodities(commoditiesBought)
 
 		// If it is bare pod deployed without k8s controller, pod buys quota commodities directly from Namespace provider
-		if pod.OwnerReferences == nil {
+		if !util.HasController(pod) {
 			namespaceUID, exists := builder.namespaceUIDMap[pod.Namespace]
 			if exists {
 				commoditiesBoughtQuota, err := builder.getQuotaCommoditiesBought(namespaceUID, pod, cpuFrequency)

--- a/pkg/discovery/worker/controller_metrics_collector.go
+++ b/pkg/discovery/worker/controller_metrics_collector.go
@@ -40,8 +40,8 @@ func (collector *ControllerMetricsCollector) CollectControllerMetrics() ([]*repo
 	kubeControllersMap := make(map[string]*repository.KubeController)
 	var kubeControllerList []*repository.KubeController
 	for _, pod := range collector.podList {
-		if pod.OwnerReferences == nil {
-			// If pod has no OwnerReferences, it is a bare pod without controller. Skip this.
+		if !util.HasController(pod) {
+			// If pod has no Controller, it is a bare pod directly deployed on Namespace. Skip this.
 			glog.V(4).Infof("Skip creating KubeController for bare Pod %s", util.PodKeyFunc(pod))
 			continue
 		}


### PR DESCRIPTION
This PR is to fix 2 issues of the new container model:
https://vmturbo.atlassian.net/browse/OM-58094
https://vmturbo.atlassian.net/browse/OM-58116

**Problem**:
1. OM-58094 -- There were some suspicious move actions where current node provider does not satisfy the required commodities bought by the pod.
2. OM-58116 -- No ContainerSpec commodity data got retained in database

**Diagnosis**:
1. For the suspicious move actions issue, it turns out that some discovered WorkloadControllers (K8s controller) have the same UID and name as Nodes. When shopping in Market analysis, those WorkloadControllers could be incorrectly used as node provider so that such suspicious move actions got generated.

Basically we create the WorkloadController entity based on the Pod.OwnerReference , but some Pod.OwnerReference returns the Node instead of a K8s controller.

For example, this Pod in cluster "K8s 1.17.5 in DC11":
```yaml
kind: Pod
metadata:
  annotations:
    kubernetes.io/config.hash: 02b05f9ab378cba4f8179a4353121767
    kubernetes.io/config.mirror: 02b05f9ab378cba4f8179a4353121767
    kubernetes.io/config.seen: "2020-04-24T08:22:24.795013614Z"
    kubernetes.io/config.source: file
  creationTimestamp: "2020-04-24T08:22:35Z"
  labels:
    component: kube-apiserver
    tier: control-plane
  name: kube-apiserver-pt-k8s-master-2
  namespace: kube-system
  ownerReferences:
  - apiVersion: v1
    controller: true
    kind: Node
    name: pt-k8s-master-2
    uid: 3c2910f0-2c62-4d57-a13d-569081f6aa17
```
where  the ownerReferences is the corresponding Node which hosts this Pod, and “controller” flag is true.

Starting from K8s v1.17, the OwnerReference of a mirror Pod is set as Node: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/20190916-noderestriction-pods.md#ownerreferences

So we need to skip creating the WorkloadController entity for such OwnerReference.

2. For the missing historical stats data of ContainerSpec entity, initially, the commodities sold by ContainerSpec were set to inactive to make them avoid being sent to Market analysis. In Turbo server, we only store active commodities into database. So we need to set the commodities sold by ContainerSpec as active. This won’t cause further problems because ContainerSpec entities already have monitored as false so that they won’t be sent to market analysis.

**Solution**:
1. Create a `HasController` function in `pod_util` to check if pod.OwnerReference has kind as Node.
2. Set commodities sold to active=true for ContainerSpec

**Testing Done**:

**Before the fix**,
1. 51 WorkloadControllers were discovered, where 4 of them are actually nodes:
<img width="1079" alt="Screen Shot 2020-05-05 at 00 39 36" src="https://user-images.githubusercontent.com/23689754/81036128-e69e4b80-8e6b-11ea-88f5-88cb1cdc7718.png">
and there were lots of suspicious Pod move actions due to VPU request:
<img width="1111" alt="Screen Shot 2020-05-05 at 01 01 42" src="https://user-images.githubusercontent.com/23689754/81036153-03d31a00-8e6c-11ea-9cef-b0a8b0460c7d.png">

2. No historical data got retained for ContainerSpec entities from "Multiple Resources" widget:
<img width="1319" alt="Screen Shot 2020-05-05 at 01 02 30" src="https://user-images.githubusercontent.com/23689754/81036201-341ab880-8e6c-11ea-8718-689705d7ade9.png">

---
**After the fix**,
1. 47 WorkloadControllers were correctly discovered without the nodes:
<img width="910" alt="Screen Shot 2020-05-04 at 23 28 38" src="https://user-images.githubusercontent.com/23689754/81036266-6b896500-8e6c-11ea-9f37-1f1f7050ef7d.png">

And when scoping to the Pod with OwnerReference kind as Node (`kube-apiserver-pt-k8s-master-2`), it directly buying from Namespace:
<img width="703" alt="Screen Shot 2020-05-04 at 23 43 19" src="https://user-images.githubusercontent.com/23689754/81036340-c15e0d00-8e6c-11ea-96ff-452a0d4f25dc.png">

2. Historical data were populated in "Multiple Resources" widget for ContainerSpec:
<img width="1343" alt="Screen Shot 2020-05-05 at 01 08 00" src="https://user-images.githubusercontent.com/23689754/81036385-ed798e00-8e6c-11ea-826d-a1a13a52c618.png">
