### PR TITLE
Set resizable to false for requests commodities sold by containers before the complete requests resizing is supported

### DIFF
--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -250,8 +250,10 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 
 	//1c. vCPURequest
 	// Container sells vCPURequest commodity only if CPU request is set on the container
+	// TODO temporarily set isResizable to false for VCPURequest and VMemRequest commodities sold by containers to avoid
+	// suspicious resizing actions before we implement the full support to resize requests commodities
 	if isCpuRequestSet {
-		cpuRequestCommodities, err := builder.createCommoditiesSold(containerEntityType, cpuRequestCommodity, containerMId, converter)
+		cpuRequestCommodities, err := builder.createCommoditiesSold(containerEntityType, cpuRequestCommodity, containerMId, converter, false)
 		if err != nil {
 			return nil, err
 		}
@@ -261,7 +263,7 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 	//1d. vMemRequest
 	// Container sells vMemRequest commodity only if memory request is set on the container
 	if isMemRequestSet {
-		memRequestCommodities, err := builder.createCommoditiesSold(containerEntityType, memRequestCommodity, containerMId, nil)
+		memRequestCommodities, err := builder.createCommoditiesSold(containerEntityType, memRequestCommodity, containerMId, nil, false)
 		if err != nil {
 			return nil, err
 		}
@@ -283,9 +285,9 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 
 // createCommoditiesSold creates a slice of resource commodities sold of the given resourceType.
 func (builder *containerDTOBuilder) createCommoditiesSold(entityType metrics.DiscoveredEntityType,
-	resourceTypes []metrics.ResourceType, containerMId string, converter *converter) ([]*proto.CommodityDTO, error) {
+	resourceTypes []metrics.ResourceType, containerMId string, converter *converter, isResizable bool) ([]*proto.CommodityDTO, error) {
 	attrSetter := NewCommodityAttrSetter()
-	attrSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(true) }, resourceTypes...)
+	attrSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(isResizable) }, resourceTypes...)
 	commoditiesSold, err := builder.getResourceCommoditiesSold(entityType, containerMId, resourceTypes, converter, attrSetter)
 	return commoditiesSold, err
 }


### PR DESCRIPTION
This PR is to set `resizable` field to false for VCPURequest and VMemRequest commodities sold by containers before the complete requests resizing is supported in Market analysis in the server side. 

We added reservation values back to commodities bought by container and pod in a previous PR (https://github.com/turbonomic/kubeturbo/pull/413) so that we'll still have resizing down reservation actions generated for containers, where requests values are set to "reservation" field on VCPU and VMem commodities sold by containers.

For VCPU and VMem requests commodities sold by containers, we haven't found any suspicious actions yet with `resizable` as true. But to make sure the sold requests commodities won't impact container resizing, we want to temporarily set `resizable` to false before we implement the complete support to resize requests.

**Testing Done**:
1. From the discovery DTO response, container is selling VCPURequest and VMemRequest commodities with `resizable` as false:
```json
entityDTO {
  entityType: CONTAINER
  id: "76883e3c-643e-4bd6-b1bd-389b20919da5-0"
  displayName: "kube-system/coredns-76798d84dd-ntpnk/coredns"
  ...
  commoditiesSold {
    commodityType: VCPU_REQUEST
    used: 12.455706057989998
    capacity: 266.3778
    peak: 12.455706057989998
    resizable: false
  }
  commoditiesSold {
    commodityType: VMEM_REQUEST
    used: 9904.0
    capacity: 71680.0
    peak: 9904.0
    resizable: false
  }
```

2. In the TopologyDTO, all requests commdities sold by containers have `resizable`=false, for example:
```json
          {
            "entity": {
              "entityType": 40,
              "typeSpecificInfo": {},
              "oid": "73445975498507",
              "displayName": "monitoring/prometheus-k8s-0/rules-configmap-reloader",
              "environmentType": "ON_PREM",
              "commoditySoldList": [
                {
                  "commodityType": {
                    "type": 100
                  },
                  "used": 0.0,
                  "peak": 0.0,
                  "capacity": 266.3778,
                  "isResizeable": false,
                  "isThin": true,
                  "active": true,
                  "historicalUsed": {
                    "maxQuantity": 0.0,
                    "timeSlot": []
                  },
                  "displayName": "",
                  "aggregates": []
                },
                {
                  "commodityType": {
                    "type": 101
                  },
                  "used": 2048.0,
                  "peak": 2048.0,
                  "capacity": 25600.0,
                  "isResizeable": false,
                  "isThin": true,
                  "active": true,
                  "historicalUsed": {
                    "maxQuantity": 2048.0,
                    "timeSlot": []
                  },
                  "displayName": "",
                  "aggregates": []
                }
```
where entityType "40" is Container, commodityType "100" is "VCPU_REQUEST" and "100" is "VMEM_REQUEST".