### PR TITLE
Update action executor to resize container requests from requests commodities

### DIFF
--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -149,14 +149,14 @@ func (r *ContainerResizer) buildResourceLists(pod *k8sapi.Pod, actionItem *proto
 		} else if _, exists := resourceRequestCommodities[cType]; exists {
 			resourceList = spec.NewRequest
 		} else {
-			return fmt.Errorf("failed to build resource list when resize %v capacity to %v: %v commodity type is not supported",
-				cType.String(), amount, cType.String())
+			return fmt.Errorf("failed to build resource list when resize %s capacity to %v: %s commodity type is not supported",
+				cType, amount, cType)
 		}
 		if err := r.buildResourceList(pod, cType, amount, resourceList); err != nil {
-			return fmt.Errorf("failed to build resource list when resize %v capacity to %v: %v",
-				cType.String(), amount, err)
+			return fmt.Errorf("failed to build resource list when resize %s capacity to %v: %v",
+				cType, amount, err)
 		}
-		glog.V(3).Infof("Resize pod-%v %v Capacity to %v", pod.Name, cType.String(), amount)
+		glog.V(3).Infof("Resize pod-%s %s Capacity to %v", pod.Name, cType, amount)
 	}
 
 	//2. check reservation

--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -20,6 +20,18 @@ const (
 	smallestAmount float64 = 1.0
 )
 
+var (
+	resourceCommodities = map[proto.CommodityDTO_CommodityType]struct{}{
+		proto.CommodityDTO_VCPU: {},
+		proto.CommodityDTO_VMEM: {},
+	}
+
+	resourceRequestCommodities = map[proto.CommodityDTO_CommodityType]struct{}{
+		proto.CommodityDTO_VCPU_REQUEST: {},
+		proto.CommodityDTO_VMEM_REQUEST: {},
+	}
+)
+
 type containerResizeSpec struct {
 	// the new capacity of the resources
 	NewCapacity k8sapi.ResourceList
@@ -85,13 +97,13 @@ func (r *ContainerResizer) setCPUQuantity(cpuMhz float64, host string, rlist k8s
 func (r *ContainerResizer) buildResourceList(pod *k8sapi.Pod, cType proto.CommodityDTO_CommodityType,
 	amount float64, result k8sapi.ResourceList) error {
 	switch cType {
-	case proto.CommodityDTO_VCPU:
+	case proto.CommodityDTO_VCPU, proto.CommodityDTO_VCPU_REQUEST:
 		host := pod.Spec.NodeName
 		err := r.setCPUQuantity(amount, host, result)
 		if err != nil {
 			return fmt.Errorf("failed to build cpu.Capacity: %v", err)
 		}
-	case proto.CommodityDTO_VMEM:
+	case proto.CommodityDTO_VMEM, proto.CommodityDTO_VMEM_REQUEST:
 		memory, err := genMemoryQuantity(amount)
 		if err != nil {
 			return fmt.Errorf("failed to build mem.Capacity: %v", err)
@@ -131,7 +143,16 @@ func (r *ContainerResizer) buildResourceLists(pod *k8sapi.Pod, actionItem *proto
 	//1. check capacity change
 	change, amount := getNewAmount(comm1.GetCapacity(), comm2.GetCapacity())
 	if change {
-		if err := r.buildResourceList(pod, cType, amount, spec.NewCapacity); err != nil {
+		var resourceList k8sapi.ResourceList
+		if _, exists := resourceCommodities[cType]; exists {
+			resourceList = spec.NewCapacity
+		} else if _, exists := resourceRequestCommodities[cType]; exists {
+			resourceList = spec.NewRequest
+		} else {
+			return fmt.Errorf("failed to build resource list when resize %v capacity to %v: %v commodity type is not supported",
+				cType.String(), amount, cType.String())
+		}
+		if err := r.buildResourceList(pod, cType, amount, resourceList); err != nil {
 			return fmt.Errorf("failed to build resource list when resize %v capacity to %v: %v",
 				cType.String(), amount, err)
 		}

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -17,7 +17,7 @@ import (
 )
 
 // update the Pod.Containers[index]'s Resources.Requests
-func updateReservation(container *k8sapi.Container, patchReservation k8sapi.ResourceList) bool {
+func updateRequests(container *k8sapi.Container, patchReservation k8sapi.ResourceList) bool {
 	glog.V(4).Infof("Begin to update Request(Reservation).")
 	changed := false
 
@@ -45,7 +45,7 @@ func updateReservation(container *k8sapi.Container, patchReservation k8sapi.Reso
 }
 
 // update the Pod.Containers[index]'s Resources.Limits
-func updateCapacity(container *k8sapi.Container, patchCapacity k8sapi.ResourceList) bool {
+func updateLimits(container *k8sapi.Container, patchCapacity k8sapi.ResourceList) bool {
 	glog.V(4).Infof("Begin to update Capacity.")
 	changed := false
 
@@ -109,12 +109,12 @@ func updateResourceAmount(podSpec *k8sapi.PodSpec, spec *containerResizeSpec) (b
 	//2. update Limits
 	changed := false
 	if spec.NewCapacity != nil && len(spec.NewCapacity) > 0 {
-		changed = changed || updateCapacity(container, spec.NewCapacity)
+		changed = changed || updateLimits(container, spec.NewCapacity)
 	}
 
 	//3. update Requests
 	if spec.NewRequest != nil && len(spec.NewRequest) > 0 {
-		changed = changed || updateReservation(container, spec.NewRequest)
+		changed = changed || updateRequests(container, spec.NewRequest)
 	}
 
 	//4. check the new Limits vs. Requests, make sure Limits >= Requests

--- a/pkg/action/executor/resize_container_util_test.go
+++ b/pkg/action/executor/resize_container_util_test.go
@@ -142,7 +142,7 @@ func TestUpdateCapacity(t *testing.T) {
 	}
 
 	//c := NewContainerResizer(nil, nil, "1.5", "aa", nil)
-	updateCapacity(container, patch)
+	updateLimits(container, patch)
 	if err := compareResourceList(container.Resources.Limits, 250, 500); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
**Intent and Background**:
Previously resizing down reservation action is generated to resize container resource requests outside Market analysis. We are currently working on putting resizing requests into Market and recommend resizing requests commodities instead of reservation on VCPU/VMem commodities. The intent is to update action executor to resize requests from requests commodities. We'll remove all corresponding logic related to reservations after resizing requests in Market analysis is full supported.

**Implementation**:
In `resize_container.go`, if given commodity type from the action is VCPU/VMem resource commodities, set resourceList to `sepc.NewCapacity` which will update resource limits after executing the action; else if given commodity type is VCPURequest/VMemRequest, set resrouceList to `sepc.NewRequest`, which will update resource requests after executing the action.

**Testing**:
The support of resizing requests inside Market analysis is still being worked on. I tested the action execution changes by applying Shravan's changes of recommending resizing requests actions.

1. Tested consistent resizing request on containers. I executed such resize up requests action:
> Resize up VCPU Request for Container history-test/test-request-resize-7568fdd67d-7gzhf/request-resizing from 27 MHz to 39 MHz

(Note that this action is only for current testing purpose and Market analysis will only generate resizing down requests actions after the full support).

Before the action, the container has 10m CPU:
```
spec:
  containers:
    name: request-resizing
    resources:
      requests:
        cpu: 10m
        memory: 40Mi
```
The action was successfully executed with following log messages:
```
I0526 10:11:55.743484    8752 action_handler.go:327] Received an action RIGHT_SIZE for entity CONTAINER [history-test/test-request-resize-7568fdd67d-7gzhf/request-resizing]
I0526 10:11:55.816785    8752 resize_container.go:159] Resize pod-test-request-resize-7568fdd67d-7gzhf VCPU_REQUEST Capacity to 38.637779235839844
I0526 10:11:55.832245    8752 resize_container_util.go:180] Begin to consistently resize Deployment of pod history-test/test-request-resize-7568fdd67d-7gzhf.
I0526 10:11:55.832266    8752 k8s_controller_updater.go:97] Begin to update Deployment of pod history-test/test-request-resize-7568fdd67d-7gzhf
I0526 10:11:55.852481    8752 k8s_controller_updater.go:139] Update container history-test/test-request-resize-7568fdd67d-7gzhf-0 resources in the pod specification.
I0526 10:11:55.852506    8752 resize_container_util.go:21] Begin to update Request(Reservation).
I0526 10:11:55.852513    8752 resize_container_util.go:40] Try to update container request-resizing resource request from map[cpu:{i:{value:10 scale:-3} d:{Dec:<nil>} s:10m Format:DecimalSI} memory:{i:{value:41943040 scale:0} d:{Dec:<nil>} s: Format:BinarySI}] to map[cpu:{i:{value:15 scale:-3} d:{Dec:<nil>} s:15m Format:DecimalSI} memory:{i:{value:41943040 scale:0} d:{Dec:<nil>} s: Format:BinarySI}]
I0526 10:11:55.876879    8752 k8s_controller_updater.go:115] Successfully updated Deployment of pod history-test/test-request-resize-7568fdd67d-7gzhf
I0526 10:11:55.876927    8752 go_util.go:56] [retry-1/3] success
```
After the action, the Pod has the container with the updated CPU requests (15m):
```
spec:
  containers:
    name: request-resizing
    resources:
      requests:
        cpu: 15m
        memory: 40Mi
```

2. I also executed such resize up requests action on a bare pod:
> Resize up VCPU Request for Container history-test/test-request-resize-1c4b4stagd0t8/cpu-high-util from 40 MHz to 50MHz


Before the action, the container has 10m CPU:
```
spec:
  containers:
  - name: cpu-high-util
    image: beekman9527/cpumemload:latest
    resources:
      requests:
        cpu: 10m
        memory: 10Mi
```

The action was successfully executed with following logs:
```
I0522 15:16:15.833783   21399 resize_container.go:159] Resize pod-test-request-resize-1c4b4stagd0t8 VCPU_REQUEST Capacity to 49.956668853759766
I0522 15:16:15.833864   21399 move_util.go:68] Generated new pod name test-request-resize-1c4bfmsiklpt0 for pod test-request-resize-1c4b4stagd0t8 (original pod test-request-resize)
I0522 15:16:15.833877   21399 resize_container_util.go:299] Update container history-test/test-request-resize-1c4b4stagd0t8-0 resources in the pod specification.
I0522 15:16:15.833901   21399 resize_container_util.go:21] Begin to update Request(Reservation)
I0522 15:16:15.887349   21399 resize_container_util.go:315] Create a clone pod success: history-test/test-request-resize-1c4bfmsiklpt0
```

Then the new Pod has the container with the updated CPU requests (19m):
```
spec:
  containers:
    name: cpu-high-util
    resources:
      requests:
        cpu: 19m
        memory: 10Mi
```