### PR TITLE
Cont storage volumes fixes

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -364,11 +364,8 @@ func (builder *podEntityDTOBuilder) buyCommoditiesFromVolumes(pod *api.Pod, moun
 	for _, mount := range mounts {
 		mountName := mount.MountName
 		volEntityID := util.PodVolumeMetricId(podKey, mountName)
-		// We use <ns>/<pod-name>/<mounted-vol-name> as the commodity key
-		// to keep the relationship between pod and volume unique.
-		commKey := fmt.Sprintf("%s/%s", podKey, mountName)
 		commBought, err := builder.getResourceCommodityBoughtWithKey(metrics.PodType, volEntityID,
-			metrics.StorageAmount, commKey, nil, nil)
+			metrics.StorageAmount, "", nil, nil)
 		if err != nil {
 			glog.Errorf("Failed to build %s bought by pod %s mounted %s from volume %s: %v",
 				metrics.StorageAmount, podKey, mountName, mount.UsedVolume.Name, err)

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -385,6 +385,9 @@ func (builder *podEntityDTOBuilder) buyCommoditiesFromVolumes(pod *api.Pod, moun
 
 		provider := sdkbuilder.CreateProvider(proto.EntityDTO_VIRTUAL_VOLUME, providerVolUID)
 		dtoBuilder = dtoBuilder.Provider(provider)
+		dtoBuilder.IsMovable(proto.EntityDTO_VIRTUAL_VOLUME, false).
+			IsStartable(proto.EntityDTO_VIRTUAL_VOLUME, false).
+			IsScalable(proto.EntityDTO_VIRTUAL_VOLUME, false)
 
 		// Each pod mounts any given volume only once
 		dtoBuilder.BuysCommodities([]*proto.CommodityDTO{commBought})

--- a/pkg/discovery/dtofactory/volume_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/volume_entity_dto_builder.go
@@ -1,8 +1,6 @@
 package dtofactory
 
 import (
-	"fmt"
-
 	api "k8s.io/api/core/v1"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
@@ -89,8 +87,6 @@ func (builder *volumeEntityDTOBuilder) getVolumeCommoditiesSold(vol *api.Persist
 
 	volumeCapacity := float64(0)
 	for _, podVol := range podVols {
-		podKey := podVol.QualifiedPodName
-		mountName := podVol.MountName
 		// Volume capacity metrics is available as part of volume spec.
 		// However we dont use that if the actual queried volume size
 		// is available and discovered by the kubelet as part of
@@ -102,10 +98,8 @@ func (builder *volumeEntityDTOBuilder) getVolumeCommoditiesSold(vol *api.Persist
 		}
 		volumeCapacity = capacity
 
-		commKey := fmt.Sprintf("%s/%s", podKey, mountName)
-		commBuilder := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_STORAGE_AMOUNT).Key(commKey)
+		commBuilder := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_STORAGE_AMOUNT)
 		commBuilder.Used(used)
-		commBuilder.Peak(used)
 		commBuilder.Capacity(capacity)
 		commodityPerPod, err := commBuilder.Create()
 		if err != nil {

--- a/pkg/discovery/processor/volume_processor.go
+++ b/pkg/discovery/processor/volume_processor.go
@@ -76,7 +76,7 @@ func (p *VolumeProcessor) ProcessVolumes() {
 				claim := vol.VolumeSource.PersistentVolumeClaim
 				if claim != nil {
 					if pvc != nil {
-						if claim.ClaimName == pvc.Name {
+						if pod.Namespace == pvc.Namespace && claim.ClaimName == pvc.Name {
 							pVol := repository.PodVolume{
 								QualifiedPodName: util.PodKeyFunc(pod),
 								MountName:        vol.Name,

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -423,9 +423,8 @@ func (f *SupplyChainFactory) buildVolumeSupplyBuilder() (*proto.TemplateDTO, err
 
 // Stitching metadata required for stitching with XL
 func (f *SupplyChainFactory) buildVolumeMergedEntityMetadata() (*proto.MergedEntityMetadata, error) {
-	fieldsUsedCapacity := map[string][]string{
-		builder.PropertyUsed:     {},
-		builder.PropertyCapacity: {},
+	fieldsUsed := map[string][]string{
+		builder.PropertyUsed: {},
 	}
 
 	mergedEntityMetadataBuilder := builder.NewMergedEntityMetadataBuilder()
@@ -436,6 +435,6 @@ func (f *SupplyChainFactory) buildVolumeMergedEntityMetadata() (*proto.MergedEnt
 		ExternalMatchingField(VOLUMEUUID, []string{})
 
 	return mergedEntityMetadataBuilder.
-		PatchSoldMetadata(proto.CommodityDTO_STORAGE_AMOUNT, fieldsUsedCapacity).
+		PatchSoldMetadata(proto.CommodityDTO_STORAGE_AMOUNT, fieldsUsed).
 		Build()
 }


### PR DESCRIPTION
Fixes for the known issues with the storage volumes work, which are:
- Duplicate commodities show up if the same volume mount names and pvcs used across workloads (multiple XLs is a typical example). [Fixed]
- Solve reconfigure actions. In discussion with storage team, until volumes are added as providers in market all probes disable actions on them.[ Fixed]
- Stitch storage_amount with actual usage from pods and no keys. Actions based on usage will show up on volumes. [Fixed]
- Patch only used storage amount and let the cloud probe drive the capacity for the same.
