### PR TITLE
Remove the logic related to reservation and set request commodities sold by container resizable=true

### DIFF
--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -158,17 +158,6 @@ func (r *ContainerResizer) buildResourceLists(pod *k8sapi.Pod, actionItem *proto
 		}
 		glog.V(3).Infof("Resize pod-%s %s Capacity to %v", pod.Name, cType, amount)
 	}
-
-	//2. check reservation
-	change, amount = getNewAmount(comm1.GetReservation(), comm2.GetReservation())
-	if change {
-		if err := r.buildResourceList(pod, cType, amount, spec.NewRequest); err != nil {
-			return fmt.Errorf("failed to build resource list when resize %v reservation to %v: %v",
-				cType.String(), amount, err)
-		}
-		glog.V(3).Infof("Resize pod-%v %v Reservation to %v", pod.Name, cType.String(), amount)
-	}
-
 	return nil
 }
 

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -17,8 +17,8 @@ import (
 )
 
 // update the Pod.Containers[index]'s Resources.Requests
-func updateRequests(container *k8sapi.Container, patchReservation k8sapi.ResourceList) bool {
-	glog.V(4).Infof("Begin to update Request(Reservation).")
+func updateRequests(container *k8sapi.Container, patchRequests k8sapi.ResourceList) bool {
+	glog.V(4).Infof("Begin to update Request.")
 	changed := false
 
 	//1. get the original requests
@@ -28,7 +28,7 @@ func updateRequests(container *k8sapi.Container, patchReservation k8sapi.Resourc
 	}
 
 	//2. apply the patch
-	for k, v := range patchReservation {
+	for k, v := range patchRequests {
 		oldv, exist := result[k]
 		if !exist || oldv.Cmp(v) != 0 {
 			result[k] = v
@@ -74,7 +74,6 @@ func updateLimits(container *k8sapi.Container, patchCapacity k8sapi.ResourceList
 }
 
 // make sure that the Request.Value is not bigger than the Limit.Value
-// Note: It is certain that OpsMgr will make sure reservation is less than capacity.
 func checkLimitsRequests(container *k8sapi.Container) error {
 	if container.Resources.Limits == nil || container.Resources.Requests == nil {
 		return nil

--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -239,10 +239,8 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 
 	//1c. vCPURequest
 	// Container sells vCPURequest commodity only if CPU request is set on the container
-	// TODO temporarily set isResizable to false for VCPURequest and VMemRequest commodities sold by containers to avoid
-	// suspicious resizing actions before we implement the full support to resize requests commodities
 	if isCpuRequestSet {
-		cpuRequestCommodities, err := builder.createCommoditiesSold(containerEntityType, cpuRequestCommodity, containerMId, converter, false)
+		cpuRequestCommodities, err := builder.createCommoditiesSold(containerEntityType, cpuRequestCommodity, containerMId, converter, true)
 		if err != nil {
 			return nil, err
 		}
@@ -253,7 +251,7 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 	//1d. vMemRequest
 	// Container sells vMemRequest commodity only if memory request is set on the container
 	if isMemRequestSet {
-		memRequestCommodities, err := builder.createCommoditiesSold(containerEntityType, memRequestCommodity, containerMId, nil, false)
+		memRequestCommodities, err := builder.createCommoditiesSold(containerEntityType, memRequestCommodity, containerMId, nil, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/discovery/dtofactory/container_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_dto_builder_test.go
@@ -170,7 +170,8 @@ func Test_containerDTOBuilder_BuildDTOs_withContainerSpec(t *testing.T) {
 	cpuUsedFreq := cpuUsed * nodeCpuFrequency
 	cpuPeakFreq := cpuUsed * nodeCpuFrequency
 	cpuCapFreq := cpuCap * nodeCpuFrequency
-	commIsResizable := false
+	commNotResizable := false
+	commIsResizable := true
 	expectedContainerSpec := &repository.ContainerSpec{
 		Namespace:         namespace,
 		ControllerUID:     controllerUID,
@@ -183,7 +184,7 @@ func Test_containerDTOBuilder_BuildDTOs_withContainerSpec(t *testing.T) {
 				Used:          &cpuUsedFreq,
 				Peak:          &cpuPeakFreq,
 				Capacity:      &cpuCapFreq,
-				Resizable:     &commIsResizable,
+				Resizable:     &commNotResizable,
 			},
 			},
 			memCommType: {{
@@ -191,7 +192,7 @@ func Test_containerDTOBuilder_BuildDTOs_withContainerSpec(t *testing.T) {
 				Used:          &memUsed,
 				Peak:          &memUsed,
 				Capacity:      &memCap,
-				Resizable:     &commIsResizable,
+				Resizable:     &commNotResizable,
 			},
 			},
 			memRequestCommType: {{

--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -226,24 +226,6 @@ func (builder generalBuilder) getResourceCommoditiesBought(entityType metrics.Di
 		// set peak value as the used value
 		commBoughtBuilder.Peak(usedValue)
 
-		// set reservation value if any
-		reservedMetricUID := metrics.GenerateEntityResourceMetricUID(entityType, entityID,
-			rType, metrics.Reservation)
-		reservedMetric, err := builder.metricsSink.GetMetric(reservedMetricUID)
-		if err != nil {
-			// not every commodity has reserved value.
-			glog.V(4).Infof("%s::%s Reservation not set for commodity %s: %s",
-				entityType, entityID, rType, err)
-		} else {
-			reservedValue := reservedMetric.GetValue().(float64)
-			if reservedValue != 0 {
-				if converter != nil && converter.Convertible(rType) {
-					reservedValue = converter.Convert(rType, reservedValue)
-				}
-				commBoughtBuilder.Reservation(reservedValue)
-			}
-		}
-
 		// set additional attribute
 		if commodityAttrSetter != nil && commodityAttrSetter.Settable(rType) {
 			commodityAttrSetter.Set(rType, commBoughtBuilder)
@@ -287,14 +269,6 @@ func (builder generalBuilder) getResourceCommodityBoughtWithKey(entityType metri
 	// set peak value as the used value
 	commBoughtBuilder.Peak(usedValue)
 
-	// set reservation value if any
-	reservationValue, _ := builder.metricValue(entityType, entityID,
-		resourceType, metrics.Reservation, converter)
-	if reservationValue != 0 {
-		glog.V(4).Infof("%s::%s Reservation set for commodity %s: %s",
-			entityType, entityID, resourceType, err)
-		commBoughtBuilder.Reservation(reservationValue)
-	}
 	// set additional attribute
 	if commodityAttrSetter != nil && commodityAttrSetter.Settable(resourceType) {
 		commodityAttrSetter.Set(resourceType, commBoughtBuilder)

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -144,9 +144,8 @@ func IsCPUType(resourceType ResourceType) bool {
 type MetricProp string
 
 const (
-	Capacity    MetricProp = "Capacity"
-	Used        MetricProp = "Used"
-	Reservation MetricProp = "Reservation"
+	Capacity MetricProp = "Capacity"
+	Used     MetricProp = "Used"
 )
 
 type Metric interface {

--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -265,8 +265,6 @@ func (m *ClusterMonitor) genPodMetrics(pod *api.Pod, nodeCPUCapacity, nodeMemCap
 	podCPURequest, podMemRequest := m.genContainerMetrics(pod, cpuCapacity, memCapacity)
 	//2.2 Generate capacity metric for CPURequest and MemRequest. Pod requests capacity is node Allocatable
 	m.genRequestCapacityMetrics(metrics.PodType, podMId, nodeCPUAllocatable, nodeMemAllocatable)
-	// TODO remove genReservationMetrics once we have full support to resize requests commodities
-	m.genReservationMetrics(metrics.PodType, podMId, podCPURequest, podMemRequest)
 	//2.3 Generate used metric for CPURequest and MemRequest
 	m.genRequestUsedMetrics(metrics.PodType, podMId, podCPURequest, podMemRequest)
 
@@ -317,8 +315,6 @@ func (m *ClusterMonitor) genContainerMetrics(pod *api.Pod, podCPU, podMem float6
 		m.genRequestCapacityMetrics(metrics.ContainerType, containerMId, cpuRequest, memRequest)
 		// Generate resource request quota metrics with used value as CPU/memory resource request capacity
 		m.genRequestQuotaUsedMetrics(metrics.ContainerType, containerMId, cpuRequest, memRequest)
-		// TODO remove genReservationMetrics once we have full support to resize requests commodities
-		m.genReservationMetrics(metrics.ContainerType, containerMId, cpuRequest, memRequest)
 
 		totalCPURequest += cpuRequest
 		totalMemRequest += memRequest
@@ -376,15 +372,6 @@ func (m *ClusterMonitor) genLimitQuotaUsedMetrics(etype metrics.DiscoveredEntity
 func (m *ClusterMonitor) genRequestQuotaUsedMetrics(etype metrics.DiscoveredEntityType, key string, cpu, memory float64) {
 	cpuMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPURequestQuota, metrics.Used, cpu)
 	memMetric := metrics.NewEntityResourceMetric(etype, key, metrics.MemoryRequestQuota, metrics.Used, memory)
-	m.sink.AddNewMetricEntries(cpuMetric, memMetric)
-}
-
-// TODO remove this function of generating reservation (request) metrics on VCPU and VMemory commodities once we implement
-// the full support to resize requests commodities
-// genReservationMetrics generates reservation (equivalent of request) metrics for VCPU and VMemory commodity
-func (m *ClusterMonitor) genReservationMetrics(etype metrics.DiscoveredEntityType, key string, cpu, memory float64) {
-	cpuMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPU, metrics.Reservation, cpu)
-	memMetric := metrics.NewEntityResourceMetric(etype, key, metrics.Memory, metrics.Reservation, memory)
 	m.sink.AddNewMetricEntries(cpuMetric, memMetric)
 }
 

--- a/pkg/discovery/repository/kube_entity.go
+++ b/pkg/discovery/repository/kube_entity.go
@@ -37,9 +37,8 @@ type KubeResourceProvider struct {
 // Abstraction for a resource that a kubernetes entity will be buy from its provider
 // in the Turbonomic server supply chain
 type KubeBoughtResource struct {
-	Type        metrics.ResourceType
-	Used        float64
-	Reservation float64
+	Type metrics.ResourceType
+	Used float64
 }
 
 // Creates a new entity for the given entity type and uid.


### PR DESCRIPTION
**Intent**:
We have put resizing requests into Market analysis and do not need resizing reservation anymore. The intent here is to remove the logic related to reservation in Kubeturbo and set requests commodities sold by container resizable=true so that Market analysis can generate resizing requests actions.

**Implementation**:
1. Set resizable to true on requests commodities sold by containers in `container_dto_builder`.
2. Remove reservation related logic in `metric`, `cluster_monitor`, `general_builder` and `resize_container`.

**Testing Done**:
1, Requests commodities sold by containers have `resizable` flag as true. For example, for such discovery dto:
```
entityDTO {
  entityType: CONTAINER
  id: "16ef3de8-286b-43a8-bf1c-3f885a7bfcbf-1"
  displayName: "default/pi2-q6jlp/istio-proxy"
  commoditiesSold {
    commodityType: VCPU_REQUEST
    used: 9.001707659177999
    capacity: 266.3778
    peak: 9.001707659177999
    resizable: true
  }
  commoditiesSold {
    commodityType: VMEM_REQUEST
    used: 36076.0
    capacity: 131072.0
    peak: 36076.0
    resizable: true
  }
```
2. No reservation value set on VCPU/VMem commodities sold by containers:
```
entityDTO {
  entityType: CONTAINER
  id: "16ef3de8-286b-43a8-bf1c-3f885a7bfcbf-1"
  displayName: "default/pi2-q6jlp/istio-proxy"
  commoditiesSold {
    commodityType: VCPU
    used: 9.001707659177999
    capacity: 5327.556
    peak: 9.001707659177999
    resizable: true
  }
  commoditiesSold {
    commodityType: VMEM
    used: 36076.0
    capacity: 1048576.0
    peak: 36076.0
    resizable: true
  }
```
3. No resizing reservation action is generated anymore.

4. Resizing requests actions can be generated, for example:
<img width="1083" alt="Screen Shot 2020-05-28 at 01 53 35" src="https://user-images.githubusercontent.com/23689754/83104128-17962880-a086-11ea-94f9-aca046b1a7c9.png">

5. Resizing requests action can be successfully executed with following log messages:
```
I0527 18:14:28.521437   30759 turbo_probe.go:194] Execute Action for Target: [key:"serverVersion" stringValue:"v1.17.5"  key:"imageID" stringValue:""  key:"masterHost" stringValue:"https://10.10.170.172:6443"  key:"targetIdentifier" stringValue:"Kubernetes-kubernetes-dc11-test-test"  key:"image" stringValue:"" ]
I0527 18:14:28.521509   30759 action_handler.go:327] Received an action RIGHT_SIZE for entity CONTAINER [history-test/memory-low-util-7985cd9c49-6lj2b/memory-low-util]
I0527 18:14:28.555502   30759 resize_container.go:159] Resize pod-memory-low-util-7985cd9c49-6lj2b VMEM_REQUEST Capacity to 3071
I0527 18:14:28.565088   30759 resize_container_util.go:179] Begin to consistently resize Deployment of pod history-test/memory-low-util-7985cd9c49-6lj2b.
I0527 18:14:28.565117   30759 k8s_controller_updater.go:97] Begin to update Deployment of pod history-test/memory-low-util-7985cd9c49-6lj2b
I0527 18:14:28.575545   30759 k8s_controller_updater.go:139] Update container history-test/memory-low-util-7985cd9c49-6lj2b-0 resources in the pod specification.
I0527 18:14:28.575568   30759 resize_container_util.go:21] Begin to update Request.
I0527 18:14:28.575576   30759 resize_container_util.go:40] Try to update container memory-low-util resource request from map[memory:{i:{value:10485760 scale:0} d:{Dec:<nil>} s:10Mi Format:BinarySI}] to map[memory:{i:{value:3144704 scale:0} d:{Dec:<nil>} s:3071Ki Format:BinarySI}]
I0527 18:14:28.607051   30759 k8s_controller_updater.go:115] Successfully updated Deployment of pod history-test/memory-low-util-7985cd9c49-6lj2b
I0527 18:14:28.607072   30759 go_util.go:56] [retry-1/3] success
```