### PR TITLE
Make group name shorter

### DIFF
--- a/pkg/discovery/dtofactory/cluster_dto_builder.go
+++ b/pkg/discovery/dtofactory/cluster_dto_builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/turbo-go-sdk/pkg/builder/group"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
@@ -40,8 +41,8 @@ func (builder *clusterDTOBuilder) Build() []*proto.GroupDTO {
 	}
 	// Create a regular group of VM without cluster constraint
 	// This group can be removed when the server is upgraded to 7.21.2+
-	vmGroupID := fmt.Sprintf("%s[VM]", builder.targetId)
-	vmGroupDisplayName := fmt.Sprintf("VMs By Cluster [%s]", builder.targetId)
+	vmGroupID := fmt.Sprintf("%s-%s", builder.targetId, metrics.ClusterType)
+	vmGroupDisplayName := fmt.Sprintf("%s/%s", metrics.ClusterType, builder.targetId)
 	vmGroupDTO, err := group.StaticGroup(vmGroupID).
 		OfType(proto.EntityDTO_VIRTUAL_MACHINE).
 		WithEntities(members).

--- a/pkg/discovery/dtofactory/group_dto_builder.go
+++ b/pkg/discovery/dtofactory/group_dto_builder.go
@@ -106,7 +106,7 @@ func (builder *groupDTOBuilder) createGroupsByEntityType(entityGroup *repository
 	groupId := entityGroup.GroupId
 	isClusterWideGroup := entityGroup.ParentName == ""
 	if isClusterWideGroup {
-		groupId = fmt.Sprintf("%s::All %ss", entityGroup.GroupId, entityGroup.ParentKind)
+		groupId = fmt.Sprintf("%s/All", entityGroup.GroupId)
 	}
 
 	// resize setting for entities is based on the parent type of the group and if sub groups will be created.
@@ -144,7 +144,7 @@ func (builder *groupDTOBuilder) createSubGroups(entityGroup *repository.EntityGr
 		etype := metrics.ContainerType
 		protoType := proto.EntityDTO_CONTAINER
 
-		groupId := fmt.Sprintf("%s::%s", entityGroup.GroupId, containerName)
+		groupId := fmt.Sprintf("%s/%s", entityGroup.GroupId, containerName)
 
 		// resize policy setting based on the parent type of the group
 		resizeFlag := isConsistentResizableByParent(entityGroup)
@@ -164,8 +164,8 @@ func (builder *groupDTOBuilder) createGroup(entityGroup *repository.EntityGroup,
 	memberList []string, consistentResizeFlag bool) *proto.GroupDTO {
 
 	// group id created using the parent type, name and target identifier
-	id := fmt.Sprintf("%s-%s[%s]", groupId, builder.targetId, entityType)
-	displayName := fmt.Sprintf("%ss By %s [%s]", entityType, groupId, builder.targetId)
+	id := fmt.Sprintf("%s-%s-%s", groupId, builder.targetId, entityType)
+	displayName := fmt.Sprintf("%s %ss", groupId, entityType)
 
 	// static group
 	groupBuilder := group.StaticGroup(id).

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -9,7 +9,7 @@ type DiscoveredEntityType string
 type ResourceType string
 
 const (
-	ClusterType     DiscoveredEntityType = "Cluster"
+	ClusterType     DiscoveredEntityType = "VMCluster"
 	NamespaceType   DiscoveredEntityType = "Namespace"
 	NodeType        DiscoveredEntityType = "Node"
 	ControllerType  DiscoveredEntityType = "Controller"

--- a/pkg/discovery/worker/group_metrics_collector.go
+++ b/pkg/discovery/worker/group_metrics_collector.go
@@ -44,7 +44,7 @@ func (collector *GroupMetricsCollector) CollectGroupMetrics() ([]*repository.Ent
 		}
 
 		podId := string(pod.UID)
-		groupKey := fmt.Sprintf("%s::%s/%s", ownerTypeString, pod.Namespace, ownerString)
+		groupKey := fmt.Sprintf("%s/%s/%s", ownerTypeString, pod.Namespace, ownerString)
 
 		// group1 = A group for each parent qualified as namespace/parentName of this kind/type
 		if _, groupExists := entityGroups[groupKey]; !groupExists {


### PR DESCRIPTION
The group names created right now are too long, and it looks cluttered on the UI. 

The following are some screenshots after the modification:

* Single container pod, same name from different clusters
![image](https://user-images.githubusercontent.com/10012486/85910244-cb0c4d00-b7eb-11ea-8909-ea1397845228.png)

* Pod with multiple containers
![image](https://user-images.githubusercontent.com/10012486/85910261-dbbcc300-b7eb-11ea-9d2b-5f8b64bb7bca.png)

* VM clusters
![image](https://user-images.githubusercontent.com/10012486/85910273-ea0adf00-b7eb-11ea-85f1-b9ea415ddc39.png)

* Auto-generated policies
![image](https://user-images.githubusercontent.com/10012486/85910299-0444bd00-b7ec-11ea-960b-637d858dfc2e.png)

* Plan scope of auto-generated groups
![image](https://user-images.githubusercontent.com/10012486/85910327-23434f00-b7ec-11ea-887a-17fc2a88bbd9.png)
