### PR TITLE
ContainerSpec entities sell aggregated VCPURequest and VMemRequest commodities

### DIFF
--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -2,9 +2,10 @@ package dtofactory
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
-	"strings"
 
 	"github.com/golang/glog"
 	api "k8s.io/api/core/v1"
@@ -261,7 +262,8 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 	}
 
 	if containerSpec != nil {
-		// Store container VCPU and VMem commodity DTOs to ContainerSpec if ContainerSpec is not nil
+		// Store container VCPU, VMem, VCPURequest (if present), and VMemRequest (if present),
+		// commodity DTOs to ContainerSpec if ContainerSpec is not nil
 		for _, commodityDTO := range commodities {
 			containerCommodities, exists := containerSpec.ContainerCommodities[*commodityDTO.CommodityType]
 			if !exists {

--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -230,23 +230,11 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 
 	commodities := append(cpuCommodities, memCommodities...)
 	if len(commodities) != len(commoditySold) {
-		err = fmt.Errorf("mismatch num of commidities (%d Vs. %d) for container:%s, %s", len(commodities), len(commoditySold), containerName, containerMId)
+		err = fmt.Errorf("mismatch num of commodities (%d Vs. %d) for container:%s, %s", len(commodities), len(commoditySold), containerName, containerMId)
 		glog.Error(err)
 		return nil, err
 	}
 	result = append(result, commodities...)
-	if containerSpec != nil {
-		// Store container VCPU and VMem commodity DTOs to ContainerSpec if ContainerSpec is not nil
-		for _, commodityDTO := range commodities {
-			containerCommodities, exists := containerSpec.ContainerCommodities[*commodityDTO.CommodityType]
-			if !exists {
-				containerCommodities = []*proto.CommodityDTO{}
-			}
-			// Store VCPU and VMem commodity DTOs to ContainerSpec
-			containerCommodities = append(containerCommodities, commodityDTO)
-			containerSpec.ContainerCommodities[*commodityDTO.CommodityType] = containerCommodities
-		}
-	}
 
 	//1c. vCPURequest
 	// Container sells vCPURequest commodity only if CPU request is set on the container
@@ -258,6 +246,7 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 			return nil, err
 		}
 		result = append(result, cpuRequestCommodities...)
+		commodities = append(commodities, cpuRequestCommodities...)
 	}
 
 	//1d. vMemRequest
@@ -268,6 +257,20 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 			return nil, err
 		}
 		result = append(result, memRequestCommodities...)
+		commodities = append(commodities, memRequestCommodities...)
+	}
+
+	if containerSpec != nil {
+		// Store container VCPU and VMem commodity DTOs to ContainerSpec if ContainerSpec is not nil
+		for _, commodityDTO := range commodities {
+			containerCommodities, exists := containerSpec.ContainerCommodities[*commodityDTO.CommodityType]
+			if !exists {
+				containerCommodities = []*proto.CommodityDTO{}
+			}
+			// Store VCPU and VMem commodity DTOs to ContainerSpec
+			containerCommodities = append(containerCommodities, commodityDTO)
+			containerSpec.ContainerCommodities[*commodityDTO.CommodityType] = containerCommodities
+		}
 	}
 
 	//2. Application

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -13,6 +13,8 @@ var (
 	ContainerSpecCommoditiesSold = []proto.CommodityDTO_CommodityType{
 		proto.CommodityDTO_VCPU,
 		proto.CommodityDTO_VMEM,
+		proto.CommodityDTO_VCPU_REQUEST,
+		proto.CommodityDTO_VMEM_REQUEST,
 	}
 )
 

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
@@ -28,6 +28,10 @@ func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
 				createCommodityDTO(proto.CommodityDTO_VMEM, 1.0, 1.0, 2.0),
 				createCommodityDTO(proto.CommodityDTO_VMEM, 3.0, 3.0, 4.0),
 			},
+			memRequestCommType: {
+				createCommodityDTO(proto.CommodityDTO_VMEM_REQUEST, 1.0, 1.0, 2.0),
+				createCommodityDTO(proto.CommodityDTO_VMEM_REQUEST, 3.0, 3.0, 4.0),
+			},
 		},
 	}
 
@@ -38,7 +42,7 @@ func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
 	}
 	commodityDTOs, err := builder.getCommoditiesSold(&containerSpecs)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(commodityDTOs))
+	assert.Equal(t, 3, len(commodityDTOs))
 	for _, commodityDTO := range commodityDTOs {
 		assert.Equal(t, true, *commodityDTO.Active)
 		assert.Equal(t, true, *commodityDTO.Resizable)

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -349,7 +349,9 @@ func (f *SupplyChainFactory) buildContainerSpecSupplyBuilder() (*proto.TemplateD
 	containerSpecSupplyChainNodeBuilder := supplychain.NewSupplyChainNodeBuilder(proto.EntityDTO_CONTAINER_SPEC)
 	containerSpecSupplyChainNodeBuilder = containerSpecSupplyChainNodeBuilder.
 		Sells(vCpuTemplateComm).
-		Sells(vMemTemplateComm)
+		Sells(vMemTemplateComm).
+		Sells(vCpuRequestTemplateCommOpt).
+		Sells(vMemRequestTemplateCommOpt)
 	return containerSpecSupplyChainNodeBuilder.Create()
 }
 


### PR DESCRIPTION
We wish to resize request commodities (VCPURequest and VMemRequest) for containers. Requests are important in kubernetes in determining container scheduling and for guaranteeing resource availability for important workloads. In Turbonomic, we will be resizing requests DOWN but not UP in the market. This means that it is extra important that we do not prematurely resize down a request commodity before the action can be justified because we will never attempt to resize it back up.

Usually a ResizeDownWarmupInterval can be used to ensure some minimum period of data collection for an entity before generating a resize down action for it but this logic does not currently work for entities such as containers that are part of consistent scaling groups. If we resize requests using the percentile algorithm, we can apply a MinimumObservationPeriod to the ContainerSpec associated with the container to ensure sufficient historical data for the container before resizing its requests. However, this can only be applied if using the percentile algorithm. Note however that the observation period is on a per-entity basis and not per-commodity basis, so the entity's minimum observation period will be applied to all the commodities on the entity in the same way.

This pull request enables percentile-based resizes for request commodities so that we may apply the MinimumObservationPeriod to prevent premature request resize down actions for containers.

**Probe DTO showing ContainerSpec with request commodity usage and historical utilization:**
> {"oid":"73472379794609","entity":{"entityType":"CONTAINER_SPEC","id":"971e9825-4c43-4f72-801f-3103665ae700/mem-load","displayName":"mem-load","commoditiesSold":[{"commodityType":"VCPU","used":28.468268306595,"capacity":10655.112,"peak":28.468268306595,"active":true,"resizable":true,"utilizationData":{"point":[0.300196275,0.2341626],"lastPointTimestampMs":"1589999184557","intervalMs":0}},{"commodityType":"VMEM","used":411924.0,"capacity":512000.0,"peak":411924.0,"active":true,"resizable":true,"utilizationData":{"point":[80.4921875,80.415625],"lastPointTimestampMs":"1589999184557","intervalMs":0}},{"commodityType":"VMEM_REQUEST","used":411924.0,"capacity":399360.0,"peak":411924.0,"active":true,"resizable":true,"utilizationData":{"point":[103.19511217948718,103.09695512820514],"lastPointTimestampMs":"1589999184557","intervalMs":0}}],"monitored":false,"actionEligibility":{}}}

**TopologyProcessor DTO for Container with historicalUsed set for a request commodity based on its ContainerSpec:**

>      entity {
>       entity_type: 40 (Container)
>       oid: 73472379794036
>       display_name: "kube-system/calico-node-k6fjh/calico-node"
>       commodity_sold_list {
>         commodityType {
>           type: 26 (VCPU)
>         }
>         used: 93.622718544575989
>         peak: 93.622718544575989
>         capacity: 799.13339999999994
>         isResizeable: true
>         isThin: true
>         active: true
>         capacity_increment: 100
>         historical_used {
>           max_quantity: 115.49518483514699
>           hist_utilization: 115.49518585205078
>           percentile: 0.17
>         }
>         historical_peak {
>           hist_utilization: 115.49518585205078
>         }
>         display_name: ""
>       }
>       commodity_sold_list {
>         commodityType {
>           type: 53 (VMEM)
>         }
>         used: 22112
>         peak: 22112
>         capacity: 488281.25
>         isResizeable: true
>         isThin: true
>         active: true
>         capacity_increment: 65536
>         historical_used {
>           max_quantity: 29766.666666666668
>           hist_utilization: 29766.666015625
>           percentile: 0.05
>         }
>         historical_peak {
>           hist_utilization: 29766.666015625
>         }
>         display_name: ""
>       }
>       commodity_sold_list {
>         commodityType {
>           type: 100 (VCPU_REQUEST)
>         }
>         used: 93.622718544575989
>         peak: 93.622718544575989
>         capacity: 399.56669999999997
>         isResizeable: false
>         isThin: true
>         active: true
>         historical_used {
>           max_quantity: 115.49518483514699
>           percentile: 0.33
>         }
>         display_name: ""
>       }
>       commodity_sold_list {
>         commodityType {
>           type: 101 (VMEM_REQUEST)
>         }
>         used: 22112
>         peak: 22112
>         capacity: 62500
>         isResizeable: false
>         isThin: true
>         active: true
>         historical_used {
>           max_quantity: 29766.666666666668
>           percentile: 1
>         }
>         display_name: ""
>       }
> 