### PR TITLE
Enable resize for application component

### DIFF
--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -123,7 +123,7 @@ func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO
 	app := proto.EntityDTO_APPLICATION_COMPONENT
 	appPolicy := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
 	appPolicy[proto.ActionItemDTO_PROVISION] = recommend
-	appPolicy[proto.ActionItemDTO_RIGHT_SIZE] = notSupported
+	appPolicy[proto.ActionItemDTO_RIGHT_SIZE] = recommend
 	appPolicy[proto.ActionItemDTO_MOVE] = notSupported
 	appPolicy[proto.ActionItemDTO_SUSPEND] = recommend
 

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -67,7 +67,7 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 
 	expected_app := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
 	expected_app[move] = notSupported
-	expected_app[resize] = notSupported
+	expected_app[resize] = recommend
 	expected_app[provision] = recommend
 	expected_app[suspend] = recommend
 


### PR DESCRIPTION
Since `DIF/Prometurbo` will discover resizable commodities such as Heap for an Application Component, we need to enable resize in `kubeturbo` action policy, otherwise, `ProbeActionCapabilitiesApplicatorEditor` in TP will disable resize for Application Component.