### PR TITLE
Discovery enhancement

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -46,6 +46,8 @@ const (
 	defaultDiscoveryIntervalSec = 600
 	defaultValidationWorkers    = 10
 	defaultValidationTimeout    = 60
+	defaultDiscoveryWorkers     = 4
+	defaultDiscoveryTimeoutSec  = 180
 )
 
 var (
@@ -92,6 +94,10 @@ type VMTServer struct {
 	// The cluster processor related config
 	ValidationWorkers int
 	ValidationTimeout int
+
+	// Discovery related config
+	DiscoveryWorkers    int
+	DiscoveryTimeoutSec int
 
 	// The Openshift SCC list allowed for action execution
 	sccSupport []string
@@ -141,6 +147,8 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.DiscoveryIntervalSec, "discovery-interval-sec", defaultDiscoveryIntervalSec, "The discovery interval in seconds")
 	fs.IntVar(&s.ValidationWorkers, "validation-workers", defaultValidationWorkers, "The validation workers")
 	fs.IntVar(&s.ValidationTimeout, "validation-timeout-sec", defaultValidationTimeout, "The validation timeout in seconds")
+	fs.IntVar(&s.DiscoveryWorkers, "discovery-workers", defaultDiscoveryWorkers, "The number of discovery workers")
+	fs.IntVar(&s.DiscoveryTimeoutSec, "discovery-timeout-sec", defaultDiscoveryTimeoutSec, "The discovery timeout in seconds for each discovery worker")
 	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=* to allow all")
 	fs.StringVar(&s.ClusterAPINamespace, "cluster-api-namespace", "default", "The Cluster API namespace.")
 	fs.StringVar(&s.BusyboxImage, "busybox-image", "busybox", "The complete image uri used for fallback node cpu frequency getter job.")
@@ -294,6 +302,8 @@ func (s *VMTServer) Run() {
 		WithDiscoveryInterval(s.DiscoveryIntervalSec).
 		WithValidationTimeout(s.ValidationTimeout).
 		WithValidationWorkers(s.ValidationWorkers).
+		WithDiscoveryWorkers(s.DiscoveryWorkers).
+		WithDiscoveryTimeout(s.DiscoveryTimeoutSec).
 		WithSccSupport(s.sccSupport).
 		WithCAPINamespace(s.ClusterAPINamespace).
 		WithContainerUtilizationDataAggStrategy(s.containerUtilizationDataAggStrategy).

--- a/pkg/discovery/monitoring/dummy_monitor.go
+++ b/pkg/discovery/monitoring/dummy_monitor.go
@@ -1,0 +1,47 @@
+package monitoring
+
+import (
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
+	"time"
+)
+
+// This implementation is for Test only
+type DummyMonitorConfig struct {
+	TaskRunTime int
+}
+
+func (config DummyMonitorConfig) GetMonitorType() types.MonitorType {
+	return types.DummyMonitor
+}
+
+func (config DummyMonitorConfig) GetMonitoringSource() types.MonitoringSource {
+	return types.DummySource
+}
+
+type DummyMonitor struct {
+	config     *DummyMonitorConfig
+	metricSink *metrics.EntityMetricSink
+}
+
+func NewDummyMonitor(config *DummyMonitorConfig) (*DummyMonitor, error) {
+	return &DummyMonitor{
+		config:     config,
+		metricSink: metrics.NewEntityMetricSink()}, nil
+}
+
+func (m *DummyMonitor) GetMonitoringSource() types.MonitoringSource {
+	return types.ClusterSource
+}
+
+func (m *DummyMonitor) ReceiveTask(task *task.Task) {
+}
+
+func (m *DummyMonitor) Stop() {
+}
+
+func (m *DummyMonitor) Do() *metrics.EntityMetricSink {
+	time.Sleep(time.Second * time.Duration(m.config.TaskRunTime))
+	return m.metricSink
+}

--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -81,7 +81,7 @@ func (m *ClusterMonitor) RetrieveClusterStat() error {
 	defer close(m.stopCh)
 
 	if m.nodeList == nil {
-		return errors.New("Invalid nodeList or empty nodeList. Nothing to monitor")
+		return errors.New("invalid nodeList or empty nodeList. Nothing to monitor")
 	}
 	select {
 	case <-m.stopCh:
@@ -89,7 +89,7 @@ func (m *ClusterMonitor) RetrieveClusterStat() error {
 	default:
 		err := m.findClusterID()
 		if err != nil {
-			return fmt.Errorf("Failed to find cluster ID based on Kubernetes service: %v", err)
+			return fmt.Errorf("failed to find cluster ID based on Kubernetes service: %v", err)
 		}
 		select {
 		case <-m.stopCh:
@@ -119,6 +119,7 @@ func (m *ClusterMonitor) findClusterID() error {
 	// TODO use a constant for cluster commodity key.
 	clusterInfo := metrics.NewEntityStateMetric(metrics.ClusterType, "", metrics.Cluster, kubernetesSvcID)
 	m.sink.AddNewMetricEntries(clusterInfo)
+	glog.V(3).Infof("Successfully added cluster info metrics for cluster %v", kubernetesSvcID)
 	return nil
 }
 
@@ -136,7 +137,7 @@ func (m *ClusterMonitor) findNodeStates() {
 		// node labels
 		labelMetrics := parseNodeLabels(node)
 		m.sink.AddNewMetricEntries(labelMetrics)
-
+		glog.V(3).Infof("Successfully generated label metrics for node %s", key)
 		// owner labels - TODO:
 
 	}
@@ -148,7 +149,7 @@ func (m *ClusterMonitor) findNodeStates() {
 //	CPURequest      capacity, used
 //	MemoryRequest   capacity, used
 func (m *ClusterMonitor) genNodeResourceMetrics(node *api.Node, key string) {
-	glog.V(4).Infof("Now get resouce metrics for node %s", key)
+	glog.V(3).Infof("Now get resource metrics for node %s", key)
 
 	//1. Capacity of CPU and Memory
 	//1.1 Get the total resource of a node
@@ -180,6 +181,7 @@ func (m *ClusterMonitor) genNodeResourceMetrics(node *api.Node, key string) {
 	m.genRequestUsedMetrics(metrics.NodeType, key, nodeCPURequestUsed, nodeMemRequestUsed)
 	glog.V(4).Infof("CPURequest used of node %s is %f core", node.Name, nodeCPURequestUsed)
 	glog.V(4).Infof("MemoryRequest used of node %s is %f Kb", node.Name, nodeMemRequestUsed)
+	glog.V(3).Infof("Successfully generated resource metrics for node %s", key)
 }
 
 // Parse the labels of a node and create one EntityStateMetric
@@ -226,6 +228,7 @@ func (m *ClusterMonitor) genNodePodsMetrics(node *api.Node, cpuCapacity, memCapa
 	}
 
 	numPods = float64(len(podList))
+	glog.V(3).Infof("Successfully generated pod metrics for node %v.", node.Name)
 	return
 }
 

--- a/pkg/discovery/monitoring/monitoring_worker.go
+++ b/pkg/discovery/monitoring/monitoring_worker.go
@@ -48,6 +48,9 @@ func BuildMonitorWorker(source types.MonitoringSource, config MonitorWorkerConfi
 			return nil, errors.New("Failed to build a cluster monitoring client as the provided config was not a ClusterMonitorConfig")
 		}
 		return master.NewClusterMonitor(clusterMonitorConfig)
+	case types.DummySource:
+		dummyMonitorConfig, _ := config.(*DummyMonitorConfig)
+		return NewDummyMonitor(dummyMonitorConfig)
 	default:
 		return nil, fmt.Errorf("Unsupported monitoring source %s", source)
 	}

--- a/pkg/discovery/monitoring/types/const.go
+++ b/pkg/discovery/monitoring/types/const.go
@@ -7,6 +7,7 @@ const (
 	K8sConntrackSource MonitoringSource = "K8sConntrack"
 	ClusterSource      MonitoringSource = "Cluster"
 	PrometheusSource   MonitoringSource = "Prometheus"
+	DummySource        MonitoringSource = "Dummy" //Testing only
 )
 
 type MonitorType string
@@ -14,4 +15,5 @@ type MonitorType string
 const (
 	ResourceMonitor MonitorType = "ResourceMonitor"
 	StateMonitor    MonitorType = "StateMonitor"
+	DummyMonitor    MonitorType = "DummyMonitor"
 )

--- a/pkg/discovery/processor/service_processor.go
+++ b/pkg/discovery/processor/service_processor.go
@@ -94,7 +94,8 @@ func findPodEndpoints(service *v1.Service, serviceEndpoint *v1.Endpoints) []stri
 			}
 
 			if !strings.EqualFold(target.Kind, "Pod") {
-				glog.Warningf("service: %v depends on non-Pod entity: %+v", serviceClusterID, target)
+				glog.Warningf("service: %v depends on non-Pod entity with kind %v and name %v",
+					serviceClusterID, target.Kind, target.Name)
 				continue
 			}
 			podName := target.Name

--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -78,7 +78,7 @@ func (s *StitchingManager) SetNodeUuidGetterByProvider(providerId string) {
 	}
 
 	s.uuidGetter = getter
-	glog.V(3).Infof("Node UUID getter is: %v", getter.Name())
+	glog.V(4).Infof("Node UUID getter is: %v", getter.Name())
 }
 
 func (s *StitchingManager) GetStitchType() StitchingPropertyType {

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	api "k8s.io/api/core/v1"
+	"strings"
 
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 
@@ -15,8 +16,8 @@ const (
 )
 
 type Task struct {
-	uid string
-
+	uid      string
+	name     string
 	nodeList []*api.Node
 	podList  []*api.Pod
 	cluster  *repository.ClusterSummary
@@ -24,14 +25,22 @@ type Task struct {
 
 // Worker task is consisted of a list of nodes the worker must discover.
 func NewTask() *Task {
+	uid := uuid.NewUUID().String()
+	name := strings.Split(uid, "-")[0]
 	return &Task{
-		uid: uuid.NewUUID().String(),
+		uid:  uid,
+		name: name,
 	}
 }
 
 // Assign nodes to the task.
 func (t *Task) WithNodes(nodeList []*api.Node) *Task {
 	t.nodeList = nodeList
+	return t
+}
+
+func (t *Task) WithNode(node *api.Node) *Task {
+	t.nodeList = append(t.nodeList, node)
 	return t
 }
 
@@ -59,6 +68,14 @@ func (t *Task) PodList() []*api.Pod {
 
 func (t *Task) Cluster() *repository.ClusterSummary {
 	return t.cluster
+}
+
+func (t *Task) String() string {
+	var nodes []string
+	for _, node := range t.nodeList {
+		nodes = append(nodes, node.GetName())
+	}
+	return "[id: " + t.name + ", node: " + strings.Join(nodes, ",") + "]"
 }
 
 type TaskResultState string

--- a/pkg/discovery/worker/controller_metrics_collector_test.go
+++ b/pkg/discovery/worker/controller_metrics_collector_test.go
@@ -93,7 +93,8 @@ func TestCollectControllerMetrics(t *testing.T) {
 	pods := []*api.Pod{testPod1, testPod2, testPod3}
 	currTask := task.NewTask().WithPods(pods).WithCluster(clusterSummary)
 
-	workerConfig := NewK8sDiscoveryWorkerConfig("sType").WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil, nil))
+	workerConfig := NewK8sDiscoveryWorkerConfig("sType", 10).
+		WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil, nil))
 	discoveryWorker, _ := NewK8sDiscoveryWorker(workerConfig, "wid")
 
 	// Add owner metrics to the metric sink

--- a/pkg/discovery/worker/dispatcher_test.go
+++ b/pkg/discovery/worker/dispatcher_test.go
@@ -1,10 +1,27 @@
 package worker
 
 import (
+	"flag"
 	"fmt"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"math"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/configs"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
+	"k8s.io/api/core/v1"
 )
+
+func init() {
+	flag.Set("alsologtostderr", fmt.Sprintf("%t", true))
+	var logLevel string
+	flag.StringVar(&logLevel, "logLevel", "2", "test")
+	flag.Lookup("v").Value.Set(logLevel)
+}
 
 func TestDispatcher_DispatchMimic(t *testing.T) {
 
@@ -54,4 +71,84 @@ func TestDispatcher_DispatchMimic(t *testing.T) {
 	if receiveNum != nodeNum {
 		t.Errorf("%d Vs. %d", receiveNum, nodeNum)
 	}
+}
+
+func getDispatcherAndCollector(workerCount, taskRunTimeSec int) (*Dispatcher, *ResultCollector) {
+	clusterScraper := &cluster.ClusterScraper{}
+	probeConfig := &configs.ProbeConfig{
+		MonitoringConfigs: []monitoring.MonitorWorkerConfig{&monitoring.DummyMonitorConfig{
+			TaskRunTime: taskRunTimeSec,
+		}},
+	}
+	dispatcherConfig := NewDispatcherConfig(clusterScraper, probeConfig, workerCount, 10)
+	dispatcher := NewDispatcher(dispatcherConfig)
+	resultCollector := NewResultCollector(workerCount * 2)
+	dispatcher.Init(resultCollector)
+	return dispatcher, resultCollector
+}
+
+// Test dispatching 1000 tasks with 100 workers, each worker run for 1 second, expect the test to finish in 10 seconds
+func TestDispatcher_Dispatch_1000_Tasks_With_100_Workers(t *testing.T) {
+	taskCount := 1000
+	workerCount := 100
+	taskRunTimeSec := 1
+	expectedRunSec := taskCount / workerCount * taskRunTimeSec
+	timeout := time.After(time.Duration(2*expectedRunSec) * time.Second)
+	done := make(chan bool)
+	start := time.Now()
+	var result *DiscoveryResult
+	go func() {
+		// Actual testing
+		kubeCluster := repository.NewKubeCluster("MyCluster", []*v1.Node{})
+		clusterSummary := repository.CreateClusterSummary(kubeCluster)
+		dispatcher, resultCollector := getDispatcherAndCollector(workerCount, taskRunTimeSec)
+		var nodes = make([]struct{}, taskCount)
+		go func() {
+			for range nodes {
+				currTask := task.NewTask().WithNodes([]*v1.Node{}).WithCluster(clusterSummary)
+				dispatcher.assignTask(currTask)
+			}
+		}()
+		result = resultCollector.Collect(len(nodes))
+		done <- true
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatal("Test didn't finish in time")
+	case <-done:
+	}
+	assert.Equal(t, taskCount, result.SuccessCount)
+	assert.True(t, time.Since(start) > time.Duration(expectedRunSec)*time.Second)
+}
+
+// Test dispatching 4 tasks with 2 workers, each worker run for 60 second, expect the test to timeout in 20 seconds
+func TestDispatcher_Dispatch_With_Task_Timeout(t *testing.T) {
+	taskCount := 4
+	workerCount := 2
+	taskRunTimeSec := 60
+	expectedRunSec := taskCount / workerCount * 10
+	timeout := time.After(time.Duration(2*expectedRunSec) * time.Second)
+	done := make(chan bool)
+	var result *DiscoveryResult
+	go func() {
+		// Actual testing
+		dispatcher, resultCollector := getDispatcherAndCollector(workerCount, taskRunTimeSec)
+		var nodes = make([]struct{}, taskCount)
+		go func() {
+			for range nodes {
+				currTask := task.NewTask()
+				dispatcher.assignTask(currTask)
+			}
+		}()
+		result = resultCollector.Collect(len(nodes))
+		done <- true
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatal("Test didn't finish in time")
+	case <-done:
+	}
+	assert.Equal(t, taskCount, result.ErrorCount)
 }

--- a/pkg/discovery/worker/k8s_discovery_worker_test.go
+++ b/pkg/discovery/worker/k8s_discovery_worker_test.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
@@ -13,41 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestCalTimeOut(t *testing.T) {
-	type Pair struct {
-		nodeNum int
-		timeout time.Duration
-	}
-
-	inputs := []*Pair{
-		&Pair{
-			nodeNum: 0,
-			timeout: defaultMonitoringWorkerTimeout,
-		},
-		&Pair{
-			nodeNum: 22,
-			timeout: defaultMonitoringWorkerTimeout + time.Second*22,
-		},
-		&Pair{
-			nodeNum: 500,
-			timeout: defaultMonitoringWorkerTimeout + time.Second*500,
-		},
-		&Pair{
-			nodeNum: 1500,
-			timeout: defaultMaxTimeout,
-		},
-	}
-
-	for _, input := range inputs {
-		result := calcTimeOut(input.nodeNum)
-		if result != input.timeout {
-			t.Errorf("tiemout error: %v Vs. %v", result, input.timeout)
-		}
-	}
-}
-
 func TestBuildDTOsWithMissingMetrics(t *testing.T) {
-	workerConfig := NewK8sDiscoveryWorkerConfig("UUID").WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil, nil))
+	workerConfig := NewK8sDiscoveryWorkerConfig("UUID", 1).
+		WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil, nil))
 	worker, err := NewK8sDiscoveryWorker(workerConfig, "wid-1")
 	if err != nil {
 		t.Errorf("Error while creating discovery worker: %v", err)

--- a/pkg/discovery/worker/metrics_collector.go
+++ b/pkg/discovery/worker/metrics_collector.go
@@ -99,7 +99,6 @@ func (podCollectionMap PodMetricsByNodeAndNamespace) addPodMetric(podName, nodeN
 // The discovery worker will add the PodMetrics to the metrics sink.
 func (collector *MetricsCollector) CollectPodMetrics() (PodMetricsByNodeAndNamespace, error) {
 	if collector.Cluster == nil {
-		glog.Errorf("Cluster summary object is null for discovery worker %s", collector.workerId)
 		return nil, fmt.Errorf("cluster summary object is null for discovery worker %s", collector.workerId)
 	}
 	podCollectionMap := make(PodMetricsByNodeAndNamespace)

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -157,8 +157,9 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	registrationClientConfig := registration.NewRegistrationClientConfig(config.StitchingPropType, config.VMPriority, config.VMIsBase)
 
 	probeConfig := createProbeConfigOrDie(config)
-	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig, config.ValidationWorkers,
-		config.ValidationTimeoutSec, config.containerUtilizationDataAggStrategy, config.containerUsageDataAggStrategy, config.ORMClient)
+	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig,
+		config.ValidationWorkers, config.ValidationTimeoutSec, config.containerUtilizationDataAggStrategy,
+		config.containerUsageDataAggStrategy, config.ORMClient, config.DiscoveryWorkers, config.DiscoveryTimeoutSec)
 
 	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.KubeClient,
 		config.KubeletClient, config.DynamicClient, config.SccSupport, config.ORMClient)

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -32,6 +32,8 @@ type Config struct {
 	StopEverything chan struct{}
 
 	DiscoveryIntervalSec int
+	DiscoveryWorkers     int
+	DiscoveryTimeoutSec  int
 	ValidationWorkers    int
 	ValidationTimeoutSec int
 
@@ -114,6 +116,16 @@ func (c *Config) WithValidationTimeout(di int) *Config {
 
 func (c *Config) WithValidationWorkers(di int) *Config {
 	c.ValidationWorkers = di
+	return c
+}
+
+func (c *Config) WithDiscoveryWorkers(workers int) *Config {
+	c.DiscoveryWorkers = workers
+	return c
+}
+
+func (c *Config) WithDiscoveryTimeout(timeout int) *Config {
+	c.DiscoveryTimeoutSec = timeout
 	return c
 }
 


### PR DESCRIPTION
This PR ports the discovery enhancement done in #450 to master:

* Discover one node per discovery worker
* Make discovery worker count and discovery timeout configurable
  * Discovery worker: Min 1, Max 10, Default 4
  * Discovery timeout for each worker: Min 10 sec, Max 20 min, Default 3 min  
* Do not process discovery result when discovery times out
* Wrap discovery result in a struct to make the code more readable
* Clean up and improve log messages
* Add unit tests to test dispatching
  * Dispatching large amount of tasks with limited workers
  * Dispatching tasks that timeout

The level 2 logging shows the following messages for a successful discovery:
```
I0724 16:13:16.543538       1 result_collector.go:40] Waiting for results from 7 tasks.
I0724 16:13:16.597479       1 dispatcher.go:77] Dispatching task [id: 950c207b, node: ae-cluster1-node-group-e90c389207]
I0724 16:13:16.597718       1 k8s_discovery_worker.go:132] Worker w1 has received a task [id: 950c207b, node: ae-cluster1-node-group-e90c389207].
I0724 16:13:16.688875       1 dispatcher.go:77] Dispatching task [id: 951a1275, node: ae-cluster1-master-gro-dcc8ae139e]
I0724 16:13:16.689197       1 k8s_discovery_worker.go:132] Worker w0 has received a task [id: 951a1275, node: ae-cluster1-master-gro-dcc8ae139e].
I0724 16:13:16.806179       1 dispatcher.go:77] Dispatching task [id: 952bf8df, node: ae-cluster1-node-group-52b4bf3ddf]
I0724 16:13:16.807535       1 k8s_discovery_worker.go:132] Worker w3 has received a task [id: 952bf8df, node: ae-cluster1-node-group-52b4bf3ddf].
I0724 16:13:16.823801       1 node_util.go:117] ae-cluster1-master-gro-dcc8ae139e is a HA node and will be marked Non Suspendable.
I0724 16:13:16.827978       1 k8s_discovery_worker.go:377] Worker w0 built total 35 entityDTOs.
I0724 16:13:16.829629       1 k8s_discovery_worker.go:135] Worker w0 has finished the task [id: 951a1275, node: ae-cluster1-master-gro-dcc8ae139e].
I0724 16:13:16.829665       1 result_collector.go:56] Processing results from worker w0
I0724 16:13:16.835998       1 k8s_discovery_worker.go:377] Worker w1 built total 39 entityDTOs.
I0724 16:13:16.836415       1 k8s_discovery_worker.go:135] Worker w1 has finished the task [id: 950c207b, node: ae-cluster1-node-group-e90c389207].
I0724 16:13:16.836435       1 result_collector.go:56] Processing results from worker w1
I0724 16:13:16.865424       1 dispatcher.go:77] Dispatching task [id: 953501d6, node: ae-cluster1-node-group-5ac24a46b5]
I0724 16:13:16.867580       1 k8s_discovery_worker.go:132] Worker w2 has received a task [id: 953501d6, node: ae-cluster1-node-group-5ac24a46b5].
I0724 16:13:16.940565       1 dispatcher.go:77] Dispatching task [id: 95407a55, node: ae-cluster1-node-group-6794a61ceb]
I0724 16:13:16.940685       1 k8s_discovery_worker.go:132] Worker w0 has received a task [id: 95407a55, node: ae-cluster1-node-group-6794a61ceb].
I0724 16:13:17.028018       1 dispatcher.go:77] Dispatching task [id: 954dd25f, node: ae-cluster1-node-group-6a0a934929]
I0724 16:13:17.032361       1 k8s_discovery_worker.go:132] Worker w1 has received a task [id: 954dd25f, node: ae-cluster1-node-group-6a0a934929].
I0724 16:13:17.078115       1 dispatcher.go:77] Dispatching task [id: 9555775c, node: ae-cluster1-node-group-976a8dfd6f]
I0724 16:13:17.192859       1 k8s_discovery_worker.go:377] Worker w2 built total 31 entityDTOs.
I0724 16:13:17.193652       1 k8s_discovery_worker.go:135] Worker w2 has finished the task [id: 953501d6, node: ae-cluster1-node-group-5ac24a46b5].
I0724 16:13:17.193679       1 k8s_discovery_worker.go:132] Worker w2 has received a task [id: 9555775c, node: ae-cluster1-node-group-976a8dfd6f].
I0724 16:13:17.194486       1 result_collector.go:56] Processing results from worker w2
I0724 16:13:17.684480       1 k8s_discovery_worker.go:377] Worker w0 built total 32 entityDTOs.
I0724 16:13:17.685678       1 k8s_discovery_worker.go:135] Worker w0 has finished the task [id: 95407a55, node: ae-cluster1-node-group-6794a61ceb].
I0724 16:13:17.685706       1 result_collector.go:56] Processing results from worker w0
I0724 16:13:18.361404       1 k8s_discovery_worker.go:377] Worker w3 built total 62 entityDTOs.
I0724 16:13:18.367096       1 k8s_discovery_worker.go:135] Worker w3 has finished the task [id: 952bf8df, node: ae-cluster1-node-group-52b4bf3ddf].
I0724 16:13:18.367394       1 result_collector.go:56] Processing results from worker w3
I0724 16:13:19.036068       1 k8s_discovery_worker.go:377] Worker w1 built total 45 entityDTOs.
I0724 16:13:19.041190       1 k8s_discovery_worker.go:135] Worker w1 has finished the task [id: 954dd25f, node: ae-cluster1-node-group-6a0a934929].
I0724 16:13:19.041362       1 result_collector.go:56] Processing results from worker w1
I0724 16:13:19.238161       1 k8s_discovery_worker.go:377] Worker w2 built total 60 entityDTOs.
I0724 16:13:19.239490       1 k8s_discovery_worker.go:135] Worker w2 has finished the task [id: 9555775c, node: ae-cluster1-node-group-976a8dfd6f].
I0724 16:13:19.239659       1 result_collector.go:56] Processing results from worker w2
I0724 16:13:19.239862       1 result_collector.go:79] Got all the results from 7 tasks with 0 tasks failed and 7 tasks succeeded.
```