### PR TITLE
Fix crash in updated metrics interface

### DIFF
--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -253,7 +253,7 @@ func (m *KubeletMonitor) genRequestUsedMetrics(etype metrics.DiscoveredEntityTyp
 
 func (m *KubeletMonitor) genNumConsumersUsedMetrics(etype metrics.DiscoveredEntityType, key string) {
 	// Each pod consumes one from numConsumers / Total available is node allocatable pod number
-	numConsumersMetric := metrics.NewEntityResourceMetric(etype, key, metrics.NumPods, metrics.Used, 1)
+	numConsumersMetric := metrics.NewEntityResourceMetric(etype, key, metrics.NumPods, metrics.Used, float64(1))
 	m.metricSink.AddNewMetricEntries(numConsumersMetric)
 }
 


### PR DESCRIPTION
@marvelyue not sure if you noticed this yet. However I did get a crash (which this change fixes) when I was testing kubeturbo with another feature on the latest.