### PR TITLE
Storage volumes support

### DIFF
--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+
 	"k8s.io/client-go/dynamic"
 
 	api "k8s.io/api/core/v1"
@@ -32,6 +33,8 @@ type ClusterScraperInterface interface {
 	GetAllEndpoints() ([]*api.Endpoints, error)
 	GetAllServices() ([]*api.Service, error)
 	GetKubernetesServiceID() (svcID string, err error)
+	GetAllPVs() ([]*api.PersistentVolume, error)
+	GetAllPVCs() ([]*api.PersistentVolumeClaim, error)
 }
 
 type ClusterScraper struct {
@@ -221,4 +224,42 @@ func (s *ClusterScraper) findRunningPodsOnNode(nodeName string) ([]*api.Pod, err
 		pods[i] = &podList.Items[i]
 	}
 	return pods, nil
+}
+
+func (s *ClusterScraper) GetAllPVs() ([]*api.PersistentVolume, error) {
+	listOption := metav1.ListOptions{
+		LabelSelector: labelSelectEverything,
+	}
+
+	pvList, err := s.CoreV1().PersistentVolumes().List(listOption)
+	if err != nil {
+		return nil, err
+	}
+
+	pvs := make([]*api.PersistentVolume, len(pvList.Items))
+	for i := 0; i < len(pvList.Items); i++ {
+		pvs[i] = &pvList.Items[i]
+	}
+	return pvs, nil
+}
+
+func (s *ClusterScraper) GetAllPVCs() ([]*api.PersistentVolumeClaim, error) {
+	listOption := metav1.ListOptions{
+		LabelSelector: labelSelectEverything,
+	}
+
+	return s.GetPVCs(api.NamespaceAll, listOption)
+}
+
+func (s *ClusterScraper) GetPVCs(namespace string, opts metav1.ListOptions) ([]*api.PersistentVolumeClaim, error) {
+	pvcList, err := s.CoreV1().PersistentVolumeClaims(namespace).List(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	pvcs := make([]*api.PersistentVolumeClaim, len(pvcList.Items))
+	for i := 0; i < len(pvcList.Items); i++ {
+		pvcs[i] = &pvcList.Items[i]
+	}
+	return pvcs, nil
 }

--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -27,6 +27,7 @@ var (
 		metrics.MemoryRequestQuota: proto.CommodityDTO_VMEM_REQUEST_QUOTA,
 		metrics.NumPods:            proto.CommodityDTO_NUMBER_CONSUMERS,
 		metrics.VStorage:           proto.CommodityDTO_VSTORAGE,
+		metrics.StorageAmount:      proto.CommodityDTO_STORAGE_AMOUNT,
 	}
 )
 

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -387,9 +387,7 @@ func (builder *podEntityDTOBuilder) buyCommoditiesFromVolumes(pod *api.Pod, moun
 		dtoBuilder = dtoBuilder.Provider(provider)
 
 		// Each pod mounts any given volume only once
-		var singleCommoditySlice []*proto.CommodityDTO
-		singleCommoditySlice = append(singleCommoditySlice, commBought)
-		dtoBuilder.BuysCommodities(singleCommoditySlice)
+		dtoBuilder.BuysCommodities([]*proto.CommodityDTO{commBought})
 	}
 
 	return nil

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -10,6 +10,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	v1 "k8s.io/api/core/v1"
 
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
@@ -164,7 +165,7 @@ func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod, podToVolsMa
 		}
 
 		// entities' properties.
-		properties, err := builder.getPodProperties(pod)
+		properties, err := builder.getPodProperties(pod, podToVolsMap[displayName])
 		if err != nil {
 			glog.Errorf("Failed to get required pod properties: %s", err)
 			continue
@@ -395,7 +396,7 @@ func (builder *podEntityDTOBuilder) buyCommoditiesFromVolumes(pod *api.Pod, moun
 }
 
 // Get the properties of the pod. This includes property related to pod cluster property.
-func (builder *podEntityDTOBuilder) getPodProperties(pod *api.Pod) ([]*proto.EntityDTO_EntityProperty, error) {
+func (builder *podEntityDTOBuilder) getPodProperties(pod *api.Pod, vols []repository.MountedVolume) ([]*proto.EntityDTO_EntityProperty, error) {
 	var properties []*proto.EntityDTO_EntityProperty
 	// additional node cluster info property.
 	podProperties := property.BuildPodProperties(pod)
@@ -412,6 +413,24 @@ func (builder *podEntityDTOBuilder) getPodProperties(pod *api.Pod) ([]*proto.Ent
 		return nil, fmt.Errorf("failed to build EntityDTO for Pod %s: %s", podClusterID, err)
 	}
 	properties = append(properties, stitchingProperty)
+
+	if len(vols) > 0 {
+		var apiVols []*v1.PersistentVolume
+		for _, vol := range vols {
+			apiVols = append(apiVols, vol.UsedVolume)
+		}
+
+		m := stitching.NewVolumeStitchingManager()
+		err := m.ProcessVolumes(apiVols)
+		if err == nil {
+			p, err := m.BuildDTOProperty(false)
+			if err == nil {
+				properties = append(properties, p)
+			} else {
+				glog.Errorf("failed to build Volume stitching properties for Pod %s: %s", podClusterID, err)
+			}
+		}
+	}
 
 	return properties, nil
 }

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -3,8 +3,6 @@ package dtofactory
 import (
 	"fmt"
 
-	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
-
 	api "k8s.io/api/core/v1"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -3,11 +3,12 @@ package dtofactory
 import (
 	"testing"
 
+	"reflect"
+
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 )
 
 var builder = &podEntityDTOBuilder{

--- a/pkg/discovery/dtofactory/property/volume_properties.go
+++ b/pkg/discovery/dtofactory/property/volume_properties.go
@@ -1,0 +1,23 @@
+package property
+
+import (
+	api "k8s.io/api/core/v1"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+const (
+	k8sVolumeName = "KubernetesVolumeName"
+)
+
+// Build entity properties for a volume. The name is the name of the volume shown inside Kubernetes cluster.
+func BuildVolumeProperties(vol *api.PersistentVolume) *proto.EntityDTO_EntityProperty {
+	propertyNamespace := k8sPropertyNamespace
+	propertyName := k8sVolumeName
+	propertyValue := vol.Name
+	return &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &propertyName,
+		Value:     &propertyValue,
+	}
+}

--- a/pkg/discovery/dtofactory/volume_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/volume_entity_dto_builder.go
@@ -1,0 +1,128 @@
+package dtofactory
+
+import (
+	"fmt"
+
+	api "k8s.io/api/core/v1"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
+	"github.com/golang/glog"
+)
+
+type volumeEntityDTOBuilder struct {
+	podVolumeMetrics []*repository.PodVolumeMetrics
+}
+
+func NewVolumeEntityDTOBuilder(podVolumeMetrics []*repository.PodVolumeMetrics) *volumeEntityDTOBuilder {
+	return &volumeEntityDTOBuilder{
+		podVolumeMetrics: podVolumeMetrics,
+	}
+}
+
+// Build entityDTOs based on the given volume to pod mappings.
+func (builder *volumeEntityDTOBuilder) BuildEntityDTOs(volToPodsMap map[*api.PersistentVolume][]repository.PodVolume) ([]*proto.EntityDTO, error) {
+	var result []*proto.EntityDTO
+
+	for vol, podVolumes := range volToPodsMap {
+		volID := string(vol.UID)
+		entityDTOBuilder := sdkbuilder.NewEntityDTOBuilder(proto.EntityDTO_VIRTUAL_VOLUME, volID)
+		displayName := vol.Name
+		entityDTOBuilder.DisplayName(displayName)
+
+		commoditiesSold, cap, err := builder.getVolumeCommoditiesSold(vol, podVolumes)
+		if err != nil {
+			glog.Errorf("Error when create commoditiesSold for volume %s: %s", displayName, err)
+		}
+
+		entityDTOBuilder.SellsCommodities(commoditiesSold)
+
+		// entities' properties.
+		properties := builder.getVolumeProperties(vol)
+		entityDTOBuilder = entityDTOBuilder.WithProperties(properties)
+
+		entityDTOBuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
+
+		// build entityDTO.
+		entityDto, err := entityDTOBuilder.Create()
+		if err != nil {
+			glog.Errorf("Failed to build Volume: %s entityDTO: %s", displayName, err)
+			continue
+		}
+
+		volCapacity := float32(cap)
+		isEphemaral := false
+		virtualVolumeData := &proto.EntityDTO_VirtualVolumeData{
+			StorageAmountCapacity: &volCapacity,
+			IsEphemeral:           &isEphemaral,
+		}
+		entityDto.EntityData = &proto.EntityDTO_VirtualVolumeData_{VirtualVolumeData: virtualVolumeData}
+
+		result = append(result, entityDto)
+	}
+
+	return result, nil
+
+}
+
+func (builder *volumeEntityDTOBuilder) getVolumeCommoditiesSold(vol *api.PersistentVolume, podVols []repository.PodVolume) ([]*proto.CommodityDTO, float64, error) {
+	var commoditiesSold []*proto.CommodityDTO
+
+	volumeCapacity := float64(0)
+	for _, podVol := range podVols {
+		podKey := podVol.QualifiedPodName
+		mountName := podVol.MountName
+		// Volume capacity metrics is available as part of volume spec.
+		// However we dont use that if the actual queried volume size
+		// is available and discovered by the kubelet as part of
+		// pod metrics for that volume. If a volume is not mounted, then
+		// we use the capacity listed in volume spec.
+		capacity, used, found := builder.getVolumeMetrics(vol, podVol.QualifiedPodName, podVol.MountName)
+		if !found {
+			continue
+		}
+		volumeCapacity = capacity
+
+		commKey := fmt.Sprintf("%s/%s", podKey, mountName)
+		commBuilder := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_STORAGE_AMOUNT).Key(commKey)
+		commBuilder.Used(used)
+		commBuilder.Peak(used)
+		commBuilder.Capacity(capacity)
+		commodityPerPod, err := commBuilder.Create()
+		if err != nil {
+			return nil, volumeCapacity, err
+		}
+
+		// TODO(irfanurrehman): Set resisable depending on node properties
+
+		commoditiesSold = append(commoditiesSold, commodityPerPod)
+	}
+
+	return commoditiesSold, volumeCapacity, nil
+}
+
+func (builder *volumeEntityDTOBuilder) getVolumeMetrics(vol *api.PersistentVolume, podKey, mountName string) (float64, float64, bool) {
+	for _, metricEntry := range builder.podVolumeMetrics {
+		if metricEntry.Volume.Name == vol.Name &&
+			metricEntry.MountName == mountName &&
+			metricEntry.QualifiedPodName == podKey {
+			return metricEntry.Capacity, metricEntry.Used, true
+		}
+	}
+
+	return float64(0), float64(0), false
+}
+
+// Get the properties of the volume.
+// TODO(irfanurrehman): Add stitching properties.
+func (builder *volumeEntityDTOBuilder) getVolumeProperties(vol *api.PersistentVolume) []*proto.EntityDTO_EntityProperty {
+	var properties []*proto.EntityDTO_EntityProperty
+
+	volProperty := property.BuildVolumeProperties(vol)
+	properties = append(properties, volProperty)
+
+	return properties
+}

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -286,9 +286,10 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 	volumeEntityDTOs, err := volumeEntityDTOBuilder.BuildEntityDTOs(clusterSummary.VolumeToPodsMap)
 	if err != nil {
 		glog.Errorf("Error while creating volume entityDTOs: %v", err)
+	} else {
+		glog.V(2).Infof("There are %d Storage Volume entityDTOs.", len(volumeEntityDTOs))
+		entityDTOs = append(entityDTOs, volumeEntityDTOs...)
 	}
-	glog.V(3).Infof("There are %d Storage Volume entityDTOs.", len(volumeEntityDTOs))
-	entityDTOs = append(entityDTOs, volumeEntityDTOs...)
 
 	glog.V(2).Infof("There are totally %d entityDTOs.", len(entityDTOs))
 

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -33,6 +33,7 @@ const (
 	Transaction        ResourceType = "Transaction"
 	NumPods            ResourceType = "NumPods"
 	VStorage           ResourceType = "VStorage"
+	StorageAmount      ResourceType = "StorageAmount"
 
 	Access       ResourceType = "Access"
 	Cluster      ResourceType = "Cluster"

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -17,6 +17,7 @@ const (
 	ContainerType   DiscoveredEntityType = "Container"
 	ApplicationType DiscoveredEntityType = "Application"
 	ServiceType     DiscoveredEntityType = "Service"
+	VolumeType      DiscoveredEntityType = "Volume"
 )
 
 const (

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -210,11 +210,7 @@ func (m *KubeletMonitor) parseVolumeStats(volStats []stats.VolumeStats, podKey s
 			used = util.Base2BytesToMegabytes(float64(*volStat.UsedBytes))
 		}
 
-		var pvcRef stats.PVCReference
-		if volStat.PVCRef != nil {
-			pvcRef = *volStat.PVCRef
-		}
-		volKey := util.PodVolumeMetricId(podKey, volStat.Name, pvcRef)
+		volKey := util.PodVolumeMetricId(podKey, volStat.Name)
 		// TODO: Generate used on etype pod and capacity on etype volume once
 		// etype volume is in place
 		m.genPVMetrics(metrics.PodType, volKey, capacity, used)

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -175,5 +175,8 @@ func (p *ClusterProcessor) DiscoverCluster() (*repository.KubeCluster, error) {
 	// Discover Services
 	NewServiceProcessor(p.clusterInfoScraper, kubeCluster).ProcessServices()
 
+	// Discover volumes
+	NewVolumeProcessor(p.clusterInfoScraper, kubeCluster).ProcessVolumes()
+
 	return kubeCluster, nil
 }

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -296,6 +296,8 @@ type MockClusterScrapper struct {
 	mockGetAllEndpoints        func() ([]*v1.Endpoints, error)
 	mockGetAllServices         func() ([]*v1.Service, error)
 	mockGetKubernetesServiceID func() (svcID string, err error)
+	mockGetAllPVs              func() ([]*v1.PersistentVolume, error)
+	mockGetAllPVCs             func() ([]*v1.PersistentVolumeClaim, error)
 }
 
 func (s *MockClusterScrapper) GetAllNodes() ([]*v1.Node, error) {
@@ -343,9 +345,24 @@ func (s *MockClusterScrapper) GetKubernetesServiceID() (string, error) {
 	}
 	return "", fmt.Errorf("GetKubernetesServiceID Not implemented")
 }
+
 func (s *MockClusterScrapper) GetAllServices() ([]*v1.Service, error) {
 	if s.mockGetAllServices != nil {
 		return s.mockGetAllServices()
+	}
+	return nil, fmt.Errorf("GetAllServices Not implemented")
+}
+
+func (s *MockClusterScrapper) GetAllPVs() ([]*v1.PersistentVolume, error) {
+	if s.mockGetAllPVs != nil {
+		return s.mockGetAllPVs()
+	}
+	return nil, fmt.Errorf("GetAllServices Not implemented")
+}
+
+func (s *MockClusterScrapper) GetAllPVCs() ([]*v1.PersistentVolumeClaim, error) {
+	if s.mockGetAllPVCs != nil {
+		return s.mockGetAllPVCs()
 	}
 	return nil, fmt.Errorf("GetAllServices Not implemented")
 }

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -357,14 +357,14 @@ func (s *MockClusterScrapper) GetAllPVs() ([]*v1.PersistentVolume, error) {
 	if s.mockGetAllPVs != nil {
 		return s.mockGetAllPVs()
 	}
-	return nil, fmt.Errorf("GetAllServices Not implemented")
+	return nil, fmt.Errorf("GetAllPVs Not implemented")
 }
 
 func (s *MockClusterScrapper) GetAllPVCs() ([]*v1.PersistentVolumeClaim, error) {
 	if s.mockGetAllPVCs != nil {
 		return s.mockGetAllPVCs()
 	}
-	return nil, fmt.Errorf("GetAllServices Not implemented")
+	return nil, fmt.Errorf("GetAllPVCs Not implemented")
 }
 
 // Implements the KubeHttpClientInterface

--- a/pkg/discovery/processor/volume_processor.go
+++ b/pkg/discovery/processor/volume_processor.go
@@ -108,7 +108,7 @@ func inverseVolToPodsMap(volToPodsMap map[*v1.PersistentVolume][]repository.PodV
 	for vol, podVols := range volToPodsMap {
 		for _, podVol := range podVols {
 			podToVolsMap[podVol.QualifiedPodName] = append(podToVolsMap[podVol.QualifiedPodName],
-				repository.MountedVolume{vol, podVol.MountName})
+				repository.MountedVolume{UsedVolume: vol, MountName: podVol.MountName})
 		}
 	}
 	return podToVolsMap

--- a/pkg/discovery/processor/volume_processor.go
+++ b/pkg/discovery/processor/volume_processor.go
@@ -1,0 +1,115 @@
+package processor
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	v1 "k8s.io/api/core/v1"
+)
+
+type VolumeProcessor struct {
+	ClusterInfoScraper cluster.ClusterScraperInterface
+	KubeCluster        *repository.KubeCluster
+}
+
+func NewVolumeProcessor(kubeClient cluster.ClusterScraperInterface,
+	kubeCluster *repository.KubeCluster) *VolumeProcessor {
+	return &VolumeProcessor{
+		ClusterInfoScraper: kubeClient,
+		KubeCluster:        kubeCluster,
+	}
+}
+
+func (p *VolumeProcessor) ProcessVolumes() {
+	clusterName := p.KubeCluster.Name
+	pvList, err := p.ClusterInfoScraper.GetAllPVs()
+	if err != nil {
+		glog.Errorf("Failed to get persistent volumes for cluster %s: %v.", clusterName, err)
+		return
+	}
+	glog.V(2).Infof("There are %d volumes.", len(pvList))
+
+	pvcList, err := p.ClusterInfoScraper.GetAllPVCs()
+	if err != nil {
+		glog.Errorf("Failed to get persistent volumes claims for cluster %s: %v.", clusterName, err)
+		return
+	}
+	glog.V(2).Infof("There are %d volume claims.", len(pvcList))
+
+	allPods, err := p.ClusterInfoScraper.GetAllPods()
+	if err != nil {
+		glog.Errorf("Failed to get all pods for cluster %s: %v.", clusterName, err)
+		return
+	}
+
+	// A map which lists the volume to pvc bindings (1 to 1)
+	// There can be volumes which are not bound via claims
+	// and pods use them directly.
+	volumeToClaimMap := make(map[*v1.PersistentVolume]*v1.PersistentVolumeClaim)
+	for _, pv := range pvList {
+		found := false
+		for _, pvc := range pvcList {
+			if pvc.Spec.VolumeName == pv.Name {
+				volumeToClaimMap[pv] = pvc
+				found = true
+				break
+			}
+		}
+		if !found {
+			volumeToClaimMap[pv] = nil
+		}
+	}
+
+	// TODO (irfanurrehman): We might need the volume name to map the metrics generated from pod
+	// and gathered via kubelet monitor to the individual volumes.
+	// TODO (irfanurrehman): (Next Step) To find out how are metrics generated for volumes which
+	// are used by multiple pods.
+	volumeToPodsMap := make(map[*v1.PersistentVolume][]repository.PodVolume)
+	for pv, pvc := range volumeToClaimMap {
+		if pvc == nil {
+			// Unused volume.
+			volumeToPodsMap[pv] = nil
+		}
+		for _, pod := range allPods {
+			for _, vol := range pod.Spec.Volumes {
+				claim := vol.VolumeSource.PersistentVolumeClaim
+				if claim != nil {
+					if pvc != nil {
+						if claim.ClaimName == pvc.Name {
+							pVol := repository.PodVolume{
+								QualifiedPodName: fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
+								MountName:        vol.Name,
+							}
+							volumeToPodsMap[pv] = append(volumeToPodsMap[pv], pVol)
+						}
+					}
+				} else {
+					// TODO (irfanurrehman): check other volume sources categorically.
+					// This could be another volume type directly used by pod.
+					// Pod owner must know all details of the cloud/storage volume
+					// and specify that explicitly as details here (There wont be any
+					// corresponding PV or PVC resource in k8s).
+					// Although archaic this is still possible and we will need to
+					// take a call if this needs support.
+				}
+			}
+
+		}
+	}
+
+	p.KubeCluster.VolumeToPodsMap = volumeToPodsMap
+	p.KubeCluster.PodToVolumesMap = inverseVolToPodsMap(volumeToPodsMap)
+}
+
+func inverseVolToPodsMap(volToPodsMap map[*v1.PersistentVolume][]repository.PodVolume) map[string][]repository.MountedVolume {
+	podToVolsMap := make(map[string][]repository.MountedVolume)
+	for vol, podVols := range volToPodsMap {
+		for _, podVol := range podVols {
+			podToVolsMap[podVol.QualifiedPodName] = append(podToVolsMap[podVol.QualifiedPodName],
+				repository.MountedVolume{vol, podVol.MountName})
+		}
+	}
+	return podToVolsMap
+}

--- a/pkg/discovery/processor/volume_processor.go
+++ b/pkg/discovery/processor/volume_processor.go
@@ -1,11 +1,10 @@
 package processor
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -79,7 +78,7 @@ func (p *VolumeProcessor) ProcessVolumes() {
 					if pvc != nil {
 						if claim.ClaimName == pvc.Name {
 							pVol := repository.PodVolume{
-								QualifiedPodName: fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
+								QualifiedPodName: util.PodKeyFunc(pod),
 								MountName:        vol.Name,
 							}
 							volumeToPodsMap[pv] = append(volumeToPodsMap[pv], pVol)

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -3,8 +3,9 @@ package repository
 import (
 	"bytes"
 	"fmt"
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"strings"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
@@ -22,6 +23,33 @@ type KubeCluster struct {
 	ClusterResources map[metrics.ResourceType]*KubeDiscoveredResource
 	// Map of Service to Pod cluster Ids
 	Services map[*v1.Service][]string
+	// Map of Persistent Volumes to namespace qualified pod names with their
+	// volume names (as named in podSpec).
+	// The unused PV will have the slice value set to nil.
+	VolumeToPodsMap map[*v1.PersistentVolume][]PodVolume
+	// Map of namespace qualified pod name wrt to the volumes they mount.
+	// This map will not feature volumes which are not mounted by any pods.
+	PodToVolumesMap map[string][]MountedVolume
+}
+
+type PodVolume struct {
+	// Namespace qualified pod name.
+	QualifiedPodName string
+	// Name used by the pod to mount the volume.
+	MountName string
+}
+
+type MountedVolume struct {
+	UsedVolume *v1.PersistentVolume
+	MountName  string
+}
+
+// Volume metrics reported for a given pod
+type PodVolumeMetrics struct {
+	Volume   *v1.PersistentVolume
+	Capacity float64
+	Used     float64
+	PodVolume
 }
 
 func NewKubeCluster(clusterName string, nodes []*v1.Node) *KubeCluster {
@@ -441,4 +469,26 @@ func parseAllocationResourceValue(resource v1.ResourceName, allocationResourceTy
 		return memoryKiloBytes
 	}
 	return DEFAULT_METRIC_VALUE
+}
+
+// =================================================================================================
+// The volumes in the cluster
+type KubeVolume struct {
+	*KubeEntity
+	*v1.PersistentVolume
+	ClusterName string
+}
+
+// Create a KubeVolume entity representing a volume in the cluster
+func NewKubeVolume(pv *v1.PersistentVolume, clusterName string) *KubeVolume {
+	entity := NewKubeEntity(metrics.VolumeType, clusterName,
+		pv.ObjectMeta.Namespace, pv.ObjectMeta.Name,
+		string(pv.ObjectMeta.UID))
+
+	volumeEntity := &KubeVolume{
+		KubeEntity:       entity,
+		PersistentVolume: pv,
+	}
+
+	return volumeEntity
 }

--- a/pkg/discovery/stitching/volume_stitching_manager.go
+++ b/pkg/discovery/stitching/volume_stitching_manager.go
@@ -1,0 +1,154 @@
+package stitching
+
+import (
+	"fmt"
+	"strings"
+
+	api "k8s.io/api/core/v1"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/builder"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"github.com/turbonomic/turbo-go-sdk/pkg/supplychain"
+
+	"github.com/golang/glog"
+)
+
+const (
+	proxyVolumeUUID = "Proxy_Volume_UUID"
+
+	awsVolPrefix   = "aws://"
+	azureVolPrefix = "azure://"
+	awsVolFormat   = "aws::%v::VL::%v"
+	azureVolFormat = "azure::VL::%v"
+)
+
+type VolumeStitchingManager struct {
+	stitchingUuids string
+}
+
+func NewVolumeStitchingManager() *VolumeStitchingManager {
+	return &VolumeStitchingManager{}
+}
+
+func (s *VolumeStitchingManager) ProcessVolumes(vols []*api.PersistentVolume) error {
+	uuids := []string{}
+	errorStrings := ""
+	atLeastOneProcessed := false
+	for _, vol := range vols {
+		var uuidGetter VolumeUUIDGetter
+		switch {
+		case vol.Spec.AWSElasticBlockStore != nil:
+			uuidGetter = &awsVolumeUUIDGetter{}
+		default:
+			uuidGetter = &defaultVolumeUUIDGetter{}
+		}
+		uuid, err := uuidGetter.GetVolumeUUID(vol)
+		if err != nil {
+			// skip this volume
+			glog.Errorf("Error processing volume: %v", err)
+			errorStrings = fmt.Sprintf("%s : %s", errorStrings, err.Error())
+		} else {
+			uuids = append(uuids, uuid)
+			atLeastOneProcessed = true
+		}
+	}
+
+	if !atLeastOneProcessed {
+		return fmt.Errorf(errorStrings)
+	}
+	s.stitchingUuids = strings.Join(uuids, ",")
+	return nil
+}
+
+// Get the property name based on whether it is a stitching or reconciliation.
+func (s *VolumeStitchingManager) getPropertyName(isForReconcile bool) string {
+	if isForReconcile {
+		return proxyVolumeUUID
+	}
+	return supplychain.SUPPLY_CHAIN_CONSTANT_UUID
+}
+
+func (s *VolumeStitchingManager) BuildDTOProperty(isForReconcile bool) (*proto.EntityDTO_EntityProperty, error) {
+	propertyNamespace := DefaultPropertyNamespace
+	propertyName := s.getPropertyName(isForReconcile)
+
+	return &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &propertyName,
+		Value:     &s.stitchingUuids,
+	}, nil
+}
+
+// Create the meta data that will be used during the reconciliation process.
+func (s *VolumeStitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_ReplacementEntityMetaData, error) {
+	replacementEntityMetaDataBuilder := builder.NewReplacementEntityMetaDataBuilder()
+
+	entity := proto.EntityDTO_VIRTUAL_VOLUME
+	// TODO use a constant, also find why is this different from supplychain.SUPPLY_CHAIN_CONSTANT_UUID
+	attribute := "Uuid"
+
+	propertyDef := &proto.ServerEntityPropDef{
+		Entity:    &entity,
+		Attribute: &attribute,
+	}
+	replacementEntityMetaDataBuilder.Matching(proxyVolumeUUID).MatchingExternal(propertyDef)
+
+	usedAndCapacityAndPeakPropertyNames := []string{builder.PropertyCapacity, builder.PropertyUsed, builder.PropertyPeak}
+	replacementEntityMetaDataBuilder.PatchSellingWithProperty(proto.CommodityDTO_STORAGE_AMOUNT, usedAndCapacityAndPeakPropertyNames)
+	meta := replacementEntityMetaDataBuilder.Build()
+	return meta, nil
+}
+
+type VolumeUUIDGetter interface {
+	GetVolumeUUID(vol *api.PersistentVolume) (string, error)
+	Name() string
+}
+
+type defaultVolumeUUIDGetter struct {
+}
+
+func (d *defaultVolumeUUIDGetter) Name() string {
+	return "Default"
+}
+
+func (d *defaultVolumeUUIDGetter) GetVolumeUUID(vol *api.PersistentVolume) (string, error) {
+	// TODO: Find a common id that suits most providers
+	uid := string(vol.UID)
+	if len(uid) < 1 {
+		return "", fmt.Errorf("vol uid is empty: %v", vol.Name)
+	}
+
+	return uid, nil
+}
+
+type awsVolumeUUIDGetter struct {
+}
+
+func (aws *awsVolumeUUIDGetter) Name() string {
+	return "AWS"
+}
+
+func (aws *awsVolumeUUIDGetter) GetVolumeUUID(vol *api.PersistentVolume) (string, error) {
+	if vol.Spec.AWSElasticBlockStore == nil {
+		return "", fmt.Errorf("not a valid AWS provisioned volume: %v", vol.Name)
+	}
+
+	volID := vol.Spec.AWSElasticBlockStore.VolumeID
+	//1. split the suffix into two parts:
+	// aws://us-east-2c/vol-0e4eaa3ef79bcb5a9 -> [us-east-2c, vol-0e4eaa3ef79bcb5a9]
+	suffix := volID[len(awsVolPrefix):]
+	parts := strings.Split(suffix, "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("failed to split uuid (%d): %v, for volume %v", len(parts), parts, vol.Name)
+	}
+
+	//2. get region by removing the zone suffix
+	if len(parts[0]) < 2 {
+		return "", fmt.Errorf("invalid zone Id: %v, for volume: %v", volID, vol.Name)
+	}
+	end := len(parts[0]) - 1
+	region := parts[0][0:end]
+
+	result := fmt.Sprintf(awsVolFormat, region, parts[1])
+	return result, nil
+}

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -19,6 +19,8 @@ type Task struct {
 
 	nodeList []*api.Node
 	podList  []*api.Pod
+	pvList   []*api.PersistentVolume
+	pvcList  []*api.PersistentVolumeClaim
 	cluster  *repository.ClusterSummary
 }
 
@@ -41,6 +43,18 @@ func (t *Task) WithPods(podList []*api.Pod) *Task {
 	return t
 }
 
+// Assign pvs to the task.
+func (t *Task) WithPVs(pvList []*api.PersistentVolume) *Task {
+	t.pvList = pvList
+	return t
+}
+
+// Assign pvcs to the task.
+func (t *Task) WithPVCs(pvcList []*api.PersistentVolumeClaim) *Task {
+	t.pvcList = pvcList
+	return t
+}
+
 // Assign cluster summary to the task.
 func (t *Task) WithCluster(cluster *repository.ClusterSummary) *Task {
 	t.cluster = cluster
@@ -55,6 +69,16 @@ func (t *Task) NodeList() []*api.Node {
 // Get pod list from the task.
 func (t *Task) PodList() []*api.Pod {
 	return t.podList
+}
+
+// Get PV list from the task.
+func (t *Task) PVList() []*api.PersistentVolume {
+	return t.pvList
+}
+
+// Get PVC list from the task.
+func (t *Task) PVCList() []*api.PersistentVolumeClaim {
+	return t.pvcList
 }
 
 func (t *Task) Cluster() *repository.ClusterSummary {

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -99,6 +99,7 @@ type TaskResult struct {
 	podEntities      []*repository.KubePod
 	kubeControllers  []*repository.KubeController
 	containerSpecs   []*repository.ContainerSpec
+	podVolumeMetrics []*repository.PodVolumeMetrics
 }
 
 func NewTaskResult(workerID string, state TaskResultState) *TaskResult {
@@ -140,6 +141,10 @@ func (r *TaskResult) ContainerSpecs() []*repository.ContainerSpec {
 	return r.containerSpecs
 }
 
+func (r *TaskResult) PodVolumeMetrics() []*repository.PodVolumeMetrics {
+	return r.podVolumeMetrics
+}
+
 func (r *TaskResult) Err() error {
 	return r.err
 }
@@ -176,5 +181,10 @@ func (r *TaskResult) WithKubeControllers(kubeControllers []*repository.KubeContr
 
 func (r *TaskResult) WithContainerSpecs(containerSpecs []*repository.ContainerSpec) *TaskResult {
 	r.containerSpecs = containerSpecs
+	return r
+}
+
+func (r *TaskResult) WithPodVolumeMetrics(podVolumeMetrics []*repository.PodVolumeMetrics) *TaskResult {
+	r.podVolumeMetrics = podVolumeMetrics
 	return r
 }

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -120,3 +120,7 @@ func PodVolumeMetricId(podKey, volName string) string {
 
 	return volKey
 }
+
+func VolumeKeyFunc(vol *api.PersistentVolume) string {
+	return vol.Name
+}

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -112,23 +112,11 @@ func ContainerSpecIdFunc(controllerUID string, containerName string) string {
 	return controllerUID + "/" + containerName
 }
 
-func PodVolumeMetricId(podKey, pvName string, pvcRef stats.PVCReference) string {
+func PodVolumeMetricId(podKey, volName string) string {
 	volKey := podKey
-	if pvName != "" {
-		volKey = volKey + "-" + pvName
+	if volName != "" {
+		volKey = volKey + "-" + volName
 	}
 
-	pvcRefKey := pvcRefKey(pvcRef)
-	if pvcRefKey != "" {
-		volKey = volKey + "-" + pvcRefKey
-	}
 	return volKey
-}
-
-func pvcRefKey(pvcRef stats.PVCReference) string {
-	key := pvcRef.Name
-	if pvcRef.Namespace != "" {
-		key = pvcRef.Namespace + "/" + key
-	}
-	return key
 }

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -111,3 +111,24 @@ func NodeKeyFromPodFunc(pod *api.Pod) string {
 func ContainerSpecIdFunc(controllerUID string, containerName string) string {
 	return controllerUID + "/" + containerName
 }
+
+func PodVolumeMetricId(podKey, pvName string, pvcRef stats.PVCReference) string {
+	volKey := podKey
+	if pvName != "" {
+		volKey = volKey + "-" + pvName
+	}
+
+	pvcRefKey := pvcRefKey(pvcRef)
+	if pvcRefKey != "" {
+		volKey = volKey + "-" + pvcRefKey
+	}
+	return volKey
+}
+
+func pvcRefKey(pvcRef stats.PVCReference) string {
+	key := pvcRef.Name
+	if pvcRef.Namespace != "" {
+		key = pvcRef.Namespace + "/" + key
+	}
+	return key
+}

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -2,10 +2,11 @@ package worker
 
 import (
 	"errors"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	"sync"
 	"time"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
@@ -304,6 +305,7 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 	// Node providers
 	nodes := currTask.NodeList()
 	cluster := currTask.Cluster()
+	volToPodsMap := currTask.Cluster().VolumeToPodsMap
 
 	for _, node := range nodes {
 		if node != nil {
@@ -336,7 +338,7 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 
 	podEntityDTOBuilder := dtofactory.NewPodEntityDTOBuilder(worker.sink, stitchingManager,
 		nodeNameUIDMap, namespaceUIDMap)
-	podEntityDTOs, err := podEntityDTOBuilder.BuildEntityDTOs(pods)
+	podEntityDTOs, err := podEntityDTOBuilder.BuildEntityDTOs(pods, volToPodsMap)
 	if err != nil {
 		glog.Errorf("Error while creating pod entityDTOs: %v", err)
 	}

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -208,6 +208,8 @@ func (worker *k8sDiscoveryWorker) executeTask(currTask *task.Task) *task.TaskRes
 	}
 	namespaceMetricsCollection := metricsCollector.CollectNamespaceMetrics(podMetricsCollection)
 
+	podVolumeMetricsCollection := metricsCollector.CollectPodVolumeMetrics()
+
 	// Add the allocation metrics in the sink for the pods and the nodes
 	worker.addPodAllocationMetrics(podMetricsCollection)
 
@@ -259,6 +261,11 @@ func (worker *k8sDiscoveryWorker) executeTask(currTask *task.Task) *task.TaskRes
 	if len(containerSpecs) > 0 {
 		result.WithContainerSpecs(containerSpecs)
 	}
+
+	if len(podVolumeMetricsCollection) > 0 {
+		result.WithPodVolumeMetrics(podVolumeMetricsCollection)
+	}
+
 	return result
 }
 
@@ -305,9 +312,9 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 	// Node providers
 	nodes := currTask.NodeList()
 	cluster := currTask.Cluster()
-	var volToPodsMap map[*api.PersistentVolume][]repository.PodVolume
+	var podToVolsMap map[string][]repository.MountedVolume
 	if cluster != nil {
-		volToPodsMap = cluster.VolumeToPodsMap
+		podToVolsMap = cluster.PodToVolumesMap
 	}
 
 	for _, node := range nodes {
@@ -341,7 +348,7 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 
 	podEntityDTOBuilder := dtofactory.NewPodEntityDTOBuilder(worker.sink, stitchingManager,
 		nodeNameUIDMap, namespaceUIDMap)
-	podEntityDTOs, err := podEntityDTOBuilder.BuildEntityDTOs(pods, volToPodsMap)
+	podEntityDTOs, err := podEntityDTOBuilder.BuildEntityDTOs(pods, podToVolsMap)
 	if err != nil {
 		glog.Errorf("Error while creating pod entityDTOs: %v", err)
 	}
@@ -360,6 +367,7 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 		glog.Errorf("Error while creating container entityDTOs: %v", err)
 	}
 	result = append(result, containerDTOs...)
+
 	glog.V(3).Infof("Worker %s built %d container DTOs.", worker.id, len(containerDTOs))
 
 	glog.V(2).Infof("Worker %s built total %d entityDTOs.", worker.id, len(result))

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -305,7 +305,10 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 	// Node providers
 	nodes := currTask.NodeList()
 	cluster := currTask.Cluster()
-	volToPodsMap := currTask.Cluster().VolumeToPodsMap
+	var volToPodsMap map[*api.PersistentVolume][]repository.PodVolume
+	if cluster != nil {
+		volToPodsMap = cluster.VolumeToPodsMap
+	}
 
 	for _, node := range nodes {
 		if node != nil {

--- a/pkg/discovery/worker/metrics_collector.go
+++ b/pkg/discovery/worker/metrics_collector.go
@@ -194,14 +194,15 @@ func (collector *MetricsCollector) CollectPodVolumeMetrics() []*repository.PodVo
 	var podVolumeMetricsCollection []*repository.PodVolumeMetrics
 
 	var podToVolsMap map[string][]repository.MountedVolume
-	if collector.Cluster.PodToVolumesMap != nil {
-		podToVolsMap = collector.Cluster.PodToVolumesMap
+	if collector.Cluster.PodToVolumesMap == nil {
+		return podVolumeMetricsCollection
 	}
+	podToVolsMap = collector.Cluster.PodToVolumesMap
 
 	metricsSink := collector.MetricsSink
 	//Iterate over all the pods in the collection
 	for _, pod := range collector.PodList {
-		podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+		podKey := util.PodKeyFunc(pod)
 		podVols, exists := podToVolsMap[podKey]
 		if !exists {
 			continue

--- a/pkg/discovery/worker/metrics_collector.go
+++ b/pkg/discovery/worker/metrics_collector.go
@@ -2,12 +2,13 @@ package worker
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // Collects allocation metrics for quotas, nodes and pods using the compute resource usages for pods
@@ -187,6 +188,55 @@ func collectContainersComputeResources(pod *v1.Pod) (float64, float64, float64, 
 		totalMemRequests += util.Base2BytesToKilobytes(float64(requests.Memory().Value()))
 	}
 	return totalCPULimits, totalCPURequests, totalMemLimits, totalMemRequests
+}
+
+func (collector *MetricsCollector) CollectPodVolumeMetrics() []*repository.PodVolumeMetrics {
+	var podVolumeMetricsCollection []*repository.PodVolumeMetrics
+
+	var podToVolsMap map[string][]repository.MountedVolume
+	if collector.Cluster.PodToVolumesMap != nil {
+		podToVolsMap = collector.Cluster.PodToVolumesMap
+	}
+
+	metricsSink := collector.MetricsSink
+	//Iterate over all the pods in the collection
+	for _, pod := range collector.PodList {
+		podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+		podVols, exists := podToVolsMap[podKey]
+		if !exists {
+			continue
+		}
+
+		for _, podVol := range podVols {
+			podVolumeMetric := repository.PodVolumeMetrics{}
+			volKey := util.PodVolumeMetricId(podKey, podVol.MountName)
+			found := false
+
+			metricUID := metrics.GenerateEntityResourceMetricUID(metrics.PodType, volKey,
+				metrics.StorageAmount, metrics.Used)
+			metric, _ := metricsSink.GetMetric(metricUID)
+			if metric != nil && metric.GetValue() != nil {
+				podVolumeMetric.Used = metric.GetValue().(float64)
+				found = true
+			}
+
+			metricUID = metrics.GenerateEntityResourceMetricUID(metrics.PodType, volKey,
+				metrics.StorageAmount, metrics.Capacity)
+			metric, _ = metricsSink.GetMetric(metricUID)
+			if metric != nil && metric.GetValue() != nil {
+				podVolumeMetric.Capacity = metric.GetValue().(float64)
+				found = true
+			}
+
+			if found == true {
+				podVolumeMetric.QualifiedPodName = podKey
+				podVolumeMetric.MountName = podVol.MountName
+				podVolumeMetric.Volume = podVol.UsedVolume
+				podVolumeMetricsCollection = append(podVolumeMetricsCollection, &podVolumeMetric)
+			}
+		}
+	}
+	return podVolumeMetricsCollection
 }
 
 // Create namespace metrics for all the namespace entities and set the quota sold usage handled by this metric collector.

--- a/pkg/discovery/worker/result_collector.go
+++ b/pkg/discovery/worker/result_collector.go
@@ -28,7 +28,7 @@ func (rc *ResultCollector) ResultPool() chan *task.TaskResult {
 }
 
 func (rc *ResultCollector) Collect(count int) ([]*proto.EntityDTO, map[string]*repository.KubePod,
-	[]*repository.NamespaceMetrics, []*repository.EntityGroup, []*repository.KubeController, []*repository.ContainerSpec) {
+	[]*repository.NamespaceMetrics, []*repository.EntityGroup, []*repository.KubeController, []*repository.ContainerSpec, []*repository.PodVolumeMetrics) {
 	discoveryResult := []*proto.EntityDTO{}
 	namespaceMetrics := []*repository.NamespaceMetrics{}
 	entityGroupList := []*repository.EntityGroup{}
@@ -36,6 +36,7 @@ func (rc *ResultCollector) Collect(count int) ([]*proto.EntityDTO, map[string]*r
 	podEntitiesMap := make(map[string]*repository.KubePod)
 	var kubeControllerList []*repository.KubeController
 	var containerSpecs []*repository.ContainerSpec
+	podVolumeMetrics := []*repository.PodVolumeMetrics{}
 	glog.V(2).Infof("Waiting for results from %d workers.", count)
 
 	stopChan := make(chan struct{})
@@ -57,6 +58,8 @@ func (rc *ResultCollector) Collect(count int) ([]*proto.EntityDTO, map[string]*r
 					namespaceMetrics = append(namespaceMetrics, result.NamespaceMetrics()...)
 					// Group data from different workers
 					entityGroupList = append(entityGroupList, result.EntityGroups()...)
+					// Volume metrics from different workers
+					podVolumeMetrics = append(podVolumeMetrics, result.PodVolumeMetrics()...)
 					// Pod data with apps from different workers
 					for _, kubePod := range result.PodEntities() {
 						podEntitiesMap[kubePod.PodClusterId] = kubePod
@@ -79,5 +82,5 @@ func (rc *ResultCollector) Collect(count int) ([]*proto.EntityDTO, map[string]*r
 		glog.Errorf("One or more discovery worker failed: %s", strings.Join(discoveryErrorString, "\t\t"))
 	}
 
-	return discoveryResult, podEntitiesMap, namespaceMetrics, entityGroupList, kubeControllerList, containerSpecs
+	return discoveryResult, podEntitiesMap, namespaceMetrics, entityGroupList, kubeControllerList, containerSpecs, podVolumeMetrics
 }

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -149,6 +149,16 @@ func (rClient *K8sRegistrationClient) GetActionPolicy() []*proto.ActionPolicyDTO
 
 	rClient.addActionPolicy(ab, node, nodePolicy)
 
+	// 6. volumes
+	volume := proto.EntityDTO_VIRTUAL_VOLUME
+	volumePolicy := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
+	volumePolicy[proto.ActionItemDTO_PROVISION] = recommend
+	volumePolicy[proto.ActionItemDTO_RIGHT_SIZE] = notSupported
+	volumePolicy[proto.ActionItemDTO_SCALE] = recommend
+	volumePolicy[proto.ActionItemDTO_SUSPEND] = notSupported
+
+	rClient.addActionPolicy(ab, volume, volumePolicy)
+
 	return ab.Create()
 }
 
@@ -175,6 +185,7 @@ func (rClient *K8sRegistrationClient) GetEntityMetadata() []*proto.EntityIdentit
 		proto.EntityDTO_CONTAINER,
 		proto.EntityDTO_APPLICATION_COMPONENT,
 		proto.EntityDTO_SERVICE,
+		proto.EntityDTO_VIRTUAL_VOLUME,
 	}
 
 	for _, etype := range entities {

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -46,6 +46,7 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 	container := proto.EntityDTO_CONTAINER
 	app := proto.EntityDTO_APPLICATION_COMPONENT
 	service := proto.EntityDTO_SERVICE
+	vol := proto.EntityDTO_VIRTUAL_VOLUME
 
 	move := proto.ActionItemDTO_MOVE
 	resize := proto.ActionItemDTO_RIGHT_SIZE
@@ -83,6 +84,12 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 	expected_node[suspend] = supported
 	expected_node[scale] = notSupported
 
+	expected_vol := make(map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_ActionCapability)
+	expected_vol[resize] = notSupported
+	expected_vol[provision] = recommend
+	expected_vol[suspend] = notSupported
+	expected_vol[scale] = recommend
+
 	policies := reg.GetActionPolicy()
 
 	for _, item := range policies {
@@ -99,6 +106,8 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 			expected = expected_node
 		} else if entity == service {
 			expected = expected_service
+		} else if entity == vol {
+			expected = expected_vol
 		} else {
 			t.Errorf("Unknown entity type: %v", entity)
 			continue
@@ -125,6 +134,7 @@ func TestK8sRegistrationClient_GetEntityMetadata(t *testing.T) {
 		proto.EntityDTO_CONTAINER,
 		proto.EntityDTO_APPLICATION_COMPONENT,
 		proto.EntityDTO_SERVICE,
+		proto.EntityDTO_VIRTUAL_VOLUME,
 	}
 	entitySet := make(map[proto.EntityDTO_EntityType]struct{})
 

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -236,7 +236,6 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 		PatchSoldMetadata(proto.CommodityDTO_VMEM_REQUEST_QUOTA, fieldsUsedCapacity).
 		PatchSoldMetadata(proto.CommodityDTO_NUMBER_CONSUMERS, fieldsUsedCapacity).
 		PatchSoldMetadata(proto.CommodityDTO_VSTORAGE, fieldsUsedCapacity).
-		PatchSoldMetadata(proto.CommodityDTO_STORAGE_AMOUNT, fieldsUsedCapacity).
 		Build()
 }
 


### PR DESCRIPTION
Creating a new PR with the work uptil now against a branch to retrigger review of this code.

This includes the code from #389 and #403 with additional stitching support for `Azure` volumes.
I have closed those PRs in favour of this one.

In summary, this includes:

1. Discover persistent volumes and persistent volume claims from cluster.
2. Get the volume metrics from kubelet source and generate relevant metrices for consumption in kubeturbo.
3. Create a mapping between pods and volumes via pvs. This helps establish relationship between the pods PersistentVolume.
4. Include the storage amount bought commodities in the POD DTOs.
5. Build Volume entity DTOs, complete with sold commodities.
6. Include volume and related commodity information in the supply chain.
7. Include volume entity metadata info in the probe registration.
8. Stiching support for AWS volumes.
9. Stitching support for Azure volumes.

Work in progress:

10. Stitching support for vsphere discovered vmdks/volumes.
