### PR TITLE
Set usage of quota commodities of namespace entity to the sum of container limits/request

### DIFF
--- a/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
@@ -78,19 +78,6 @@ func (builder *namespaceEntityDTOBuilder) getQuotaCommoditiesSold(kubeNamespace 
 					kubeNamespace.Name, resourceType, capacityValue, newVal)
 				capacityValue = newVal
 			}
-
-			// Modify the used value only if the quota is set for the resource type.
-			// This is because the used value is obtained from the resource quota objects
-			// and represented in number of cores.
-			// If quota is not set for the resource type, the usage is sum of resource
-			// usages for all the pods in the namespace and
-			// has been converted to MHz using the hosting node's CPU frequency
-			if kubeNamespace.QuotaDefined[resourceType] {
-				newVal := usedValue * kubeNamespace.AverageNodeCpuFrequency
-				glog.V(4).Infof("Changing usage of %s::%s from %f cores to %f MHz",
-					kubeNamespace.Name, resourceType, usedValue, newVal)
-				usedValue = newVal
-			}
 		}
 
 		commSoldBuilder := sdkbuilder.NewCommodityDTOBuilder(cType)


### PR DESCRIPTION
JIRA: https://vmturbo.atlassian.net/browse/OM-60477

**Intent**:
This is to fix the issue of the inconsistency of quota commodity usage between namespace and workload controller.

**Problem**:
In BofA topology, in a namespace with only one WorkloadController (without bare pods), the usage of VCPULimitQuota commodity of WorkloadController is larger the usage of VCPULimitQuota commodity of Namespace, which makes no sense. This caused IllegalArgumentException in Market analysis in Turbo server side.

Meanwhile in a namespace with only one WorkloadController in "OKD (Origin) 3.11 in DC11" cluster of our lab, WC VCPULimitQuota usage < NS VCPULimitQuota usage.

The usage of the same quota commodity should be consistent between NS and WC.

**Diagnosis**:
For the namespace with quota defined, the used value is directly from API (`resourceQuota.Used`, total NS CPU usage in cores), and then when creating namespace entity DTO, the used value is calculated by `CPU_cores_usage * average_node_frequency`; while for namespace without quota, the used value is aggregated from all pods (sum of container limits/requests).

Then for the WorloadController, the used value of quotas are always aggregated from all pods.

The issue happens when different node has different CPU frequency.

**Solution**:
Clean up the code to set usage of quota commodities of NS to sum of container limits/request to be consistent with WC.

**Note**:
Conversions between cores and MHz in Kubeturbo are confusing. Using millicores for CPU commodities would help a lot.

**Testing Done**:
Add "OKD (Origin) 3.11 in DC11" as Kubeturbo target to Turbo server.

NS `testing` has only one WC `sc-testing`.

Before the change, NS `testing` has VCPULimitQuota usage 4.64GHz, and WC `sc-testing` VCPULimitQuota usage is 3.8 GHz.
After the change, NS `testing` VCPULimitQuota usage is 3.8GHz, and WC `sc-testing` VCPULimitQuota usage is 3.8 GHz.

Additionally, the same of usage of VCPU/VMem Limit/Request quota commodities of NS matches the sum of all container CPU/memory limits/request in the same cluster.