### PR TITLE
Merge collected data samples from global metrics sink into full discovery workers

### DIFF
--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -394,13 +394,13 @@ func (builder *containerDTOBuilder) createRequestCommodityBought(entityType metr
 	}
 	commBoughtBuilder := sdkbuilder.NewCommodityDTOBuilder(cType)
 	// Used value of request commodity bought by the container is the configured resource requests capacity
-	usedValue, err := builder.metricValue(entityType, containerMId, resourceType, metrics.Capacity, converter)
+	metricValue, err := builder.metricValue(entityType, containerMId, resourceType, metrics.Capacity, converter)
 	if err != nil {
 		glog.Errorf("%s::%s cannot build bought commodity %s : %v", entityType, containerMId, resourceType, err)
 		return nil, err
 	}
-	commBoughtBuilder.Used(usedValue)
-	commBoughtBuilder.Peak(usedValue)
+	commBoughtBuilder.Used(metricValue.Avg)
+	commBoughtBuilder.Peak(metricValue.Peak)
 	commBoughtBuilder.Resizable(true)
 	commBought, err := commBoughtBuilder.Create()
 	if err != nil {

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -157,6 +157,13 @@ type Metric interface {
 	UpdateValue(existing interface{}, maxMetricPointsSize int) Metric
 }
 
+type MetricValue struct {
+	// Average of all data points
+	Avg float64
+	// Peak of all data points
+	Peak float64
+}
+
 type MetricFilterFunc func(m Metric) bool
 
 type ResourceMetric struct {

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -261,46 +261,34 @@ func (m *KubeletMonitor) parseContainerStats(pod *stats.PodStats, timestamp int6
 }
 
 func (m *KubeletMonitor) genUsedMetrics(etype metrics.DiscoveredEntityType, key string, cpu, memory float64, timestamp int64) {
-	var cpuMetric metrics.EntityResourceMetric
-	var memMetric metrics.EntityResourceMetric
-	// TODO Yue simplify if/else conditions when implementing merging global metrics sink to each individual full discovery worker
-	if m.isFullDiscovery {
-		cpuMetric = metrics.NewEntityResourceMetric(etype, key, metrics.CPU, metrics.Used, cpu)
-		memMetric = metrics.NewEntityResourceMetric(etype, key, metrics.Memory, metrics.Used, memory)
-	} else {
-		cpuMetric = metrics.NewEntityResourceMetric(etype, key, metrics.CPU, metrics.Used,
-			metrics.Points{
-				Values:    []float64{cpu},
-				Timestamp: timestamp,
-			})
-		memMetric = metrics.NewEntityResourceMetric(etype, key, metrics.Memory, metrics.Used, metrics.Points{
-			Values:    []float64{memory},
+	// Pass timestamp as parameter instead of generating a new timestamp here to make sure timestamp is same for all
+	// corresponding metrics which are scraped from kubelet at the same time
+	cpuMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPU, metrics.Used,
+		metrics.Points{
+			Values:    []float64{cpu},
 			Timestamp: timestamp,
 		})
-	}
+	memMetric := metrics.NewEntityResourceMetric(etype, key, metrics.Memory, metrics.Used, metrics.Points{
+		Values:    []float64{memory},
+		Timestamp: timestamp,
+	})
 	m.metricSink.AddNewMetricEntries(cpuMetric, memMetric)
 }
 
 // genRequestUsedMetrics generates used metrics for VCPURequest and VMemRequest commodity
 func (m *KubeletMonitor) genRequestUsedMetrics(etype metrics.DiscoveredEntityType, key string, cpu, memory float64, timestamp int64) {
-	var cpuRequestMetric metrics.EntityResourceMetric
-	var memRequestMetric metrics.EntityResourceMetric
-	// TODO Yue simplify if/else conditions when implementing merging global metrics sink to each individual full discovery worker
-	if m.isFullDiscovery {
-		cpuRequestMetric = metrics.NewEntityResourceMetric(etype, key, metrics.CPURequest, metrics.Used, cpu)
-		memRequestMetric = metrics.NewEntityResourceMetric(etype, key, metrics.MemoryRequest, metrics.Used, memory)
-	} else {
-		cpuRequestMetric = metrics.NewEntityResourceMetric(etype, key, metrics.CPURequest, metrics.Used,
-			metrics.Points{
-				Values:    []float64{cpu},
-				Timestamp: timestamp,
-			})
-		memRequestMetric = metrics.NewEntityResourceMetric(etype, key, metrics.MemoryRequest, metrics.Used,
-			metrics.Points{
-				Values:    []float64{memory},
-				Timestamp: timestamp,
-			})
-	}
+	// Pass timestamp as parameter instead of generating a new timestamp here to make sure timestamp is same for all
+	// corresponding metrics which are scraped from kubelet at the same time
+	cpuRequestMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPURequest, metrics.Used,
+		metrics.Points{
+			Values:    []float64{cpu},
+			Timestamp: timestamp,
+		})
+	memRequestMetric := metrics.NewEntityResourceMetric(etype, key, metrics.MemoryRequest, metrics.Used,
+		metrics.Points{
+			Values:    []float64{memory},
+			Timestamp: timestamp,
+		})
 	m.metricSink.AddNewMetricEntries(cpuRequestMetric, memRequestMetric)
 }
 

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
@@ -81,7 +81,7 @@ func checkPodMetrics(sink *metrics.EntityMetricSink, podMId string, pod *stats.P
 			return fmt.Errorf("Failed to get resource[%v] used value: %v", res, err)
 		}
 
-		value := tmp.GetValue().(float64)
+		value := tmp.GetValue().(metrics.Points)
 		expected := float64(0.0)
 		if res == metrics.CPU {
 			for _, c := range pod.Containers {
@@ -95,7 +95,7 @@ func checkPodMetrics(sink *metrics.EntityMetricSink, podMId string, pod *stats.P
 			expected = util.Base2BytesToKilobytes(expected)
 		}
 
-		if math.Abs(value-expected) > myzero {
+		if math.Abs(value.Values[0]-expected) > myzero {
 			return fmt.Errorf("pod %v used value check failed: %v Vs. %v", res, expected, value)
 		}
 
@@ -116,7 +116,7 @@ func checkContainerMetrics(sink *metrics.EntityMetricSink, containerMId string, 
 			return fmt.Errorf("Failed to get resource[%v] used value: %v", res, err)
 		}
 
-		value := tmp.GetValue().(float64)
+		value := tmp.GetValue().(metrics.Points)
 		expected := float64(0.0)
 		if res == metrics.CPU {
 			expected += float64(*container.CPU.UsageNanoCores)
@@ -126,7 +126,7 @@ func checkContainerMetrics(sink *metrics.EntityMetricSink, containerMId string, 
 			expected = util.Base2BytesToKilobytes(expected)
 		}
 
-		if math.Abs(value-expected) > myzero {
+		if math.Abs(value.Values[0]-expected) > myzero {
 			return fmt.Errorf("container %v used value check failed: %v Vs. %v", res, expected, value)
 		}
 		//fmt.Printf("%v, v=%.4f Vs. %.4f\n", mid, value, expected)
@@ -146,7 +146,7 @@ func checkApplicationMetrics(sink *metrics.EntityMetricSink, appMId string, cont
 			return fmt.Errorf("Failed to get resource[%v] used value: %v", res, err)
 		}
 
-		value := tmp.GetValue().(float64)
+		value := tmp.GetValue().(metrics.Points)
 		expected := float64(0.0)
 		if res == metrics.CPU {
 			expected += float64(*container.CPU.UsageNanoCores)
@@ -156,7 +156,7 @@ func checkApplicationMetrics(sink *metrics.EntityMetricSink, appMId string, cont
 			expected = util.Base2BytesToKilobytes(expected)
 		}
 
-		if math.Abs(value-expected) > myzero {
+		if math.Abs(value.Values[0]-expected) > myzero {
 			return fmt.Errorf("Application %v used value check failed: %v Vs. %v", res, expected, value)
 		}
 		//fmt.Printf("%v, v=%.4f Vs. %.4f\n", mid, value, expected)

--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -85,7 +85,7 @@ func (d *Dispatcher) Init(c *ResultCollector) {
 			workerConfig.WithMonitoringWorkerConfig(mc)
 		}
 		wid := fmt.Sprintf("w%d", i)
-		discoveryWorker, err := NewK8sDiscoveryWorker(workerConfig, wid, metrics.NewEntityMetricSink().WithMaxMetricPointsSize(d.config.samples), true)
+		discoveryWorker, err := NewK8sDiscoveryWorker(workerConfig, wid, d.globalMetricSink, true)
 		if err != nil {
 			glog.Fatalf("failed to build discovery worker %s", err)
 		}


### PR DESCRIPTION
JIRA: 
https://vmturbo.atlassian.net/browse/OM-61191
https://vmturbo.atlassian.net/browse/OM-61194

**Intent**:
Merge collected data samples from global metrics sink into full discovery workers.

**Background**:
There are two separated discoveries running in Kubeturbo:
1. Existing full discovery - triggered by Turbo server, either manually or by discovery scheduler (default 10 mins). Each discovery worker has its own metrics sink to store collected metrics.
2. New data sampling discoveries (implemented in https://github.com/turbonomic/kubeturbo/pull/459) - keeps running along with Kubeturbo server, collects more usage data samples from kubelet and stores in a global metrics sink

**Implementation**:
1. Add a new field `globleMetricSink` in `k8sDiscoveryWorker`.
2. Merge stored data from global metrics sink into each individual full discovery worker in `k8s_discovery_worker.go` `executeTask` func.
3. Simplify the logic in kubelet_monitor.go to store `metrics.Points` instead of float value when generating resource used metrics for both full discovery or sampling discovery.
4. Modify `generalBuild:: metricValue` to calculate average of multiple data points as commodity used value and peak of multiple data points as commodity peak value.

Note that previously used and peak values are always the same for resource commodities. With the changes, we'll be able to better show the VCPU/VMem peak value apart from average usage for ApplicationComponent, Container, ContainerPod and VM entities.

**Testing Doen**:
1. Both full and sampling discoveries are scheduled properly.
2. By debugging the code, data samples are merged correctly from globalMetricSink into individual full discovery worker.
3. By dumping discovery DTO data,
before the changes, commodity used and peak are always same:
```
entityDTO {
  entityType: CONTAINER
  id: "4bea5914-1c27-11ea-bd96-005056803564-0"
  displayName: "openshift-sdn/ovs-vzb5f/openvswitch"
  commoditiesSold {
    commodityType: VCPU
    used: 44.70772850146199
    capacity: 15982.667999999998
    peak: 44.70772850146199
    resizable: false
  }
  commoditiesSold {
    commodityType: VMEM
    used: 77288.0
    capacity: 1.6266172E7
    peak: 77288.0
    resizable: false
  }
```

after the changes, commodity peak value can be differentiated from used value:
```
entityDTO {
  entityType: CONTAINER_POD
  id: "4bea5914-1c27-11ea-bd96-005056803564"
  displayName: "openshift-sdn/ovs-vzb5f"
  commoditiesSold {
    commodityType: VCPU
    used: 33.084825597825294
    capacity: 15982.667999999998
    peak: 43.938517319736
    resizable: false
  }
  commoditiesSold {
    commodityType: VMEM
    used: 77320.4
    capacity: 1.6266172E7
    peak: 77456.0
    resizable: false
  }
```