### PR TITLE
Discovery enhancement

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -43,6 +43,8 @@ const (
 	defaultDiscoveryIntervalSec = 600
 	defaultValidationWorkers    = 10
 	defaultValidationTimeout    = 60
+	defaultDiscoveryWorkers     = 4
+	defaultDiscoveryTimeoutSec  = 180
 )
 
 var (
@@ -90,6 +92,10 @@ type VMTServer struct {
 	ValidationWorkers int
 	ValidationTimeout int
 
+	// Discovery related config
+	DiscoveryWorkers    int
+	DiscoveryTimeoutSec int
+
 	// The Openshift SCC list allowed for action execution
 	sccSupport []string
 
@@ -133,6 +139,8 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.DiscoveryIntervalSec, "discovery-interval-sec", defaultDiscoveryIntervalSec, "The discovery interval in seconds")
 	fs.IntVar(&s.ValidationWorkers, "validation-workers", defaultValidationWorkers, "The validation workers")
 	fs.IntVar(&s.ValidationTimeout, "validation-timeout-sec", defaultValidationTimeout, "The validation timeout in seconds")
+	fs.IntVar(&s.DiscoveryWorkers, "discovery-workers", defaultDiscoveryWorkers, "The number of discovery workers")
+	fs.IntVar(&s.DiscoveryTimeoutSec, "discovery-timeout-sec", defaultDiscoveryTimeoutSec, "The discovery timeout in seconds for each discovery worker")
 	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=* to allow all")
 	fs.StringVar(&s.ClusterAPINamespace, "cluster-api-namespace", "default", "The Cluster API namespace.")
 	fs.StringVar(&s.BusyboxImage, "busybox-image", "busybox", "The complete image uri used for fallback node cpu frequency getter job.")
@@ -285,6 +293,8 @@ func (s *VMTServer) Run() {
 		WithDiscoveryInterval(s.DiscoveryIntervalSec).
 		WithValidationTimeout(s.ValidationTimeout).
 		WithValidationWorkers(s.ValidationWorkers).
+		WithDiscoveryWorkers(s.DiscoveryWorkers).
+		WithDiscoveryTimeout(s.DiscoveryTimeoutSec).
 		WithSccSupport(s.sccSupport).
 		WithCAPINamespace(s.ClusterAPINamespace)
 	glog.V(3).Infof("Finished creating turbo configuration: %+v", vmtConfig)

--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -185,11 +185,11 @@ func (s *VMTServer) createKubeClientOrDie(kubeConfig *restclient.Config) *kubern
 // The forceSelfSignedCerts will be used as follows:
 // * If it is false, which means we are in the environment where we must use proper certificates, then we don't force self-signed certs.
 // * If it is true, then we use whatever flag we passed through the command line.
-func (s *VMTServer) createKubeletClientOrDie(kubeConfig *restclient.Config, forceSelfSignedCerts bool, fallbackClient *kubernetes.Clientset, busyboxImage string) *kubeclient.KubeletClient {
+func (s *VMTServer) createKubeletClientOrDie(kubeConfig *restclient.Config, fallbackClient *kubernetes.Clientset, busyboxImage string) *kubeclient.KubeletClient {
 	kubeletClient, err := kubeclient.NewKubeletConfig(kubeConfig).
 		WithPort(s.KubeletPort).
 		EnableHttps(s.EnableKubeletHttps).
-		ForceSelfSignedCerts(forceSelfSignedCerts && s.ForceSelfSignedCerts).
+		ForceSelfSignedCerts(s.ForceSelfSignedCerts).
 		// Timeout(to).
 		Create(fallbackClient, busyboxImage)
 	if err != nil {
@@ -266,7 +266,7 @@ func (s *VMTServer) Run() {
 	// For Kubernetes distro, the secure connection to Kubelet will fail due to
 	// the certificate issue of 'doesn't contain any IP SANs'.
 	// See https://github.com/kubernetes/kubernetes/issues/59372
-	kubeletClient := s.createKubeletClientOrDie(kubeConfig, !isOpenshift, kubeClient, s.BusyboxImage)
+	kubeletClient := s.createKubeletClientOrDie(kubeConfig, kubeClient, s.BusyboxImage)
 	caClient, err := clusterclient.NewForConfig(kubeConfig)
 	if err != nil {
 		glog.Errorf("Failed to generate correct TAP config: %v", err.Error())

--- a/pkg/discovery/monitoring/dummy_monitor.go
+++ b/pkg/discovery/monitoring/dummy_monitor.go
@@ -1,0 +1,47 @@
+package monitoring
+
+import (
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
+	"time"
+)
+
+// This implementation is for Test only
+type DummyMonitorConfig struct {
+	TaskRunTime int
+}
+
+func (config DummyMonitorConfig) GetMonitorType() types.MonitorType {
+	return types.DummyMonitor
+}
+
+func (config DummyMonitorConfig) GetMonitoringSource() types.MonitoringSource {
+	return types.DummySource
+}
+
+type DummyMonitor struct {
+	config     *DummyMonitorConfig
+	metricSink *metrics.EntityMetricSink
+}
+
+func NewDummyMonitor(config *DummyMonitorConfig) (*DummyMonitor, error) {
+	return &DummyMonitor{
+		config:     config,
+		metricSink: metrics.NewEntityMetricSink()}, nil
+}
+
+func (m *DummyMonitor) GetMonitoringSource() types.MonitoringSource {
+	return types.ClusterSource
+}
+
+func (m *DummyMonitor) ReceiveTask(task *task.Task) {
+}
+
+func (m *DummyMonitor) Stop() {
+}
+
+func (m *DummyMonitor) Do() *metrics.EntityMetricSink {
+	time.Sleep(time.Second * time.Duration(m.config.TaskRunTime))
+	return m.metricSink
+}

--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -79,7 +79,7 @@ func (m *ClusterMonitor) RetrieveClusterStat() error {
 	defer close(m.stopCh)
 
 	if m.nodeList == nil {
-		return errors.New("Invalid nodeList or empty nodeList. Nothing to monitor")
+		return errors.New("invalid nodeList or empty nodeList. Nothing to monitor")
 	}
 	select {
 	case <-m.stopCh:
@@ -87,7 +87,7 @@ func (m *ClusterMonitor) RetrieveClusterStat() error {
 	default:
 		err := m.findClusterID()
 		if err != nil {
-			return fmt.Errorf("Failed to find cluster ID based on Kubernetes service: %v", err)
+			return fmt.Errorf("failed to find cluster ID based on Kubernetes service: %v", err)
 		}
 		select {
 		case <-m.stopCh:
@@ -117,6 +117,7 @@ func (m *ClusterMonitor) findClusterID() error {
 	// TODO use a constant for cluster commodity key.
 	clusterInfo := metrics.NewEntityStateMetric(metrics.ClusterType, "", metrics.Cluster, kubernetesSvcID)
 	m.sink.AddNewMetricEntries(clusterInfo)
+	glog.V(2).Infof("Successfully added cluster info metrics for cluster %v", kubernetesSvcID)
 	return nil
 }
 
@@ -134,7 +135,7 @@ func (m *ClusterMonitor) findNodeStates() {
 		// node labels
 		labelMetrics := parseNodeLabels(node)
 		m.sink.AddNewMetricEntries(labelMetrics)
-
+		glog.V(3).Infof("Successfully generated label metrics for node %s", key)
 		// owner labels - TODO:
 
 	}
@@ -146,7 +147,7 @@ func (m *ClusterMonitor) findNodeStates() {
 //	CPURequest      capacity, used
 //	MemoryRequest   capacity, used
 func (m *ClusterMonitor) genNodeResourceMetrics(node *api.Node, key string) {
-	glog.V(3).Infof("Now get resouce metrics for node %s", key)
+	glog.V(3).Infof("Now get resource metrics for node %s", key)
 
 	//1. Capacity of CPU and Memory
 	//1.1 Get the total resource of a node
@@ -177,6 +178,7 @@ func (m *ClusterMonitor) genNodeResourceMetrics(node *api.Node, key string) {
 	m.genRequestUsedMetrics(metrics.NodeType, key, nodeCPURequestUsed, nodeMemRequestUsed)
 	glog.V(4).Infof("CPURequest used of node %s is %f core", node.Name, nodeCPURequestUsed)
 	glog.V(4).Infof("MemoryRequest used of node %s is %f Kb", node.Name, nodeMemRequestUsed)
+	glog.V(3).Infof("Successfully generated resource metrics for node %s", key)
 }
 
 // Parse the labels of a node and create one EntityStateMetric
@@ -222,6 +224,7 @@ func (m *ClusterMonitor) genNodePodsMetrics(node *api.Node, cpuCapacity, memCapa
 	}
 
 	numPods = float64(len(podList))
+	glog.V(3).Infof("Successfully generated pod metrics for node %v.", node.Name)
 	return
 }
 

--- a/pkg/discovery/monitoring/monitoring_worker.go
+++ b/pkg/discovery/monitoring/monitoring_worker.go
@@ -48,6 +48,9 @@ func BuildMonitorWorker(source types.MonitoringSource, config MonitorWorkerConfi
 			return nil, errors.New("Failed to build a cluster monitoring client as the provided config was not a ClusterMonitorConfig")
 		}
 		return master.NewClusterMonitor(clusterMonitorConfig)
+	case types.DummySource:
+		dummyMonitorConfig, _ := config.(*DummyMonitorConfig)
+		return NewDummyMonitor(dummyMonitorConfig)
 	default:
 		return nil, fmt.Errorf("Unsupported monitoring source %s", source)
 	}

--- a/pkg/discovery/monitoring/types/const.go
+++ b/pkg/discovery/monitoring/types/const.go
@@ -7,6 +7,7 @@ const (
 	K8sConntrackSource MonitoringSource = "K8sConntrack"
 	ClusterSource      MonitoringSource = "Cluster"
 	PrometheusSource   MonitoringSource = "Prometheus"
+	DummySource        MonitoringSource = "Dummy" //Testing only
 )
 
 type MonitorType string
@@ -14,4 +15,5 @@ type MonitorType string
 const (
 	ResourceMonitor MonitorType = "ResourceMonitor"
 	StateMonitor    MonitorType = "StateMonitor"
+	DummyMonitor    MonitorType = "DummyMonitor"
 )

--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -72,7 +72,7 @@ func (s *StitchingManager) SetNodeUuidGetterByProvider(providerId string) {
 	}
 
 	s.uuidGetter = getter
-	glog.V(3).Infof("Node UUID getter is: %v", getter.Name())
+	glog.V(4).Infof("Node UUID getter is: %v", getter.Name())
 }
 
 func (s *StitchingManager) GetStitchType() StitchingPropertyType {

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	api "k8s.io/api/core/v1"
+	"strings"
 
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 
@@ -59,6 +60,14 @@ func (t *Task) PodList() []*api.Pod {
 
 func (t *Task) Cluster() *repository.ClusterSummary {
 	return t.cluster
+}
+
+func (t *Task) String() string {
+	var nodes []string
+	for _, node := range t.nodeList {
+		nodes = append(nodes, node.GetName())
+	}
+	return t.uid + " " + strings.Join(nodes, ",")
 }
 
 type TaskResultState string

--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -2,28 +2,28 @@ package worker
 
 import (
 	"fmt"
+	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/configs"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
 	api "k8s.io/api/core/v1"
-	"math"
-
-	"github.com/golang/glog"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 )
 
 type DispatcherConfig struct {
 	clusterInfoScraper *cluster.ClusterScraper
 	probeConfig        *configs.ProbeConfig
-
-	workerCount int
+	workerCount        int
+	workerTimeoutSec   int
 }
 
-func NewDispatcherConfig(clusterInfoScraper *cluster.ClusterScraper, probeConfig *configs.ProbeConfig, workerCount int) *DispatcherConfig {
+func NewDispatcherConfig(clusterInfoScraper *cluster.ClusterScraper, probeConfig *configs.ProbeConfig,
+	workerCount int, workerTimeoutSec int) *DispatcherConfig {
 	return &DispatcherConfig{
 		clusterInfoScraper: clusterInfoScraper,
 		probeConfig:        probeConfig,
 		workerCount:        workerCount,
+		workerTimeoutSec:   workerTimeoutSec,
 	}
 }
 
@@ -47,7 +47,7 @@ func (d *Dispatcher) Init(c *ResultCollector) {
 	// Create discovery workers
 	for i := 0; i < d.config.workerCount; i++ {
 		// Create the worker instance
-		workerConfig := NewK8sDiscoveryWorkerConfig(d.config.probeConfig.StitchingPropertyType)
+		workerConfig := NewK8sDiscoveryWorkerConfig(d.config.probeConfig.StitchingPropertyType, d.config.workerTimeoutSec)
 		for _, mc := range d.config.probeConfig.MonitoringConfigs {
 			workerConfig.WithMonitoringWorkerConfig(mc)
 		}
@@ -63,44 +63,23 @@ func (d *Dispatcher) Init(c *ResultCollector) {
 
 // Register the k8sDiscoveryWorker and its monitoring workers
 func (d *Dispatcher) RegisterWorker(worker *k8sDiscoveryWorker) {
+	// Return the free worker to the pool
 	d.workerPool <- worker.taskChan
 }
 
-// Create Task objects for discovery and monitoring for each group of the nodes and pods
+// Create Task objects for discovery and monitoring for each node, and the pods and containers on that node
 // Dispatch the task to the pool, task will be picked by the k8sDiscoveryWorker
-// Receives the complete list of nodes in the cluster that are divided in groups and submitted as
-// Tasks to the DiscoveryWorkers to carry out the discovery of the pods, containers and resources
 func (d *Dispatcher) Dispatch(nodes []*api.Node, cluster *repository.ClusterSummary) int {
-
-	// make sure when len(node) < workerCount, worker will receive at most 1 node to discover
-	perTaskNodeLength := int(math.Ceil(float64(len(nodes)) / float64(d.config.workerCount)))
-	glog.V(3).Infof("The number of nodes per task is: %d", perTaskNodeLength)
-	assignedNodesCount := 0
-	assignedWorkerCount := 0
-	// Divide up the nodes into groups and assign each group to a separate task
-	for assignedNodesCount+perTaskNodeLength <= len(nodes) {
-		currNodes := nodes[assignedNodesCount : assignedNodesCount+perTaskNodeLength]
-
-		currPods := d.config.clusterInfoScraper.GetRunningAndReadyPodsOnNodes(currNodes)
-
-		currTask := task.NewTask().WithNodes(currNodes).WithPods(currPods).WithCluster(cluster)
-		d.assignTask(currTask)
-
-		assignedNodesCount += perTaskNodeLength
-
-		assignedWorkerCount++
-	}
-	if assignedNodesCount < len(nodes) {
-		currNodes := nodes[assignedNodesCount:]
-		currPods := d.config.clusterInfoScraper.GetRunningAndReadyPodsOnNodes(currNodes)
-		currTask := task.NewTask().WithNodes(currNodes).WithPods(currPods).WithCluster(cluster)
-		d.assignTask(currTask)
-
-		assignedWorkerCount++
-	}
-	glog.V(2).Infof("Dispatched discovery task to %d workers", assignedWorkerCount)
-
-	return assignedWorkerCount
+	go func() {
+		for _, node := range nodes {
+			currNodes := []*api.Node{node}
+			currPods := d.config.clusterInfoScraper.GetRunningAndReadyPodsOnNodes(currNodes)
+			currTask := task.NewTask().WithNodes(currNodes).WithPods(currPods).WithCluster(cluster)
+			glog.V(2).Infof("Dispatching task %v", currTask)
+			d.assignTask(currTask)
+		}
+	}()
+	return len(nodes)
 }
 
 // Assign task to the k8sDiscoveryWorker

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -171,8 +171,8 @@ func (worker *k8sDiscoveryWorker) executeTask(currTask *task.Task) *task.TaskRes
 				w.ReceiveTask(resourceMonitorTask)
 				t := time.NewTimer(timeoutSecond)
 				go func() {
-					glog.V(2).Infof("A %s monitoring worker from discovery worker %v is invoked.",
-						w.GetMonitoringSource(), worker.id)
+					glog.V(2).Infof("A %s monitoring worker from discovery worker %v is invoked for task %s.",
+						w.GetMonitoringSource(), worker.id, resourceMonitorTask)
 					// Assign task to monitoring worker.
 					monitoringSink := w.Do()
 					select {
@@ -196,7 +196,7 @@ func (worker *k8sDiscoveryWorker) executeTask(currTask *task.Task) *task.TaskRes
 					return
 				case <-t.C:
 					glog.Errorf("%s monitoring worker from discovery worker %v exceeds the max time limit for "+
-						"completing the task: %v", w.GetMonitoringSource(), worker.id, timeoutSecond)
+						"completing the task %s: %v", w.GetMonitoringSource(), worker.id, resourceMonitorTask, timeoutSecond)
 					timeout = true
 					stopCh <- struct{}{}
 					//glog.Infof("%s stop", w.GetMonitoringSource())

--- a/pkg/discovery/worker/k8s_discovery_worker_test.go
+++ b/pkg/discovery/worker/k8s_discovery_worker_test.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
@@ -13,41 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestCalTimeOut(t *testing.T) {
-	type Pair struct {
-		nodeNum int
-		timeout time.Duration
-	}
-
-	inputs := []*Pair{
-		&Pair{
-			nodeNum: 0,
-			timeout: defaultMonitoringWorkerTimeout,
-		},
-		&Pair{
-			nodeNum: 22,
-			timeout: defaultMonitoringWorkerTimeout + time.Second*22,
-		},
-		&Pair{
-			nodeNum: 500,
-			timeout: defaultMonitoringWorkerTimeout + time.Second*500,
-		},
-		&Pair{
-			nodeNum: 1500,
-			timeout: defaultMaxTimeout,
-		},
-	}
-
-	for _, input := range inputs {
-		result := calcTimeOut(input.nodeNum)
-		if result != input.timeout {
-			t.Errorf("tiemout error: %v Vs. %v", result, input.timeout)
-		}
-	}
-}
-
 func TestBuildDTOsWithMissingMetrics(t *testing.T) {
-	workerConfig := NewK8sDiscoveryWorkerConfig("UUID").WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil, nil))
+	workerConfig := NewK8sDiscoveryWorkerConfig("UUID", 1).
+		WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil, nil))
 	worker, err := NewK8sDiscoveryWorker(workerConfig, "wid-1")
 	if err != nil {
 		t.Errorf("Error while creating discovery worker: %v", err)

--- a/pkg/discovery/worker/service_discovery_worker.go
+++ b/pkg/discovery/worker/service_discovery_worker.go
@@ -165,7 +165,8 @@ func findPodEndpoints(service *api.Service, endpointMap map[string]*api.Endpoint
 			}
 
 			if !strings.EqualFold(target.Kind, "Pod") {
-				glog.Warningf("service: %v depends on non-Pod entity: %+v", serviceClusterID, target)
+				glog.Warningf("service: %v depends on non-Pod entity with kind %v and name %v",
+					serviceClusterID, target.Kind, target.Name)
 				continue
 			}
 			podName := target.Name

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -117,7 +117,8 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	registrationClientConfig := registration.NewRegistrationClientConfig(config.StitchingPropType, config.VMPriority, config.VMIsBase)
 
 	probeConfig := createProbeConfigOrDie(config)
-	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig, config.ValidationWorkers, config.ValidationTimeoutSec)
+	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig,
+		config.ValidationWorkers, config.ValidationTimeoutSec, config.DiscoveryWorkers, config.DiscoveryTimeoutSec)
 
 	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.KubeClient, config.KubeletClient, config.DynamicClient, config.SccSupport)
 

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -28,6 +28,8 @@ type Config struct {
 	StopEverything chan struct{}
 
 	DiscoveryIntervalSec int
+	DiscoveryWorkers     int
+	DiscoveryTimeoutSec  int
 	ValidationWorkers    int
 	ValidationTimeoutSec int
 
@@ -100,6 +102,16 @@ func (c *Config) WithValidationTimeout(di int) *Config {
 
 func (c *Config) WithValidationWorkers(di int) *Config {
 	c.ValidationWorkers = di
+	return c
+}
+
+func (c *Config) WithDiscoveryWorkers(workers int) *Config {
+	c.DiscoveryWorkers = workers
+	return c
+}
+
+func (c *Config) WithDiscoveryTimeout(timeout int) *Config {
+	c.DiscoveryTimeoutSec = timeout
 	return c
 }
 


### PR DESCRIPTION
This PR implements a few enhancements to the discovery framework:

* Discover one node per discovery worker
We used to divide the total number of nodes by the number of workers to calculate how many nodes to process per discovery worker. For all the nodes allocated to a discovery worker's cluster monitor worker, the processing of these nodes is done sequentially. This causes timeout in a big environment (with 70 nodes, 7000 pods). By processing only one node per discovery worker, we make it much more flexible to tune the number of discovery workers and the discovery timeout. A timeout of processing one node will not affect processing of other nodes, such that we can process as many nodes (and pods on the nodes) as possible.
* Make discovery worker count and discovery timeout configurable through command line options:
```
meng@Mengs-MBP$ ./kubeturbo -h
Usage of ./kubeturbo:
...
      --discovery-timeout-sec int        The discovery timeout in seconds for each discovery worker (default 180)
      --discovery-workers int            The number of discovery workers (default 4)

```
* Do not process discovery result when discovery times out
* Improve log messages
* Add unit tests to test dispatching
* Do not associate forceSelfSignedCerts with openshift cluster

Tested in Openshift 3.11
```
I0722 21:10:42.469280       1 k8s_discovery_client.go:45] Number of discovery workers: 4.
I0722 21:10:42.469340       1 k8s_discovery_worker.go:44] Discovery timeout is 3m0s
I0722 21:10:42.469398       1 k8s_discovery_worker.go:44] Discovery timeout is 3m0s
I0722 21:10:42.469425       1 k8s_discovery_worker.go:44] Discovery timeout is 3m0s
I0722 21:10:42.469445       1 k8s_discovery_worker.go:44] Discovery timeout is 3m0s
```
```
I0722 21:11:24.126514       1 k8s_discovery_worker.go:332] Worker w2 builds 1 node entityDTOs.
I0722 21:11:24.126533       1 k8s_discovery_worker.go:343] Worker w2 receives 28 pods.
I0722 21:11:24.129380       1 k8s_discovery_worker.go:352] Worker w2 builds 28 pod entityDTOs.
I0722 21:11:24.130303       1 k8s_discovery_worker.go:366] Worker w2 builds 29 container entityDTOs.
I0722 21:11:24.130871       1 k8s_discovery_worker.go:375] Worker w2 builds 29 application entityDTOs.
I0722 21:11:24.130894       1 k8s_discovery_worker.go:378] Worker w2 builds 87 entityDTOs.
I0722 21:11:24.130920       1 k8s_discovery_worker.go:133] Worker w2 has finished the discovery task e4b3e784-cc5f-11ea-9f16-0a580a800290 pt-okd-node-3.
I0722 21:11:24.130947       1 result_collector.go:52] Processing results from worker w2
I0722 21:11:24.923229       1 cluster_monitor.go:227] Successfully generated pod metrics for node pt-okd-node-1.
I0722 21:11:24.924484       1 cluster_monitor.go:181] Successfully generated resource metrics for node pt-okd-node-1
I0722 21:11:24.925429       1 cluster_monitor.go:138] Successfully generated label metrics for node pt-okd-node-1
I0722 21:11:24.933874       1 k8s_discovery_worker.go:318] The node we are parsing is : pt-okd-node-1
I0722 21:11:24.934363       1 k8s_discovery_worker.go:332] Worker w3 builds 1 node entityDTOs.
I0722 21:11:24.934468       1 k8s_discovery_worker.go:343] Worker w3 receives 46 pods.
I0722 21:11:24.938634       1 k8s_discovery_worker.go:352] Worker w3 builds 46 pod entityDTOs.
I0722 21:11:24.941472       1 k8s_discovery_worker.go:366] Worker w3 builds 51 container entityDTOs.
I0722 21:11:24.944753       1 k8s_discovery_worker.go:375] Worker w3 builds 51 application entityDTOs.
I0722 21:11:24.944790       1 k8s_discovery_worker.go:378] Worker w3 builds 149 entityDTOs.
I0722 21:11:24.944818       1 k8s_discovery_worker.go:133] Worker w3 has finished the discovery task e49c55a7-cc5f-11ea-9f16-0a580a800290 pt-okd-node-1.
I0722 21:11:24.944849       1 result_collector.go:52] Processing results from worker w3
I0722 21:11:24.944883       1 result_collector.go:67] Got all the results from 6 tasks with 0 tasks failed and 6 tasks succeeded.

```