### PR TITLE
Add support for DeploymentConfig - 7.21.4

### DIFF
--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -56,6 +56,11 @@ func newK8sControllerUpdater(client *kclient.Clientset, dynamicClient dynamic.In
 			Group:    util.K8sAPIReplicasetGV.Group,
 			Version:  util.K8sAPIReplicasetGV.Version,
 			Resource: util.DeploymentResName}
+	case util.KindDeploymentConfig:
+		res = schema.GroupVersionResource{
+			Group:    util.OpenShiftAPIDeploymentConfigGV.Group,
+			Version:  util.OpenShiftAPIDeploymentConfigGV.Version,
+			Resource: util.DeploymentConfigResName}
 	default:
 		err := fmt.Errorf("unsupport controller type %s for pod %s/%s", kind, pod.Namespace, pod.Name)
 		return nil, err

--- a/pkg/discovery/dtofactory/group_dto_builder.go
+++ b/pkg/discovery/dtofactory/group_dto_builder.go
@@ -21,6 +21,7 @@ var (
 		"ReplicaSet":            true,
 		"ReplicationController": true,
 		"StatefulSet":           true,
+		"DeploymentConfig":      true,
 	}
 )
 

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -270,6 +270,7 @@ func GetPodParentInfo(pod *api.Pod) (string, string, error) {
 // GetPodGrandInfo gets grandParent (parent's parent) information of a pod: kind, name
 // If parent does not have parent, then return parent info.
 // Note: if parent kind is "ReplicaSet", then its parent's parent can be a "Deployment"
+//       or if its a "ReplicationController" its parent could be "DeploymentConfig" (as in openshift).
 func GetPodGrandInfo(dynClient dynamic.Interface, pod *api.Pod) (string, string, error) {
 	//1. get Parent info: kind and name;
 	kind, name, err := GetPodParentInfo(pod)
@@ -277,29 +278,35 @@ func GetPodGrandInfo(dynClient dynamic.Interface, pod *api.Pod) (string, string,
 		return "", "", err
 	}
 
-	//2. if parent is "ReplicaSet", check parent's parent
-	if strings.EqualFold(kind, Kind_ReplicaSet) {
-		//2.1 get parent object
-
-		rsRes := schema.GroupVersionResource{
-			Group:    commonutil.K8sAPIReplicasetGV.Group,
-			Version:  commonutil.K8sAPIReplicasetGV.Version,
+	//2. if parent is "ReplicaSet" or "ReplicationController", check parent's parent
+	var res schema.GroupVersionResource
+	switch kind {
+	case commonutil.KindReplicationController:
+		res = schema.GroupVersionResource{
+			Group:    commonutil.K8sAPIReplicationControllerGV.Group,
+			Version:  commonutil.K8sAPIReplicationControllerGV.Version,
+			Resource: commonutil.ReplicationControllerResName}
+	case commonutil.KindReplicaSet:
+		res = schema.GroupVersionResource{
+			Group:    commonutil.K8sAPIDeploymentGV.Group,
+			Version:  commonutil.K8sAPIDeploymentGV.Version,
 			Resource: commonutil.ReplicaSetResName}
-		rs, err := dynClient.Resource(rsRes).Namespace(pod.Namespace).Get(name, metav1.GetOptions{})
-		if err != nil {
-			err = fmt.Errorf("Failed to get ReplicaSet[%v/%v]: %v", pod.Namespace, name, err)
-			glog.Error(err.Error())
-			return "", "", err
-		}
+	default:
+		return kind, name, nil
+	}
 
-		//2.2 get parent's parent info by parsing ownerReferences:
-		// TODO: The ownerReferences of ReplicaSet is supported only in 1.6.0 and afetr
-		rsOwnerReferences := rs.GetOwnerReferences()
-		if rsOwnerReferences != nil && len(rsOwnerReferences) > 0 {
-			gkind, gname := ParseOwnerReferences(rsOwnerReferences)
-			if len(gkind) > 0 && len(gname) > 0 {
-				return gkind, gname, nil
-			}
+	obj, err := dynClient.Resource(res).Namespace(pod.Namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		err = fmt.Errorf("Failed to get %s[%v/%v]: %v", kind, pod.Namespace, name, err)
+		glog.Error(err.Error())
+		return "", "", err
+	}
+	//2.2 get parent's parent info by parsing ownerReferences:
+	rsOwnerReferences := obj.GetOwnerReferences()
+	if rsOwnerReferences != nil && len(rsOwnerReferences) > 0 {
+		gkind, gname := ParseOwnerReferences(rsOwnerReferences)
+		if len(gkind) > 0 && len(gname) > 0 {
+			return gkind, gname, nil
 		}
 	}
 

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -4,15 +4,18 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	KindReplicationController = "ReplicationController"
+	KindDeploymentConfig      = "DeploymentConfig"
 	KindReplicaSet            = "ReplicaSet"
 	KindDeployment            = "Deployment"
 
 	K8sExtensionsGroupName = "extensions"
 	K8sAppsGroupName       = "apps"
+	OpenShiftAppsGroupName = "apps.openshift.io"
 
 	ReplicationControllerResName = "replicationcontrollers"
 	ReplicaSetResName            = "replicasets"
 	DeploymentResName            = "deployments"
+	DeploymentConfigResName      = "deploymentconfigs"
 )
 
 // The API group version under which deployments and replicasets are exposed by the k8s cluster as of today
@@ -27,3 +30,6 @@ var K8sAPIReplicasetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "
 // The API group under which replicationcontrollers are exposed by the k8s server
 // We do not discover the latest GV for this as we know that it has matured under core/v1
 var K8sAPIReplicationControllerGV = schema.GroupVersion{Group: "", Version: "v1"}
+
+// The API group under which openshifts deploymentconfig resource is exposed by the server
+var OpenShiftAPIDeploymentConfigGV = schema.GroupVersion{Group: OpenShiftAppsGroupName, Version: "v1"}


### PR DESCRIPTION
DeploymentConfig is to ReplicationControllers in openshift, what
Deplopyment is to ReplicaSet is normal kubernetes distributions.
This fix tries to extend the support for DCs discovered in openshift
environments.