### PR TITLE
Add node labels as VCTAG properties

### DIFF
--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -1,9 +1,10 @@
 package dtofactory
 
 import (
+	"math"
+
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
-	"math"
 
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -265,10 +265,8 @@ func (builder *nodeEntityDTOBuilder) getNodeProperties(node *api.Node) ([]*proto
 		*stitchingProperty.Value)
 	properties = append(properties, stitchingProperty)
 
-	// additional node cluster info property.
-	nodeProperty := property.BuildNodeProperties(node)
-	properties = append(properties, nodeProperty)
-
+	// additional node info properties.
+	properties = append(properties, property.BuildNodeProperties(node)...)
 	return properties, nil
 }
 

--- a/pkg/discovery/dtofactory/property/node_properties.go
+++ b/pkg/discovery/dtofactory/property/node_properties.go
@@ -7,15 +7,32 @@ import (
 )
 
 // Build entity properties for a node. The name is the name of the node shown inside Kubernetes cluster.
-func BuildNodeProperties(node *api.Node) *proto.EntityDTO_EntityProperty {
+func BuildNodeProperties(node *api.Node) []*proto.EntityDTO_EntityProperty {
+	var properties []*proto.EntityDTO_EntityProperty
 	propertyNamespace := k8sPropertyNamespace
 	propertyName := k8sNodeName
 	propertyValue := node.Name
-	return &proto.EntityDTO_EntityProperty{
+	nameProperty := &proto.EntityDTO_EntityProperty{
 		Namespace: &propertyNamespace,
 		Name:      &propertyName,
 		Value:     &propertyValue,
 	}
+	properties = append(properties, nameProperty)
+
+	tagsPropertyNamespace := VCTagsPropertyNamespace
+	labels := node.GetLabels()
+	for label, lval := range labels {
+		tagNamePropertyName := label
+		tagNamePropertyValue := lval
+		tagProperty := &proto.EntityDTO_EntityProperty{
+			Namespace: &tagsPropertyNamespace,
+			Name:      &tagNamePropertyName,
+			Value:     &tagNamePropertyValue,
+		}
+		properties = append(properties, tagProperty)
+	}
+
+	return properties
 }
 
 // Get node name from entity property.

--- a/pkg/discovery/dtofactory/property/property_test.go
+++ b/pkg/discovery/dtofactory/property/property_test.go
@@ -1,7 +1,6 @@
 package property
 
 import (
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -26,9 +25,7 @@ func TestNodeProperty(t *testing.T) {
 		},
 	}
 
-	property := BuildNodeProperties(node)
-	ps := []*proto.EntityDTO_EntityProperty{property}
-
+	ps := BuildNodeProperties(node)
 	nodeName := GetNodeNameFromProperty(ps)
 
 	if nodeName != node.Name {


### PR DESCRIPTION
This add further support to report node labels as tags and complete the fix for https://vmturbo.atlassian.net/browse/OM-60526.
Addind a WIP here as stitching VCTAGS properties is still open.