### PR TITLE
Delete the original outdated doc

### DIFF
--- a/docs/design/actions/move.md
+++ b/docs/design/actions/move.md
@@ -1,38 +1,20 @@
-# movePod #
-[This project](https://github.com/songbinliu/movePod) demonstrates a method that moves pods, which either are created by ReplicationController, or by ReplicaSet(which may be created by Deployment).
+# Pod move
+move a pod which is controlled by a ReplicationController, or ReplicaSet, or Deployment(via ReplicaSet).
 
-# Method #
-**1.** set the schedulerName of the parent object (ReplicationController, or ReplicaSet) of the pod to a **invalid scheduler**; 
-
-**2.** move the pod by [**Copy-Kill-Create**](https://github.com/songbinliu/movePod/blob/master/util.go#L273) steps, and uses the **Binding-on-Creation** way by assigning [pod.Spec.NodeName](https://github.com/kubernetes/client-go/blob/master/pkg/api/v1/types.go#L2470)
-when to create the new the Pod. 
-
-**3.** restore the schedulerName of the parent object.
-
-It should be noted that, if the pod has no parent object, then only the second step is necessary.
-
-# How it works #
-
-It is difficult to move a Pod controlled by ReplicationController/ReplicaSet, because in the second step of 
-the [**Copy-Delete-Create**] move operation, the ReplicationController/ReplicaSet will create a new Pod immediately 
-to make sure there is enough number of Running replicas. However, ReplicationController/ReplicaSet also amkes sure that 
-there is no more than desired number of Running replicas. So the pod created by our move operation have to 
-compete with the pod created by ReplicationController/ReplicaSet: [the first to get to the **running** 
-state will survive (see experiment)](https://gist.github.com/songbinliu/7576bd84bab50f4e399d979d7998cdf6#an-experiment).
-
-If we can make sure that the pod created by ReplicationController/ReplicaSet is scheduled **later than** the pod 
-created by our move operation, then our pod will almost alway be quicker to get to **running** state. We achive this 
-by assigning an none-exist scheduler name to the ReplictionController/ReplicaSet before the **Delete** step: which makes sure 
-the pod created by ReplicationController/ReplicaSet won't be scheduled. And because our pod don't need to be scheduled, 
-and bind to the new node directly. So our pod will get to the **running** state first. 
-(But if it takes too much time to run the pod or failed to run the pod, then our pod will be deleted.)
-
-In the end of the move operation, we restore the scheduler name of the ReplicationController/ReplicaSet, 
-to clear our modifiaction to the parent Controller.
-
-
-# Running Example #
-Test this method [here](https://github.com/songbinliu/movePod).
-
-# Other Info #
-Here are some [experiments](https://gist.github.com/songbinliu/6b28a15ac718a070ab66cff44f0cc056) about Kubernetes 1.6 [advanced scheduling feature](http://blog.kubernetes.io/2017/03/advanced-scheduling-in-kubernetes.html).
+# Three steps
+ 1. Create a clone Pod of the original Pod
+ 
+   The cloned pod **podA** has everything except the labels and podName of the original Pod.
+   Since **podA** has no labels, no controller will try to adopt it.
+   
+ 2. Delete the original Pod
+ 
+   Once the original Pod get deleted, the controller will create another new Pod **podB**.
+   
+ 3. Update the new Pod **podA** by adding the labels
+ 
+   Once **podA** get the labels, the matched controller will try to [adopt it](https://github.com/kubernetes/kubernetes/blob/fa557ee7921fc8305d4978e66eb653c92ed1a7ce/pkg/controller/replicaset/replica_set.go#L333). After [the adoption](https://github.com/kubernetes/kubernetes/blob/4beb0c2f8634054950cb7ca0b4c24a12aadc612e/pkg/controller/replicaset/replica_set.go#L616), the number of living pods
+   for the controller will be one more than the specified replica number, so controller will [select one pod to delete](https://github.com/kubernetes/kubernetes/blob/4beb0c2f8634054950cb7ca0b4c24a12aadc612e/pkg/controller/replicaset/replica_set.go#L623).
+   In this case, both **podA** ad **podB** is running, but **podA** is older than **podB**, so **podB** will get deleted. 
+ 
+ 


### PR DESCRIPTION
The current doc is outdated and doesn't reflect how Move action execution is implemented. We got question about how we perform move all the time, updating the doc is necessary.