### PR TITLE
Fix daemonset container resize action execution fail

### DIFF
--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -171,7 +171,7 @@ func (r *ReScheduler) reSchedule(pod *api.Pod, node *api.Node) (*api.Pod, error)
 		return nil, err
 	}
 
-	if !util.SupportedParent(parentKind) {
+	if !util.SupportedParent(parentKind, false) {
 		err = fmt.Errorf("The object kind [%v] of [%s] is not supported", parentKind, parentName)
 		glog.Errorf("Move action aborted: %v.", err)
 		return nil, err

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -216,7 +216,7 @@ func resizeSingleContainer(client *kclient.Clientset, originalPod *k8sapi.Pod, s
 		glog.Errorf("Resize action failed: failed to get pod[%s] parent info: %v.", fullName, err)
 		return nil, err
 	}
-	if !util.SupportedParent(parentKind) {
+	if !util.SupportedParent(parentKind, true) {
 		err = fmt.Errorf("parent kind %v is not supported", parentKind)
 		glog.Errorf("Resize action aborted: %v.", err)
 		return nil, err

--- a/pkg/action/util/util.go
+++ b/pkg/action/util/util.go
@@ -105,8 +105,12 @@ func BuildIdentifier(namespace, name string) string {
 // check whether parentKind is supported for MovePod/ResizeContainer actions
 // currently, these actions can only works on barePod, ReplicaSet, and ReplicationController
 //   Note: pod's parent cannot be Deployment. Deployment will create/control ReplicaSet, and ReplicaSet will create/control Pods.
-func SupportedParent(parentKind string) bool {
+func SupportedParent(parentKind string, isResize bool) bool {
 	if parentKind == "" {
+		return true
+	}
+
+	if isResize && strings.EqualFold(parentKind, util.KindDaemonSet) {
 		return true
 	}
 


### PR DESCRIPTION
This partially fixes https://vmturbo.atlassian.net/browse/OM-60525.
Please see the issue description for details.
This also additionally needs a way to disable merged action feature as in https://github.com/turbonomic/kubeturbo/pull/455 (probably port it to master). Or a more complete fix as described in https://vmturbo.atlassian.net/browse/OM-60525?focusedCommentId=552781