### PR TITLE
Fix affinity processor error

### DIFF
--- a/pkg/discovery/worker/compliance/affinity_processor.go
+++ b/pkg/discovery/worker/compliance/affinity_processor.go
@@ -39,7 +39,7 @@ func NewAffinityProcessor(config *affinityProcessorConfig) (*AffinityProcessor, 
 	if err != nil {
 		return nil, err
 	}
-	allPods, err := config.k8sClusterScraper.GetAllPods()
+	allPods, err := config.k8sClusterScraper.GetAllRunningAndReadyPods()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix for observed error msg while processing affinities
Fixes [OM-60545](https://vmturbo.atlassian.net/browse/OM-60545)    
    
This happens because the affinity processor considers all pods wrt only the ready and running pods on which the original pod entityDTOs are created. There is no functionality impact except with or without the fix.