### PR TITLE
Set ApplicationCommodity key to service UID instead of service name sold by Application and bought by VApp to fix incorrect plan scope

### DIFF
--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -137,7 +137,8 @@ func (builder *applicationEntityDTOBuilder) getCommoditiesSold(pod *api.Pod, ind
 	// Service is associated with the pod, then the commodities key is the service Id,
 	// Else, it is computed using the container IP
 	if svc != nil {
-		key = util.GetServiceClusterID(svc)
+		// Use svc UID as key to be universally unique across different clusters
+		key = string(svc.UID)
 	} else {
 		key = pod.Status.PodIP
 	}

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -69,7 +69,7 @@ func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpec *reposi
 		// ContainerSpec entity
 		commodities, exists := containerSpec.ContainerCommodities[commodityType]
 		if !exists {
-			glog.Errorf("ContainerSpec %s has no %s commodity from the collected ContainerSpec",
+			glog.V(4).Infof("ContainerSpec %s has no %s commodity from the collected ContainerSpec",
 				containerSpec.ContainerSpecId, commodityType)
 			continue
 		}


### PR DESCRIPTION
**JIRA**:
1. https://vmturbo.atlassian.net/browse/OM-57752
2. https://vmturbo.atlassian.net/browse/OM-57889 (duplicate of OM-57752)
3. https://vmturbo.atlassian.net/browse/OM-59291

**Intent**:
1. Set ApplicationCommodity key to service UID instead of service name sold by Application and bought by VirtualApplication to fix incorrect plan scope, which could lead to unexpected action results.
2. Change logging "has no (VCPU_REQUEST | VMEM_REQUEST) commodity from the collected ContainerSpec" from Error to v4 Info (by default log level is v2)

**Problem**:
1. OM-57752 -- In a Turbo server with multiple Kubeturbo targets, after running a plan on one cluster (VMs by xx Cluster), there are some unexpected actions like reconfigure action or suspend action on the entities which do not belong to this cluster. This is very confusing to users.
2. OM-59291 -- There are too many "has no (VCPU_REQUEST | VMEM_REQUEST) commodity from the collected ContainerSpec" messages printed each discovery cycle.

**Diagnosis**:
1. **OM-57752**

The issue is due to the way we construct the key of ApplicationCommodity sold by Application and bought by VirtualApplication (Service): `namespace/service_name`, which could be duplicate across different clusters.

In the Turbo server side, when running a plan, the scoped entities set is created via provider and consumer relationships of the initial user defined scope. For example, if the scope is a group of VMs, then the logic will find out the entities which consume from or provided by these VMs and then iteratively find the corresponding entities from those entities. Specifically, the potential sellers of each corresponding entity will be added to the final scoped entities set.

The problem happens on VirtualApplication. There are 2 different VApp with the same name and namespace from 2 different K8s clusters: `vApp-istio-system/istio-ingressgateway`. When running a plan on cluster1, the corresponding Application (selling AppComm with key as service name) from cluster2 will be added to the plan scope as a potential seller of this VApp from cluster1; then additionally, the corresponding Container and ContainerPod from cluster2 will be also added to the plan scope, which finally leads in unexpected actions.

2. **OM-59291**:

When request is not defined on a container, the container does not sell the request commodity and the corresponding ContainerSpec entity does not sell request commodity either. It's a valid case that ContainerSpec entity has no VCPU/VMem request commodity. So we just need to change the log from Error to V4 Info.

**Solution**:
**OM-57752**
Use “service_UID“ instead of “namespace/service_name“ as the key of ApplicationCommodity sold by Application and bought by VirtualApplication.
**OM-59291**:
Change the log from Error to V4 Info.

**Testing Done**:
Added 2 kubeturbo targets where there are service with same name and namespace. Ran a custom plan on cluster1 with 159 Containers, 134 ContainerPods and 6 VMs.

1. Before the fix, a reconfigure action is generated on a Pod which belongs to a different cluster:
<img width="1363" alt="Screen Shot 2020-06-07 at 11 32 31" src="https://user-images.githubusercontent.com/23689754/83978561-6342a080-a8d6-11ea-9550-42bcbeb69fb2.png">

In discovery dto, a VApp buys AppComm with key as namespace/service_name:
```
entityDTO {
  entityType: VIRTUAL_APPLICATION
  id: "15e5de56-fb2e-11e9-97cf-005056803564"
  displayName: "vApp-openshift-monitoring/node-exporter"
  commoditiesBought {
    providerId: "App-16a4d8c7-fb2e-11e9-97cf-005056803564-0"
    bought {
      commodityType: APPLICATION
      key: "openshift-monitoring/node-exporter"
    }
    providerType: APPLICATION
  }
```
and corresponding Application sells AppComm with key:
```
entityDTO {
  entityType: APPLICATION
  id: "App-16a4a4b7-fb2e-11e9-97cf-005056803564-0"
  displayName: "App-openshift-monitoring/node-exporter-6j6gp/node-exporter"
  commoditiesSold {
    commodityType: APPLICATION
    key: "openshift-monitoring/node-exporter"
  }
```

2. After the fix, 

In the discovery dto, VApp is buying AppComm with key as service UID:
```
entityDTO {
  entityType: VIRTUAL_APPLICATION
  id: "15e5de56-fb2e-11e9-97cf-005056803564"
  displayName: "vApp-openshift-monitoring/node-exporter"
  commoditiesBought {
    providerId: "App-1782c430-fb2e-11e9-97cf-005056803564-1"
    bought {
      commodityType: APPLICATION
      key: "15e5de56-fb2e-11e9-97cf-005056803564-1"
    }
    providerType: APPLICATION
  }
```
and the corresponding Application is selling AppComm with key as service UID:
```
entityDTO {
  entityType: APPLICATION
  id: "App-1782c430-fb2e-11e9-97cf-005056803564-1"
  displayName: "App-openshift-monitoring/node-exporter-z2qph/kube-rbac-proxy"
  commoditiesSold {
    commodityType: APPLICATION
    key: "15e5de56-fb2e-11e9-97cf-005056803564-1"
  }
```

After running a custom plan on the cluster1, the reconfigure action is gone:
<img width="1357" alt="Screen Shot 2020-06-07 at 11 47 02" src="https://user-images.githubusercontent.com/23689754/83978571-78b7ca80-a8d6-11ea-9096-058d2e09d208.png">
By double checking the log message, the scoped entities are shown correctly:

```
topology-processor-578bdd5486-2b 2020-06-07 15:46:06,913  INFO [plan-pipeline-runner-0] 
[Stages$BroadcastStage]	: Successfully sent 563 entities within topology 73497131060976 for 
context 214234619405632 and broadcast of type TopologyBroadcastImpl. Type breakdown: 
{VIRTUAL_MACHINE=6[7 KB], APPLICATION=159[103 KB], CONTAINER_POD=134[229 KB], 
VIRTUAL_APPLICATION=18[7 KB], WORKLOAD_CONTROLLER=73[66 KB], CONTAINER=159[156 
KB], NAMESPACE=14[7 KB]}
```

---
Furthermore, tested the changes with arm1.1 kubeturbo changes in ARM1.1 build (7.21.200-EA1), the stitching is still working properly between prometurbo and kubeturbo:
<img width="1085" alt="Screen Shot 2020-06-05 at 16 49 26" src="https://user-images.githubusercontent.com/23689754/83978629-e2d06f80-a8d6-11ea-91ea-3aaeb96fe233.png">

---
For **OM-59291**,

before the change, with default v2 log level, lots of "has no (VCPU_REQUEST | VMEM_REQUEST) commodity from the collected ContainerSpec" messages are printed every discovery cycle;

after the changes, no such messages are printed in v2 level.