### PR TITLE
Create new data sampling discovery workers

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -38,16 +38,18 @@ import (
 
 const (
 	// The default port for vmt service server
-	KubeturboPort               = 10265
-	DefaultKubeletPort          = 10255
-	DefaultKubeletHttps         = false
-	defaultVMPriority           = -1
-	defaultVMIsBase             = true
-	defaultDiscoveryIntervalSec = 600
-	defaultValidationWorkers    = 10
-	defaultValidationTimeout    = 60
-	defaultDiscoveryWorkers     = 4
-	defaultDiscoveryTimeoutSec  = 180
+	KubeturboPort                     = 10265
+	DefaultKubeletPort                = 10255
+	DefaultKubeletHttps               = false
+	defaultVMPriority                 = -1
+	defaultVMIsBase                   = true
+	defaultDiscoveryIntervalSec       = 600
+	defaultValidationWorkers          = 10
+	defaultValidationTimeout          = 60
+	defaultDiscoveryWorkers           = 4
+	defaultDiscoveryTimeoutSec        = 180
+	defaultDiscoverySamples           = 10
+	defaultDiscoverySampleIntervalSec = 60
 )
 
 var (
@@ -99,6 +101,10 @@ type VMTServer struct {
 	DiscoveryWorkers    int
 	DiscoveryTimeoutSec int
 
+	// Data sampling discovery related config
+	DiscoverySamples           int
+	DiscoverySampleIntervalSec int
+
 	// The Openshift SCC list allowed for action execution
 	sccSupport []string
 
@@ -149,6 +155,8 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.ValidationTimeout, "validation-timeout-sec", defaultValidationTimeout, "The validation timeout in seconds")
 	fs.IntVar(&s.DiscoveryWorkers, "discovery-workers", defaultDiscoveryWorkers, "The number of discovery workers")
 	fs.IntVar(&s.DiscoveryTimeoutSec, "discovery-timeout-sec", defaultDiscoveryTimeoutSec, "The discovery timeout in seconds for each discovery worker")
+	fs.IntVar(&s.DiscoverySamples, "discovery-samples", defaultDiscoverySamples, "The number of resource usage data samples to be collected from kubelet in each main discovery cycle")
+	fs.IntVar(&s.DiscoverySampleIntervalSec, "discovery-sample-interval", defaultDiscoverySampleIntervalSec, "The discovery interval in seconds to collect additional resource usage data samples from kubelet")
 	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=* to allow all")
 	fs.StringVar(&s.ClusterAPINamespace, "cluster-api-namespace", "default", "The Cluster API namespace.")
 	fs.StringVar(&s.BusyboxImage, "busybox-image", "busybox", "The complete image uri used for fallback node cpu frequency getter job.")
@@ -304,6 +312,8 @@ func (s *VMTServer) Run() {
 		WithValidationWorkers(s.ValidationWorkers).
 		WithDiscoveryWorkers(s.DiscoveryWorkers).
 		WithDiscoveryTimeout(s.DiscoveryTimeoutSec).
+		WithDiscoverySamples(s.DiscoverySamples).
+		WithDiscoverySampleIntervalSec(s.DiscoverySampleIntervalSec).
 		WithSccSupport(s.sccSupport).
 		WithCAPINamespace(s.ClusterAPINamespace).
 		WithContainerUtilizationDataAggStrategy(s.containerUtilizationDataAggStrategy).

--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -155,7 +155,7 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.ValidationTimeout, "validation-timeout-sec", defaultValidationTimeout, "The validation timeout in seconds")
 	fs.IntVar(&s.DiscoveryWorkers, "discovery-workers", defaultDiscoveryWorkers, "The number of discovery workers")
 	fs.IntVar(&s.DiscoveryTimeoutSec, "discovery-timeout-sec", defaultDiscoveryTimeoutSec, "The discovery timeout in seconds for each discovery worker")
-	fs.IntVar(&s.DiscoverySamples, "discovery-samples", defaultDiscoverySamples, "The number of resource usage data samples to be collected from kubelet in each main discovery cycle")
+	fs.IntVar(&s.DiscoverySamples, "discovery-samples", defaultDiscoverySamples, "The number of resource usage data samples to be collected from kubelet in each full discovery cycle")
 	fs.IntVar(&s.DiscoverySampleIntervalSec, "discovery-sample-interval", defaultDiscoverySampleIntervalSec, "The discovery interval in seconds to collect additional resource usage data samples from kubelet")
 	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=* to allow all")
 	fs.StringVar(&s.ClusterAPINamespace, "cluster-api-namespace", "default", "The Cluster API namespace.")

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -284,7 +284,7 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 	taskCount := dc.dispatcher.Dispatch(nodes, clusterSummary)
 	result := dc.resultCollector.Collect(taskCount)
 
-	// Clear globalEntityMetricSink cache after collecting main discovery results
+	// Clear globalEntityMetricSink cache after collecting full discovery results
 	dc.globalEntityMetricSink.ClearCache()
 	// Reschedule dispatch sampling discovery tasks for newly discovered nodes
 	dc.samplingDispatcher.ScheduleDispatch(nodes)

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"fmt"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"strings"
 	"time"
 
@@ -24,12 +25,14 @@ const (
 )
 
 type DiscoveryClientConfig struct {
-	probeConfig          *configs.ProbeConfig
-	targetConfig         *configs.K8sTargetConfig
-	ValidationWorkers    int
-	ValidationTimeoutSec int
-	DiscoveryWorkers     int
-	DiscoveryTimeoutSec  int
+	probeConfig                *configs.ProbeConfig
+	targetConfig               *configs.K8sTargetConfig
+	ValidationWorkers          int
+	ValidationTimeoutSec       int
+	DiscoveryWorkers           int
+	DiscoveryTimeoutSec        int
+	DiscoverySamples           int
+	DiscoverySampleIntervalSec int
 	// Strategy to aggregate Container utilization data on ContainerSpec entity
 	containerUtilizationDataAggStrategy string
 	// Strategy to aggregate Container usage data on ContainerSpec entity
@@ -43,7 +46,7 @@ func NewDiscoveryConfig(probeConfig *configs.ProbeConfig,
 	targetConfig *configs.K8sTargetConfig, ValidationWorkers int,
 	ValidationTimeoutSec int, containerUtilizationDataAggStrategy,
 	containerUsageDataAggStrategy string, ormClient *resourcemapping.ORMClient,
-	discoveryWorkers int, discoveryTimeoutMin int) *DiscoveryClientConfig {
+	discoveryWorkers, discoveryTimeoutMin, discoverySamples, discoverySampleIntervalSec int) *DiscoveryClientConfig {
 	if discoveryWorkers < minDiscoveryWorker {
 		glog.Warningf("Invalid number of discovery workers %v, set it to %v.",
 			discoveryWorkers, minDiscoveryWorker)
@@ -65,16 +68,20 @@ func NewDiscoveryConfig(probeConfig *configs.ProbeConfig,
 		ormClient:                           ormClient,
 		DiscoveryWorkers:                    discoveryWorkers,
 		DiscoveryTimeoutSec:                 discoveryTimeoutMin,
+		DiscoverySamples:                    discoverySamples,
+		DiscoverySampleIntervalSec:          discoverySampleIntervalSec,
 	}
 }
 
 // Implements the go sdk discovery client interface
 type K8sDiscoveryClient struct {
-	config            *DiscoveryClientConfig
-	k8sClusterScraper *cluster.ClusterScraper
-	clusterProcessor  *processor.ClusterProcessor
-	dispatcher        *worker.Dispatcher
-	resultCollector   *worker.ResultCollector
+	config                 *DiscoveryClientConfig
+	k8sClusterScraper      *cluster.ClusterScraper
+	clusterProcessor       *processor.ClusterProcessor
+	dispatcher             *worker.Dispatcher
+	samplingDispatcher     *worker.SamplingDispatcher
+	resultCollector        *worker.ResultCollector
+	globalEntityMetricSink *metrics.EntityMetricSink
 }
 
 func NewK8sDiscoveryClient(config *DiscoveryClientConfig) *K8sDiscoveryClient {
@@ -83,20 +90,31 @@ func NewK8sDiscoveryClient(config *DiscoveryClientConfig) *K8sDiscoveryClient {
 	// for discovery tasks
 	clusterProcessor := processor.NewClusterProcessor(k8sClusterScraper, config.probeConfig.NodeClient,
 		config.ValidationWorkers, config.ValidationTimeoutSec)
+
+	globalEntityMetricSink := metrics.NewEntityMetricSink().WithMaxMetricPointsSize(config.DiscoverySamples)
+
 	// make maxWorkerCount of result collector twice the worker count.
 	resultCollector := worker.NewResultCollector(config.DiscoveryWorkers * 2)
 
 	dispatcherConfig := worker.NewDispatcherConfig(k8sClusterScraper, config.probeConfig,
-		config.DiscoveryWorkers, config.DiscoveryTimeoutSec)
-	dispatcher := worker.NewDispatcher(dispatcherConfig)
+		config.DiscoveryWorkers, config.DiscoveryTimeoutSec, config.DiscoverySamples, config.DiscoverySampleIntervalSec)
+	dispatcher := worker.NewDispatcher(dispatcherConfig, globalEntityMetricSink)
 	dispatcher.Init(resultCollector)
 
+	// Create new SamplingDispatcher to assign tasks to collect additional resource usage data samples from kubelet
+	samplingDispatcherConfig := worker.NewDispatcherConfig(k8sClusterScraper, config.probeConfig,
+		config.DiscoveryWorkers, config.DiscoverySampleIntervalSec, config.DiscoverySamples, config.DiscoverySampleIntervalSec)
+	dataSamplingDispatcher := worker.NewSamplingDispatcher(samplingDispatcherConfig, globalEntityMetricSink)
+	dataSamplingDispatcher.InitSamplingDiscoveryWorkers()
+
 	dc := &K8sDiscoveryClient{
-		config:            config,
-		k8sClusterScraper: k8sClusterScraper,
-		clusterProcessor:  clusterProcessor,
-		dispatcher:        dispatcher,
-		resultCollector:   resultCollector,
+		config:                 config,
+		k8sClusterScraper:      k8sClusterScraper,
+		clusterProcessor:       clusterProcessor,
+		dispatcher:             dispatcher,
+		samplingDispatcher:     dataSamplingDispatcher,
+		resultCollector:        resultCollector,
+		globalEntityMetricSink: globalEntityMetricSink,
 	}
 	return dc
 }
@@ -257,11 +275,19 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 	nodes := clusterSummary.NodeList
 	// Call cache cleanup
 	dc.config.probeConfig.NodeClient.CleanupCache(nodes)
+	// Stops scheduling dispatcher to assign sampling discovery tasks.
+	dc.samplingDispatcher.FinishSampling()
 
 	// Discover pods and create DTOs for nodes, namespaces, controllers, pods, containers, application.
-	// Collect the kubePod, kubeNamespace metrics, groups and kubeControllers from all the discovery workers
+	// Merge collected usage data samples from globalEntityMetricSink into the metric sink of each individual discovery worker.
+	// Collect the kubePod, kubeNamespace metrics, groups and kubeControllers from all the discovery workers.
 	taskCount := dc.dispatcher.Dispatch(nodes, clusterSummary)
 	result := dc.resultCollector.Collect(taskCount)
+
+	// Clear globalEntityMetricSink cache after collecting main discovery results
+	dc.globalEntityMetricSink.ClearCache()
+	// Reschedule dispatch sampling discovery tasks for newly discovered nodes
+	dc.samplingDispatcher.ScheduleDispatch(nodes)
 
 	// Namespace discovery worker to create namespace DTOs
 	stitchType := dc.config.probeConfig.StitchingPropertyType

--- a/pkg/discovery/metrics/metric_sink.go
+++ b/pkg/discovery/metrics/metric_sink.go
@@ -10,13 +10,19 @@ import (
 )
 
 type EntityMetricSink struct {
-	data *turbostore.Cache
+	data                *turbostore.Cache
+	maxMetricPointsSize int
 }
 
 func NewEntityMetricSink() *EntityMetricSink {
 	return &EntityMetricSink{
 		data: turbostore.NewCache(),
 	}
+}
+
+func (s *EntityMetricSink) WithMaxMetricPointsSize(maxMetricPointsSize int) *EntityMetricSink {
+	s.maxMetricPointsSize = maxMetricPointsSize
+	return s
 }
 
 // Add one or more metric entries to sink.
@@ -32,7 +38,7 @@ func (s *EntityMetricSink) AddNewMetricEntries(metrics ...Metric) {
 func (s *EntityMetricSink) UpdateMetricEntry(metric Metric) {
 	m, exists := s.data.Get(metric.GetUID())
 	if exists {
-		metric.UpdateValue(m)
+		metric = metric.UpdateValue(m, s.maxMetricPointsSize)
 	}
 	s.AddNewMetricEntries(metric)
 }
@@ -69,4 +75,9 @@ func (s *EntityMetricSink) MergeSink(anotherSink *EntityMetricSink, filterFunc M
 		}
 		s.UpdateMetricEntry(metric)
 	}
+}
+
+// ClearCache clears all metrics data
+func (s *EntityMetricSink) ClearCache() {
+	s.data = turbostore.NewCache()
 }

--- a/pkg/discovery/metrics/metric_sink_test.go
+++ b/pkg/discovery/metrics/metric_sink_test.go
@@ -1,0 +1,29 @@
+package metrics
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEntityMetricSink_UpdateMetricEntry(t *testing.T) {
+	maxMetricPointsSize := 10
+	sink := NewEntityMetricSink().WithMaxMetricPointsSize(maxMetricPointsSize)
+
+	containerId := "containerId"
+	for i := 0; i < 20; i++ {
+		containerResMetric := NewEntityResourceMetric(ContainerType, containerId, Memory, Used,
+			Points{
+				Values:    []float64{float64(i)},
+				Timestamp: int64(i),
+			})
+		sink.UpdateMetricEntry(containerResMetric)
+	}
+
+	containerMid := GenerateEntityResourceMetricUID(ContainerType, containerId, Memory, Used)
+	metric, _ := sink.GetMetric(containerMid)
+	metricVal := metric.GetValue().(Points)
+	expectedPoints := []float64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
+	assert.EqualValues(t, maxMetricPointsSize, len(metricVal.Values))
+	assert.EqualValues(t, expectedPoints, metricVal.Values)
+	assert.EqualValues(t, 19, metricVal.Timestamp)
+}

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
@@ -168,7 +168,7 @@ func checkApplicationMetrics(sink *metrics.EntityMetricSink, appMId string, cont
 func TestParseStats(t *testing.T) {
 	conf := &KubeletMonitorConfig{}
 
-	klet, err := NewKubeletMonitor(conf)
+	klet, err := NewKubeletMonitor(conf, true)
 	if err != nil {
 		t.Errorf("Failed to create kubeletMonitor: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestParseStats(t *testing.T) {
 	podstat1 := createPodStat("pod1")
 	podstat2 := createPodStat("pod2")
 	pods := []stats.PodStats{*podstat1, *podstat2}
-	klet.parsePodStats(pods)
+	klet.parsePodStats(pods, 0)
 
 	for _, podstat := range pods {
 		//1. check pod metrics

--- a/pkg/discovery/monitoring/monitoring_worker.go
+++ b/pkg/discovery/monitoring/monitoring_worker.go
@@ -33,7 +33,7 @@ type StateMonitoringWorker interface {
 	RetrieveClusterStat() error
 }
 
-func BuildMonitorWorker(source types.MonitoringSource, config MonitorWorkerConfig, isMainDiscovery bool) (MonitoringWorker, error) {
+func BuildMonitorWorker(source types.MonitoringSource, config MonitorWorkerConfig, isFullDiscovery bool) (MonitoringWorker, error) {
 	// Build monitoring client
 	switch source {
 	case types.KubeletSource:
@@ -41,7 +41,7 @@ func BuildMonitorWorker(source types.MonitoringSource, config MonitorWorkerConfi
 		if !ok {
 			return nil, errors.New("failed to build a Kubelet monitoring client as the provided config was not a KubeletMonitorConfig")
 		}
-		return kubelet.NewKubeletMonitor(kubeletConfig, isMainDiscovery)
+		return kubelet.NewKubeletMonitor(kubeletConfig, isFullDiscovery)
 	case types.ClusterSource:
 		clusterMonitorConfig, ok := config.(*master.ClusterMonitorConfig)
 		if !ok {

--- a/pkg/discovery/monitoring/monitoring_worker.go
+++ b/pkg/discovery/monitoring/monitoring_worker.go
@@ -33,7 +33,7 @@ type StateMonitoringWorker interface {
 	RetrieveClusterStat() error
 }
 
-func BuildMonitorWorker(source types.MonitoringSource, config MonitorWorkerConfig) (MonitoringWorker, error) {
+func BuildMonitorWorker(source types.MonitoringSource, config MonitorWorkerConfig, isMainDiscovery bool) (MonitoringWorker, error) {
 	// Build monitoring client
 	switch source {
 	case types.KubeletSource:
@@ -41,7 +41,7 @@ func BuildMonitorWorker(source types.MonitoringSource, config MonitorWorkerConfi
 		if !ok {
 			return nil, errors.New("failed to build a Kubelet monitoring client as the provided config was not a KubeletMonitorConfig")
 		}
-		return kubelet.NewKubeletMonitor(kubeletConfig)
+		return kubelet.NewKubeletMonitor(kubeletConfig, isMainDiscovery)
 	case types.ClusterSource:
 		clusterMonitorConfig, ok := config.(*master.ClusterMonitorConfig)
 		if !ok {

--- a/pkg/discovery/worker/controller_metrics_collector_test.go
+++ b/pkg/discovery/worker/controller_metrics_collector_test.go
@@ -93,9 +93,9 @@ func TestCollectControllerMetrics(t *testing.T) {
 	pods := []*api.Pod{testPod1, testPod2, testPod3}
 	currTask := task.NewTask().WithPods(pods).WithCluster(clusterSummary)
 
-	workerConfig := NewK8sDiscoveryWorkerConfig("sType", 10).
+	workerConfig := NewK8sDiscoveryWorkerConfig("sType", 10, 10).
 		WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil, nil))
-	discoveryWorker, _ := NewK8sDiscoveryWorker(workerConfig, "wid")
+	discoveryWorker, _ := NewK8sDiscoveryWorker(workerConfig, "wid", metrics.NewEntityMetricSink(), true)
 
 	// Add owner metrics to the metric sink
 	var ownerMetricsList []metrics.EntityStateMetric

--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -5,39 +5,71 @@ import (
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/configs"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
 	api "k8s.io/api/core/v1"
+	"math"
+	"time"
 )
 
 type DispatcherConfig struct {
-	clusterInfoScraper *cluster.ClusterScraper
-	probeConfig        *configs.ProbeConfig
-	workerCount        int
-	workerTimeoutSec   int
+	clusterInfoScraper  *cluster.ClusterScraper
+	probeConfig         *configs.ProbeConfig
+	workerCount         int
+	workerTimeoutSec    int
+	samples             int
+	samplingIntervalSec int
 }
 
 func NewDispatcherConfig(clusterInfoScraper *cluster.ClusterScraper, probeConfig *configs.ProbeConfig,
-	workerCount int, workerTimeoutSec int) *DispatcherConfig {
+	workerCount, workerTimeoutSec, samples, samplingIntervalSec int) *DispatcherConfig {
 	return &DispatcherConfig{
-		clusterInfoScraper: clusterInfoScraper,
-		probeConfig:        probeConfig,
-		workerCount:        workerCount,
-		workerTimeoutSec:   workerTimeoutSec,
+		clusterInfoScraper:  clusterInfoScraper,
+		probeConfig:         probeConfig,
+		workerCount:         workerCount,
+		workerTimeoutSec:    workerTimeoutSec,
+		samples:             samples,
+		samplingIntervalSec: samplingIntervalSec,
 	}
 }
 
 type Dispatcher struct {
-	config     *DispatcherConfig
-	workerPool chan chan *task.Task
+	config           *DispatcherConfig
+	workerPool       chan chan *task.Task
+	globalMetricSink *metrics.EntityMetricSink
 }
 
-func NewDispatcher(config *DispatcherConfig) *Dispatcher {
+func NewDispatcher(config *DispatcherConfig, globalMetricSink *metrics.EntityMetricSink) *Dispatcher {
 	return &Dispatcher{
 		config: config,
 		// TODO use maxWorker count for now. Improve in the future once we find a good way to get the number of task.
 		// TODO If we allow worker number burst (# of workers > maxWorker), then the extra worker would block on registering. Or we use a threshold for burst number.
-		workerPool: make(chan chan *task.Task, config.workerCount),
+		workerPool:       make(chan chan *task.Task, config.workerCount),
+		globalMetricSink: globalMetricSink,
+	}
+}
+
+type SamplingDispatcher struct {
+	Dispatcher
+	// Timestamp when starting to schedule sampling discovery tasks in each main discovery cycle
+	timestamp time.Time
+	// Whether previous sampling discoveries are done
+	samplingDone chan bool
+	// Collected data samples since last main discovery
+	collectedSamples int
+}
+
+func NewSamplingDispatcher(config *DispatcherConfig, globalMetricSink *metrics.EntityMetricSink) *SamplingDispatcher {
+	return &SamplingDispatcher{
+		Dispatcher: Dispatcher{
+			config:           config,
+			workerPool:       make(chan chan *task.Task, config.workerCount),
+			globalMetricSink: globalMetricSink,
+		},
+		samplingDone:     make(chan bool),
+		collectedSamples: 0,
 	}
 }
 
@@ -47,17 +79,40 @@ func (d *Dispatcher) Init(c *ResultCollector) {
 	// Create discovery workers
 	for i := 0; i < d.config.workerCount; i++ {
 		// Create the worker instance
-		workerConfig := NewK8sDiscoveryWorkerConfig(d.config.probeConfig.StitchingPropertyType, d.config.workerTimeoutSec)
+		workerConfig := NewK8sDiscoveryWorkerConfig(d.config.probeConfig.StitchingPropertyType, d.config.workerTimeoutSec, d.config.samples)
 		for _, mc := range d.config.probeConfig.MonitoringConfigs {
 			workerConfig.WithMonitoringWorkerConfig(mc)
 		}
 		wid := fmt.Sprintf("w%d", i)
-		discoveryWorker, err := NewK8sDiscoveryWorker(workerConfig, wid)
+		discoveryWorker, err := NewK8sDiscoveryWorker(workerConfig, wid, metrics.NewEntityMetricSink().WithMaxMetricPointsSize(d.config.samples), true)
 		if err != nil {
 			glog.Fatalf("failed to build discovery worker %s", err)
 		}
 		// Register the worker and let it wait on a separate thread for a task to be submitted
 		go discoveryWorker.RegisterAndRun(d, c)
+	}
+}
+
+func (d *Dispatcher) InitSamplingDiscoveryWorkers() {
+	// Create sampling discovery workers
+	// Sampling discovery only scrape kubelet which is very lightweight, so use 2 times of main discovery worker count
+	for i := 0; i < 2*d.config.workerCount; i++ {
+		// Timeout of each sampling discovery worker is the given samplingIntervalSec to avoid goroutine pile up
+		workerConfig := NewK8sDiscoveryWorkerConfig("", d.config.samplingIntervalSec, d.config.samples)
+		for _, mc := range d.config.probeConfig.MonitoringConfigs {
+			// Only monitor kubelet to collect additional resource usage data samples
+			if mc.GetMonitoringSource() == types.KubeletSource {
+				workerConfig.WithMonitoringWorkerConfig(mc)
+			}
+		}
+		wid := fmt.Sprintf("w%d", i)
+		discoveryWorker, err := NewK8sDiscoveryWorker(workerConfig, wid, d.globalMetricSink, false)
+		if err != nil {
+			glog.Fatalf("failed to build sampling discovery worker %s", err)
+		}
+		// Register the worker and let it wait on a separate thread for a task to be submitted
+		// No need to collect results because sampled data are directly stored in globalEntityMetricSink
+		go discoveryWorker.RegisterAndRun(d, nil)
 	}
 }
 
@@ -79,6 +134,78 @@ func (d *Dispatcher) Dispatch(nodes []*api.Node, cluster *repository.ClusterSumm
 		}
 	}()
 	return len(nodes)
+}
+
+// FinishSampling stops scheduling dispatcher to assign sampling discovery tasks.
+func (d *SamplingDispatcher) FinishSampling() {
+	if !d.timestamp.IsZero() {
+		// Finish previous sampling discoveries
+		d.samplingDone <- true
+	}
+}
+
+// Create Task objects to discover multiple resource usage data samples for each node, and the pods and containers on that
+// node from kubelet. Schedule dispatching tasks to the pool based on given sampling interval, tasks will be picked by
+// the sampling discovery workers.
+func (d *SamplingDispatcher) ScheduleDispatch(nodes []*api.Node) {
+	glog.V(2).Info("Start scheduling sampling discovery tasks.")
+	d.timestamp = time.Now()
+	go func() {
+		samplingInterval := time.Duration(d.config.samplingIntervalSec) * time.Second
+		// Create a ticker to schedule dispatch based on given sampling interval
+		ticker := time.NewTicker(samplingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-d.samplingDone:
+				elapsedTime := time.Now().Sub(d.timestamp).Seconds()
+				samples := int(math.Min(float64(d.config.samples), float64(d.collectedSamples)))
+				glog.V(2).Infof("Collected %v usage data samples from kubelet in %v seconds since last main discovery.", samples, elapsedTime)
+				d.collectedSamples = 0
+				return
+			case <-ticker.C:
+				d.dispatchSamplingDiscoveries(nodes, samplingInterval)
+			}
+		}
+	}()
+}
+
+// Dispatch sampling discovery tasks. Each task to discover one node will be picked up by an available sampling discovery
+// worker. Set the timeout of finish assigning tasks of all nodes as given samplingInterval to avoid goroutine pile up.
+func (d *SamplingDispatcher) dispatchSamplingDiscoveries(nodes []*api.Node, samplingInterval time.Duration) {
+	finishCh := make(chan struct{})
+	stopCh := make(chan struct{})
+	defer close(finishCh)
+	defer close(stopCh)
+	t := time.NewTimer(samplingInterval)
+	// Dispatch tasks to the pool, which will be picked up by available sampling discovery workers
+	go func() {
+		for i, node := range nodes {
+			select {
+			case <-stopCh:
+				glog.Warningf("Dispatching sampling discovery tasks timeout. Collected data for %v out of %v nodes in this sampling cycle",
+					i+1, len(nodes))
+				return
+			default:
+			}
+			currPods := d.config.clusterInfoScraper.GetRunningAndReadyPodsOnNode(node)
+			currTask := task.NewTask().WithNode(node).WithPods(currPods)
+			glog.V(3).Infof("Dispatching sampling discovery task %v", currTask)
+			d.assignTask(currTask)
+		}
+		t.Stop()
+		finishCh <- struct{}{}
+	}()
+	select {
+	case <-finishCh:
+		d.collectedSamples++
+		return
+	case <-t.C:
+		glog.Errorf("Dispatching sampling discovery tasks for %v nodes with %v workers exceeds the max time limit: %v",
+			len(nodes), d.config.workerCount, samplingInterval)
+		stopCh <- struct{}{}
+		return
+	}
 }
 
 // Assign task to the k8sDiscoveryWorker

--- a/pkg/discovery/worker/dispatcher_test.go
+++ b/pkg/discovery/worker/dispatcher_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"flag"
 	"fmt"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"math"
 	"testing"
@@ -80,8 +81,8 @@ func getDispatcherAndCollector(workerCount, taskRunTimeSec int) (*Dispatcher, *R
 			TaskRunTime: taskRunTimeSec,
 		}},
 	}
-	dispatcherConfig := NewDispatcherConfig(clusterScraper, probeConfig, workerCount, 10)
-	dispatcher := NewDispatcher(dispatcherConfig)
+	dispatcherConfig := NewDispatcherConfig(clusterScraper, probeConfig, workerCount, 10, 1, 1)
+	dispatcher := NewDispatcher(dispatcherConfig, metrics.NewEntityMetricSink())
 	resultCollector := NewResultCollector(workerCount * 2)
 	dispatcher.Init(resultCollector)
 	return dispatcher, resultCollector

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -30,9 +30,11 @@ type k8sDiscoveryWorkerConfig struct {
 	monitoringSourceConfigs map[types.MonitorType][]monitoring.MonitorWorkerConfig
 	stitchingPropertyType   stitching.StitchingPropertyType
 	monitoringWorkerTimeout time.Duration
+	// Max metric samples to be collected by this discovery worker
+	metricSamples int
 }
 
-func NewK8sDiscoveryWorkerConfig(sType stitching.StitchingPropertyType, timeoutSec int) *k8sDiscoveryWorkerConfig {
+func NewK8sDiscoveryWorkerConfig(sType stitching.StitchingPropertyType, timeoutSec, metricSamples int) *k8sDiscoveryWorkerConfig {
 	var monitoringWorkerTimeout time.Duration
 	if timeoutSec < minTimeoutSec {
 		glog.Warningf("Invalid discovery timeout %v, set it to %v", timeoutSec, minTimeoutSec)
@@ -49,6 +51,7 @@ func NewK8sDiscoveryWorkerConfig(sType stitching.StitchingPropertyType, timeoutS
 		stitchingPropertyType:   sType,
 		monitoringSourceConfigs: make(map[types.MonitorType][]monitoring.MonitorWorkerConfig),
 		monitoringWorkerTimeout: monitoringWorkerTimeout,
+		metricSamples:           metricSamples,
 	}
 }
 
@@ -71,6 +74,8 @@ func (c *k8sDiscoveryWorkerConfig) WithMonitoringWorkerConfig(config monitoring.
 type k8sDiscoveryWorker struct {
 	// A UID of a discovery worker.
 	id string
+	// Whether this is main discovery worker, where EntityMetricSink needs to be reset in each discovery
+	isMainDiscoveryWorker bool
 
 	// config
 	config *k8sDiscoveryWorkerConfig
@@ -87,10 +92,11 @@ type k8sDiscoveryWorker struct {
 
 // Create new instance of k8sDiscoveryWorker.
 // Also creates instances of MonitoringWorkers for each MonitorType.
-func NewK8sDiscoveryWorker(config *k8sDiscoveryWorkerConfig, wid string) (*k8sDiscoveryWorker, error) {
+func NewK8sDiscoveryWorker(config *k8sDiscoveryWorkerConfig, wid string, entityMetricSink *metrics.EntityMetricSink,
+	isMainDiscoveryWorker bool) (*k8sDiscoveryWorker, error) {
 	// id := uuid.NewUUID().String()
 	if len(config.monitoringSourceConfigs) == 0 {
-		return nil, errors.New("No monitoring source config found in config.")
+		return nil, errors.New("no monitoring source config found in config")
 	}
 
 	// Build all the monitoring worker based on configs.
@@ -101,7 +107,7 @@ func NewK8sDiscoveryWorker(config *k8sDiscoveryWorkerConfig, wid string) (*k8sDi
 			monitorList = []monitoring.MonitoringWorker{}
 		}
 		for _, config := range configList {
-			monitoringWorker, err := monitoring.BuildMonitorWorker(config.GetMonitoringSource(), config)
+			monitoringWorker, err := monitoring.BuildMonitorWorker(config.GetMonitoringSource(), config, isMainDiscoveryWorker)
 			if err != nil {
 				// TODO return?
 				glog.Errorf("Failed to build monitoring worker configuration: %v", err)
@@ -113,10 +119,11 @@ func NewK8sDiscoveryWorker(config *k8sDiscoveryWorkerConfig, wid string) (*k8sDi
 	}
 
 	return &k8sDiscoveryWorker{
-		id:               wid,
-		config:           config,
-		monitoringWorker: monitoringWorkerMap,
-		sink:             metrics.NewEntityMetricSink(),
+		id:                    wid,
+		isMainDiscoveryWorker: isMainDiscoveryWorker,
+		config:                config,
+		monitoringWorker:      monitoringWorkerMap,
+		sink:                  entityMetricSink,
 
 		taskChan: make(chan *task.Task),
 	}, nil
@@ -129,10 +136,17 @@ func (worker *k8sDiscoveryWorker) RegisterAndRun(dispatcher *Dispatcher, collect
 		// wait for a Task to be submitted
 		select {
 		case currTask := <-worker.taskChan:
-			glog.V(2).Infof("Worker %s has received a task %v.", worker.id, currTask)
+			logLevel := glog.Level(2)
+			if !worker.isMainDiscoveryWorker {
+				logLevel = glog.Level(3)
+			}
+
+			glog.V(logLevel).Infof("Worker %s has received a task %v.", worker.id, currTask)
 			result := worker.executeTask(currTask)
-			collector.ResultPool() <- result
-			glog.V(2).Infof("Worker %s has finished the task %v.", worker.id, currTask)
+			if collector != nil {
+				collector.ResultPool() <- result
+			}
+			glog.V(logLevel).Infof("Worker %s has finished the task %v.", worker.id, currTask)
 			dispatcher.RegisterWorker(worker)
 		}
 	}
@@ -157,8 +171,10 @@ func (worker *k8sDiscoveryWorker) executeTask(currTask *task.Task) *task.TaskRes
 	var timeout bool
 	// Resource monitoring
 	resourceMonitorTask := currTask
-	// Reset the main sink
-	worker.sink = metrics.NewEntityMetricSink()
+	if worker.isMainDiscoveryWorker {
+		// Reset the main sink
+		worker.sink = metrics.NewEntityMetricSink().WithMaxMetricPointsSize(worker.config.metricSamples)
+	}
 	// if resourceMonitoringWorkers, exist := worker.monitoringWorker[types.ResourceMonitor]; exist {
 	for _, resourceMonitoringWorkers := range worker.monitoringWorker {
 		for _, rmWorker := range resourceMonitoringWorkers {
@@ -187,6 +203,9 @@ func (worker *k8sDiscoveryWorker) executeTask(currTask *task.Task) *task.TaskRes
 					t.Stop()
 					// Don't do any filtering
 					worker.sink.MergeSink(monitoringSink, nil)
+					if worker.isMainDiscoveryWorker {
+						// TODO Yue merge global metrics sink into the metrics sink of each main discovery worker
+					}
 					// glog.Infof("send to finish channel %p", finishCh)
 					finishCh <- struct{}{}
 				}()
@@ -212,6 +231,11 @@ func (worker *k8sDiscoveryWorker) executeTask(currTask *task.Task) *task.TaskRes
 
 	if timeout {
 		return task.NewTaskResult(worker.id, task.TaskFailed).WithErr(fmt.Errorf("discovery timeout"))
+	}
+
+	if !worker.isMainDiscoveryWorker {
+		// Sampling discovery doesn't need to collect additional metrics
+		return task.NewTaskResult(worker.id, task.TaskSucceeded)
 	}
 
 	// Collect usages for pods in different namespaces and create used and capacity

--- a/pkg/discovery/worker/k8s_discovery_worker_test.go
+++ b/pkg/discovery/worker/k8s_discovery_worker_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"reflect"
 	"testing"
 
@@ -13,9 +14,9 @@ import (
 )
 
 func TestBuildDTOsWithMissingMetrics(t *testing.T) {
-	workerConfig := NewK8sDiscoveryWorkerConfig("UUID", 1).
+	workerConfig := NewK8sDiscoveryWorkerConfig("UUID", 1, 1).
 		WithMonitoringWorkerConfig(kubelet.NewKubeletMonitorConfig(nil, nil))
-	worker, err := NewK8sDiscoveryWorker(workerConfig, "wid-1")
+	worker, err := NewK8sDiscoveryWorker(workerConfig, "wid-1", metrics.NewEntityMetricSink(), true)
 	if err != nil {
 		t.Errorf("Error while creating discovery worker: %v", err)
 	}

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -159,7 +159,8 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	probeConfig := createProbeConfigOrDie(config)
 	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig,
 		config.ValidationWorkers, config.ValidationTimeoutSec, config.containerUtilizationDataAggStrategy,
-		config.containerUsageDataAggStrategy, config.ORMClient, config.DiscoveryWorkers, config.DiscoveryTimeoutSec)
+		config.containerUsageDataAggStrategy, config.ORMClient, config.DiscoveryWorkers, config.DiscoveryTimeoutSec,
+		config.DiscoverySamples, config.DiscoverySampleIntervalSec)
 
 	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.KubeClient,
 		config.KubeletClient, config.DynamicClient, config.SccSupport, config.ORMClient)

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -37,6 +37,9 @@ type Config struct {
 	ValidationWorkers    int
 	ValidationTimeoutSec int
 
+	DiscoverySamples           int
+	DiscoverySampleIntervalSec int
+
 	SccSupport    []string
 	CAPINamespace string
 
@@ -126,6 +129,16 @@ func (c *Config) WithDiscoveryWorkers(workers int) *Config {
 
 func (c *Config) WithDiscoveryTimeout(timeout int) *Config {
 	c.DiscoveryTimeoutSec = timeout
+	return c
+}
+
+func (c *Config) WithDiscoverySamples(discoverySamples int) *Config {
+	c.DiscoverySamples = discoverySamples
+	return c
+}
+
+func (c *Config) WithDiscoverySampleIntervalSec(sampleIntervalSec int) *Config {
+	c.DiscoverySampleIntervalSec = sampleIntervalSec
 	return c
 }
 


### PR DESCRIPTION
**Intent**:
Create a new set of workers to discover more usage data samples from kubelet and store the multi-points data into a global metrics cache.

**Background**:
The main idea is to have these new workers run more frequently in parallel with the existing main discovery workers with the given configurable number of samples and sampling interval. We don't need to discover limit/request capacity more frequently, because 1) it’s very heavy to talk to API server (cluster monitor), and 2) container limit/request does not change very often.

**Implementation**:
1. Introduced 2 configurable variables:
  - `discovery-samples` - this defines the max size of the data stored in global metrics cache. Since our new workers keep running in Kubeturbo, this would avoid out of memory when Turbo server side crashes and no discovery is triggered. Default value is 10.
  - `discovery-sample-interval` - this defines how frequently our new workers scrap kubelet. Default value is 60 (seconds).
2. Create `SamplingDispatcher` to schedule assigning sampling discoveries based on configured samplingInterval. Set the timeout of one set of sampling discovery to the configured samplingInterval to avoid goroutine pile up.
3. Create a `globalEntityMetricSink` in `K8sDiscoveryClient` to store collected multi-points metrics samples discovered by sampling discovery workers.
4. Clear the `globalEntityMetricSink` and reschedule sampling discoveries after finishing a full discovery.
5. In `kubelet_monitor`, create new `scrapeKubeletForSampling` func to collect only resource usage data during sampling discoveries.

**Note**:
There will be 2 following changes in different PR to:
1. Merge sampled data from `globalEntityMetricSink` into the metrics sink of each individual main discovery worker
2. Construct multi-points UtilizationData on ContainerSpec based on collected data samples.

**Testing Done**:
1. Main discovery still works correctly.
2. Sampling discoveries are triggered every given samplingInterval. By debugging the code, `globalEntityMetricSink` store at most given samples of data for each collected metrics.
3. Will do more end-to-end tests once finishing the 2 following changes mentioned above.