### PR TITLE
Make HA nodes non suspendable

### DIFF
--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -119,9 +119,9 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) ([]*prot
 		})
 
 		// Action settings for a node
-		// Allow suspend for all nodes except masters
-		isMasterNode := util.DetectMasterRole(node)
-		entityDTOBuilder.IsSuspendable(!isMasterNode)
+		// Allow suspend for all nodes except those marked as HA via kubeturbo config
+		isHANode := util.DetectHARole(node)
+		entityDTOBuilder.IsSuspendable(!isHANode)
 
 		// Power state.
 		// Will be Powered On, only if it is ready and has no issues with kubelet accessibility.
@@ -146,11 +146,7 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) ([]*prot
 
 		result = append(result, entityDto)
 
-		if isMasterNode {
-			glog.V(3).Infof("master node dto:\n	 %++v\n", entityDto)
-		} else {
-			glog.V(4).Infof("node dto : %++v\n", entityDto)
-		}
+		glog.V(3).Infof("node dto : %++v\n", entityDto)
 	}
 
 	return result, nil

--- a/pkg/discovery/dtofactory/node_roles_group_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_roles_group_dto_builder.go
@@ -37,8 +37,10 @@ func (builder *NodeRolesGroupDTOBuilder) Build() []*proto.GroupDTO {
 		var err error
 		roleName := role.roleName
 		if role.isHA {
-			groupID := fmt.Sprintf("NodeRole[HA]-%s-%s", roleName, builder.targetId)
-			displayName := fmt.Sprintf("NodeRole[HA]::%s [%s]", roleName, builder.targetId)
+			groupID := fmt.Sprintf("NodeRole-%s-%s", roleName, builder.targetId)
+			displayName := fmt.Sprintf("[HA]NodeRole::%s [%s]", roleName, builder.targetId)
+			// The group is automatically created when this policy is created.
+			// The display name used for the group is the groupID.
 			dtos, err = group.DoNotPlaceTogether(groupID).
 				WithDisplayName(displayName).
 				OnSellerType(proto.EntityDTO_PHYSICAL_MACHINE).

--- a/pkg/discovery/util/node_util.go
+++ b/pkg/discovery/util/node_util.go
@@ -3,10 +3,11 @@ package util
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
 	api "k8s.io/api/core/v1"
-	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -88,8 +89,6 @@ const (
 	labelNodeRolePrefix = "node-role.kubernetes.io/"
 	// nodeLabelRole specifies the role of a node
 	nodeLabelRole = "kubernetes.io/role"
-
-	masterRoleName = "master"
 )
 
 func DetectNodeRoles(node *api.Node) sets.String {
@@ -110,12 +109,12 @@ func DetectNodeRoles(node *api.Node) sets.String {
 	return allRoles
 }
 
-func DetectMasterRole(node *api.Node) bool {
+func DetectHARole(node *api.Node) bool {
 	nodeRoles := DetectNodeRoles(node)
 
-	isMasterNode := nodeRoles.Has(masterRoleName)
-	if isMasterNode {
-		glog.V(3).Infof("%s is a master node", node.Name)
+	isHANode := nodeRoles.Intersection(detectors.HANodeRoles).Len() > 0
+	if isHANode {
+		glog.V(2).Infof("%s is a HA node and will be marked Non Suspendable.", node.Name)
 	}
-	return isMasterNode
+	return isHANode
 }


### PR DESCRIPTION
This PR updates the node role groups as below:
1. Add suspendable = false for entities (VMs) that are part of the HA Node consumer group.
2. All node role groups have a common naming.
3. There is no inbuilt check for `master` as a node label to make the node non suspendable. This is replaced by 1 above.
