### PR TITLE
Update utilization data for container spec entity based on collected multiple data samples

### DIFF
--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -79,17 +79,17 @@ func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpecMetrics 
 		commSoldBuilder := sdkbuilder.NewCommodityDTOBuilder(commodityType)
 
 		// Aggregate container replicas utilization data.
-		// Note that the returned dataInterval is not the real sampling interval because there could be multiple data
+		// Note that the returned dataIntervalMs is not the real sampling interval because there could be multiple data
 		// points from container replicas discovered at the same time in one set of data samples. This is just a calculated
-		// equivalent interval to be fed into percentile based algorithm in Turbo server side.
-		utilizationDataPoints, lastPointTimestamp, dataInterval, err := builder.containerUtilizationDataAggregator.Aggregate(resourceMetrics)
+		// equivalent interval between 2 data points to be fed into percentile based algorithm in Turbo server side.
+		utilizationDataPoints, lastPointTimestamp, dataIntervalMs, err := builder.containerUtilizationDataAggregator.Aggregate(resourceMetrics)
 		if err != nil {
 			glog.Errorf("Error aggregating %s utilization data for ContainerSpec %s, %v",
 				resourceType, containerSpecMetrics.ContainerSpecId, err)
 			continue
 		}
 		// Construct UtilizationData with multiple data points, last point timestamp in milliseconds and interval in milliseconds
-		commSoldBuilder.UtilizationData(utilizationDataPoints, lastPointTimestamp, dataInterval)
+		commSoldBuilder.UtilizationData(utilizationDataPoints, lastPointTimestamp, dataIntervalMs)
 
 		// Aggregate container replicas usage data (capacity, used and peak)
 		aggregatedCap, aggregatedUsed, aggregatedPeak, err :=

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -2,37 +2,36 @@ package dtofactory
 
 import (
 	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-	"time"
 )
 
 var (
-	ContainerSpecCommoditiesSold = []proto.CommodityDTO_CommodityType{
-		proto.CommodityDTO_VCPU,
-		proto.CommodityDTO_VMEM,
-		proto.CommodityDTO_VCPU_REQUEST,
-		proto.CommodityDTO_VMEM_REQUEST,
+	ContainerSpecResourceTypes = []metrics.ResourceType{
+		metrics.CPU,
+		metrics.Memory,
+		metrics.CPURequest,
+		metrics.MemoryRequest,
 	}
 )
 
 type containerSpecDTOBuilder struct {
-	// Map from ContainerSpec ID to ContainerSpec entity which contains list of individual container replica commodities
-	// data to be aggregated
-	containerSpecMap map[string]*repository.ContainerSpec
+	// Map from ContainerSpec ID to ContainerSpecMetrics which contains list of container replicas usage metrics data to be aggregated
+	containerSpecMetricsMap map[string]*repository.ContainerSpecMetrics
 	// Aggregator to aggregate container replicas commodity utilization data
 	containerUtilizationDataAggregator aggregation.ContainerUtilizationDataAggregator
 	// Aggregator to aggregate container replicas commodity usage data (used, peak and capacity)
 	containerUsageDataAggregator aggregation.ContainerUsageDataAggregator
 }
 
-func NewContainerSpecDTOBuilder(containerSpecMap map[string]*repository.ContainerSpec,
+func NewContainerSpecDTOBuilder(containerSpecMetricsMap map[string]*repository.ContainerSpecMetrics,
 	containerUtilizationDataAggregator aggregation.ContainerUtilizationDataAggregator,
 	containerUsageDataAggregator aggregation.ContainerUsageDataAggregator) *containerSpecDTOBuilder {
 	return &containerSpecDTOBuilder{
-		containerSpecMap:                   containerSpecMap,
+		containerSpecMetricsMap:            containerSpecMetricsMap,
 		containerUtilizationDataAggregator: containerUtilizationDataAggregator,
 		containerUsageDataAggregator:       containerUsageDataAggregator,
 	}
@@ -40,7 +39,7 @@ func NewContainerSpecDTOBuilder(containerSpecMap map[string]*repository.Containe
 
 func (builder *containerSpecDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, error) {
 	var result []*proto.EntityDTO
-	for containerSpecId, containerSpec := range builder.containerSpecMap {
+	for containerSpecId, containerSpec := range builder.containerSpecMetricsMap {
 		entityDTOBuilder := sdkbuilder.NewEntityDTOBuilder(proto.EntityDTO_CONTAINER_SPEC, containerSpecId)
 		entityDTOBuilder.DisplayName(containerSpec.ContainerSpecName)
 		commoditiesSold, err := builder.getCommoditiesSold(containerSpec)
@@ -62,37 +61,46 @@ func (builder *containerSpecDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, error) 
 }
 
 // getCommoditiesSold gets commodity DTOs with aggregated container utilization and usage data.
-func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpec *repository.ContainerSpec) ([]*proto.CommodityDTO, error) {
+func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpecMetrics *repository.ContainerSpecMetrics) ([]*proto.CommodityDTO, error) {
 	var commoditiesSold []*proto.CommodityDTO
-	for _, commodityType := range ContainerSpecCommoditiesSold {
-		// commodities is a list of commodity DTOs of commodityType sold by container replicas represented by this
-		// ContainerSpec entity
-		commodities, exists := containerSpec.ContainerCommodities[commodityType]
+	for _, resourceType := range ContainerSpecResourceTypes {
+		commodityType, exist := rTypeMapping[resourceType]
+		if !exist {
+			glog.Errorf("Unsupported resource type %s when building commoditiesSold for ContainerSpec %s",
+				resourceType, containerSpecMetrics.ContainerSpecId)
+			continue
+		}
+		resourceMetrics, exists := containerSpecMetrics.ContainerMetrics[resourceType]
 		if !exists {
-			glog.V(4).Infof("ContainerSpec %s has no %s commodity from the collected ContainerSpec",
-				containerSpec.ContainerSpecId, commodityType)
+			glog.V(4).Infof("ContainerMetrics collected from ContainerSpec %s has no %s resource type",
+				containerSpecMetrics.ContainerSpecId, resourceType)
 			continue
 		}
 		commSoldBuilder := sdkbuilder.NewCommodityDTOBuilder(commodityType)
 
 		// Aggregate container replicas utilization data
-		utilizationDataPoints, err := builder.containerUtilizationDataAggregator.Aggregate(commodities)
+		utilizationDataPoints, lastPointTimestamp, samplingDuration, err := builder.containerUtilizationDataAggregator.Aggregate(resourceMetrics)
 		if err != nil {
-			glog.Errorf("Error aggregating commodity utilization data for ContainerSpec %s, %v",
-				containerSpec.ContainerSpecId, err)
+			glog.Errorf("Error aggregating %s utilization data for ContainerSpec %s, %v",
+				resourceType, containerSpecMetrics.ContainerSpecId, err)
 			continue
 		}
-		currentMs := time.Now().UnixNano() / int64(time.Millisecond)
-		// Currently we only collect one set of metrics data points from Kubernetes within a discovery cycle so the
-		// lastPointTimestampMs of utilizationData is current timestamp in milliseconds and intervalMs is 0.
-		commSoldBuilder.UtilizationData(utilizationDataPoints, currentMs, 0)
+		// Calculate interval between data points. Note that this is not the real sampling interval because there could
+		// be multiple data points from container replicas discovered at the same time in one set of data samples. This
+		// is to just calculate an equivalent interval to be fed into percentile based algorithm in Turbo server side.
+		var interval int32
+		if len(utilizationDataPoints) > 1 {
+			interval = samplingDuration / int32(len(utilizationDataPoints)-1)
+		}
+		// Construct UtilizationData with multiple data points, last point timestamp in milliseconds and interval in milliseconds
+		commSoldBuilder.UtilizationData(utilizationDataPoints, lastPointTimestamp, interval)
 
 		// Aggregate container replicas usage data (capacity, used and peak)
 		aggregatedCap, aggregatedUsed, aggregatedPeak, err :=
-			builder.containerUsageDataAggregator.Aggregate(commodities)
+			builder.containerUsageDataAggregator.Aggregate(resourceMetrics)
 		if err != nil {
 			glog.Errorf("Error aggregating commodity usage data for ContainerSpec %s, %v",
-				containerSpec.ContainerSpecId, err)
+				containerSpecMetrics.ContainerSpecId, err)
 			continue
 		}
 		commSoldBuilder.Capacity(aggregatedCap)

--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -194,14 +194,14 @@ func (builder generalBuilder) metricValue(entityType metrics.DiscoveredEntityTyp
 
 	value := metric.GetValue()
 	switch value.(type) {
-	case metrics.Points:
+	case []metrics.Point:
 		var sum float64
 		var peak float64
-		for _, val := range value.(metrics.Points).Values {
-			sum += val
-			peak = math.Max(peak, val)
+		for _, point := range value.([]metrics.Point) {
+			sum += point.Value
+			peak = math.Max(peak, point.Value)
 		}
-		metricValue.Avg = sum / float64(len(value.(metrics.Points).Values))
+		metricValue.Avg = sum / float64(len(value.([]metrics.Point)))
 		metricValue.Peak = peak
 	case float64:
 		metricValue.Avg = value.(float64)

--- a/pkg/discovery/dtofactory/general_builder_test.go
+++ b/pkg/discovery/dtofactory/general_builder_test.go
@@ -197,20 +197,20 @@ func TestMetricValueWithMultiplePoints(t *testing.T) {
 	metricsSink = metrics.NewEntityMetricSink().WithMaxMetricPointsSize(3)
 	containerId := "container"
 	cpuUsedMetric1 := metrics.NewEntityResourceMetric(metrics.ContainerType, containerId, metrics.CPU, metrics.Used,
-		metrics.Points{
-			Values:    []float64{2},
-			Timestamp: 0,
-		})
-	cpuUsedMetric2 := metrics.NewEntityResourceMetric(metrics.ContainerType, containerId, metrics.CPU, metrics.Used,
-		metrics.Points{
-			Values:    []float64{4},
+		[]metrics.Point{{
+			Value:     2,
 			Timestamp: 1,
-		})
-	cpuUsedMetric3 := metrics.NewEntityResourceMetric(metrics.ContainerType, containerId, metrics.CPU, metrics.Used,
-		metrics.Points{
-			Values:    []float64{3},
+		}})
+	cpuUsedMetric2 := metrics.NewEntityResourceMetric(metrics.ContainerType, containerId, metrics.CPU, metrics.Used,
+		[]metrics.Point{{
+			Value:     4,
 			Timestamp: 2,
-		})
+		}})
+	cpuUsedMetric3 := metrics.NewEntityResourceMetric(metrics.ContainerType, containerId, metrics.CPU, metrics.Used,
+		[]metrics.Point{{
+			Value:     3,
+			Timestamp: 3,
+		}})
 	metricsSink.AddNewMetricEntries(cpuUsedMetric1)
 	metricsSink.UpdateMetricEntry(cpuUsedMetric2)
 	metricsSink.UpdateMetricEntry(cpuUsedMetric3)

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -314,7 +314,7 @@ func (dc *K8sDiscoveryClient) discoverWithNewFramework(targetID string) ([]*prot
 	// replicas. ContainerSpec is an entity type which represents a certain type of container replicas deployed by a
 	// K8s controller.
 	containerSpecDiscoveryWorker := worker.NewK8sContainerSpecDiscoveryWorker()
-	containerSpecDtos, err := containerSpecDiscoveryWorker.Do(result.ContainerSpecs, dc.config.containerUtilizationDataAggStrategy,
+	containerSpecDtos, err := containerSpecDiscoveryWorker.Do(result.ContainerSpecMetrics, dc.config.containerUtilizationDataAggStrategy,
 		dc.config.containerUsageDataAggStrategy)
 	if err != nil {
 		glog.Errorf("Failed to discover ContainerSpecs from current Kubernetes cluster with the new discovery framework: %s", err)

--- a/pkg/discovery/metrics/metric_sink_test.go
+++ b/pkg/discovery/metrics/metric_sink_test.go
@@ -6,24 +6,36 @@ import (
 )
 
 func TestEntityMetricSink_UpdateMetricEntry(t *testing.T) {
-	maxMetricPointsSize := 10
+	maxMetricPointsSize := 3
 	sink := NewEntityMetricSink().WithMaxMetricPointsSize(maxMetricPointsSize)
 
 	containerId := "containerId"
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 5; i++ {
 		containerResMetric := NewEntityResourceMetric(ContainerType, containerId, Memory, Used,
-			Points{
-				Values:    []float64{float64(i)},
+			[]Point{{
+				Value:     float64(i + 1),
 				Timestamp: int64(i),
-			})
+			}})
 		sink.UpdateMetricEntry(containerResMetric)
 	}
 
 	containerMid := GenerateEntityResourceMetricUID(ContainerType, containerId, Memory, Used)
 	metric, _ := sink.GetMetric(containerMid)
-	metricVal := metric.GetValue().(Points)
-	expectedPoints := []float64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
-	assert.EqualValues(t, maxMetricPointsSize, len(metricVal.Values))
-	assert.EqualValues(t, expectedPoints, metricVal.Values)
-	assert.EqualValues(t, 19, metricVal.Timestamp)
+	metricPoints := metric.GetValue().([]Point)
+	expectedPoints := []Point{
+		{
+			Value:     3,
+			Timestamp: 2,
+		},
+		{
+			Value:     4,
+			Timestamp: 3,
+		},
+		{
+			Value:     5,
+			Timestamp: 4,
+		},
+	}
+	assert.EqualValues(t, maxMetricPointsSize, len(metricPoints))
+	assert.EqualValues(t, expectedPoints, metricPoints)
 }

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -141,6 +141,7 @@ func (m *KubeletMonitor) scrapeKubelet(node *api.Node) {
 		}
 	}
 
+	// TODO Use time stamp attached to the discovered CPUStats/MemoryStats of node and pod from kubelet to be more precise
 	currentMilliSec := time.Now().UnixNano() / int64(time.Millisecond)
 	m.parseNodeStats(summary.Node, currentMilliSec)
 	m.parsePodStats(summary.Pods, currentMilliSec)

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -136,7 +136,7 @@ func (m *KubeletMonitor) scrapeKubelet(node *api.Node) {
 		} else {
 			// It's a valid case if a node is available from the full discovery but not available during sampling discoveries.
 			// Need to wait for a full discovery to fetch the available nodes.
-			glog.Warningf("Failed to get resource metrics summary sample from %s. Waiting for the next full discovery: %s", node.Name, err)
+			glog.Warningf("Failed to get resource metrics summary sample from %s. Waiting for the next full discovery.", node.Name)
 			return
 		}
 	}
@@ -264,14 +264,15 @@ func (m *KubeletMonitor) genUsedMetrics(etype metrics.DiscoveredEntityType, key 
 	// Pass timestamp as parameter instead of generating a new timestamp here to make sure timestamp is same for all
 	// corresponding metrics which are scraped from kubelet at the same time
 	cpuMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPU, metrics.Used,
-		metrics.Points{
-			Values:    []float64{cpu},
+		[]metrics.Point{{
+			Value:     cpu,
 			Timestamp: timestamp,
-		})
-	memMetric := metrics.NewEntityResourceMetric(etype, key, metrics.Memory, metrics.Used, metrics.Points{
-		Values:    []float64{memory},
-		Timestamp: timestamp,
-	})
+		}})
+	memMetric := metrics.NewEntityResourceMetric(etype, key, metrics.Memory, metrics.Used,
+		[]metrics.Point{{
+			Value:     memory,
+			Timestamp: timestamp,
+		}})
 	m.metricSink.AddNewMetricEntries(cpuMetric, memMetric)
 }
 
@@ -280,15 +281,15 @@ func (m *KubeletMonitor) genRequestUsedMetrics(etype metrics.DiscoveredEntityTyp
 	// Pass timestamp as parameter instead of generating a new timestamp here to make sure timestamp is same for all
 	// corresponding metrics which are scraped from kubelet at the same time
 	cpuRequestMetric := metrics.NewEntityResourceMetric(etype, key, metrics.CPURequest, metrics.Used,
-		metrics.Points{
-			Values:    []float64{cpu},
+		[]metrics.Point{{
+			Value:     cpu,
 			Timestamp: timestamp,
-		})
+		}})
 	memRequestMetric := metrics.NewEntityResourceMetric(etype, key, metrics.MemoryRequest, metrics.Used,
-		metrics.Points{
-			Values:    []float64{memory},
+		[]metrics.Point{{
+			Value:     memory,
 			Timestamp: timestamp,
-		})
+		}})
 	m.metricSink.AddNewMetricEntries(cpuRequestMetric, memRequestMetric)
 }
 

--- a/pkg/discovery/repository/entity_metrics.go
+++ b/pkg/discovery/repository/entity_metrics.go
@@ -63,3 +63,42 @@ func (namespaceMetrics *NamespaceMetrics) UpdateQuotaSoldUsed(quotaSoldUsed map[
 		namespaceMetrics.QuotaSoldUsed[resourceType] = totalUsed
 	}
 }
+
+// ContainerMetrics collects resource capacity and multiple usage data samples for container replicas which belong to the
+// same ContainerSpec.
+type ContainerMetrics struct {
+	Capacity float64
+	Used     []metrics.Point
+}
+
+func NewContainerMetrics(capacity float64, used []metrics.Point) *ContainerMetrics {
+	return &ContainerMetrics{
+		Capacity: capacity,
+		Used:     used,
+	}
+}
+
+// ContainerSpecMetrics collects the shared portion of individual container replicas defined by the controller that manages
+// the pods where these containers run, including container replicas and resource metrics with multiple samples of usage data.
+type ContainerSpecMetrics struct {
+	Namespace         string
+	ControllerUID     string
+	ContainerSpecName string
+	ContainerSpecId   string
+	// Container replicas number
+	ContainerReplicas int32
+	// Map from resource type to ContainerMetrics with multiple samples of resource usage data discovered from all
+	// container replicas which belong to the same ContainerSpec.
+	ContainerMetrics map[metrics.ResourceType]*ContainerMetrics
+}
+
+func NewContainerSpecMetrics(namespace, controllerUID, containerName, containerSpecId string) *ContainerSpecMetrics {
+	return &ContainerSpecMetrics{
+		Namespace:         namespace,
+		ControllerUID:     controllerUID,
+		ContainerSpecName: containerName,
+		ContainerSpecId:   containerSpecId,
+		ContainerReplicas: 1,
+		ContainerMetrics:  make(map[metrics.ResourceType]*ContainerMetrics),
+	}
+}

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
@@ -263,37 +261,6 @@ func parseResourceValue(computeResourceType metrics.ResourceType, resourceList v
 		return memoryCapacityKiloBytes
 	}
 	return DEFAULT_METRIC_VALUE
-}
-
-// =================================================================================================
-// ContainerSpec models the shared portion of individual container replicas defined by the controller that manages the
-// pods where the containers run.
-type ContainerSpec struct {
-	Namespace         string
-	ControllerUID     string
-	ContainerSpecName string
-	ContainerSpecId   string
-	ContainerIDs      []string
-	// Container replicas number
-	ContainerReplicas int32
-	// Map from commodity type to list of commodity DTOs of this commodity type sold by container replicas of the
-	// same ContainerSpec entity
-	ContainerCommodities map[proto.CommodityDTO_CommodityType][]*proto.CommodityDTO
-}
-
-func NewContainerSpec(namespace, controllerUID, containerName, containerSpecId string) *ContainerSpec {
-	return &ContainerSpec{
-		Namespace:            namespace,
-		ControllerUID:        controllerUID,
-		ContainerSpecName:    containerName,
-		ContainerSpecId:      containerSpecId,
-		ContainerReplicas:    1,
-		ContainerCommodities: make(map[proto.CommodityDTO_CommodityType][]*proto.CommodityDTO),
-	}
-}
-
-func (spec *ContainerSpec) AddContainerUID(containerID string) {
-	spec.ContainerIDs = append(spec.ContainerIDs, containerID)
 }
 
 // K8s controller in the cluster

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -83,15 +83,15 @@ type TaskResultState string
 // A TaskResult contains a state, indicate whether the task is finished successfully; a err if there is any; a list of
 // EntityDTO.
 type TaskResult struct {
-	workerID         string
-	state            TaskResultState
-	err              error
-	content          []*proto.EntityDTO
-	namespaceMetrics []*repository.NamespaceMetrics
-	entityGroups     []*repository.EntityGroup
-	podEntities      []*repository.KubePod
-	kubeControllers  []*repository.KubeController
-	containerSpecs   []*repository.ContainerSpec
+	workerID             string
+	state                TaskResultState
+	err                  error
+	content              []*proto.EntityDTO
+	namespaceMetrics     []*repository.NamespaceMetrics
+	entityGroups         []*repository.EntityGroup
+	podEntities          []*repository.KubePod
+	kubeControllers      []*repository.KubeController
+	containerSpecMetrics []*repository.ContainerSpecMetrics
 }
 
 func NewTaskResult(workerID string, state TaskResultState) *TaskResult {
@@ -129,8 +129,8 @@ func (r *TaskResult) KubeControllers() []*repository.KubeController {
 	return r.kubeControllers
 }
 
-func (r *TaskResult) ContainerSpecs() []*repository.ContainerSpec {
-	return r.containerSpecs
+func (r *TaskResult) ContainerSpecMetrics() []*repository.ContainerSpecMetrics {
+	return r.containerSpecMetrics
 }
 
 func (r *TaskResult) Err() error {
@@ -167,7 +167,7 @@ func (r *TaskResult) WithKubeControllers(kubeControllers []*repository.KubeContr
 	return r
 }
 
-func (r *TaskResult) WithContainerSpecs(containerSpecs []*repository.ContainerSpec) *TaskResult {
-	r.containerSpecs = containerSpecs
+func (r *TaskResult) WithContainerSpecMetrics(containerSpecMetrics []*repository.ContainerSpecMetrics) *TaskResult {
+	r.containerSpecMetrics = containerSpecMetrics
 	return r
 }

--- a/pkg/discovery/util/node_util.go
+++ b/pkg/discovery/util/node_util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"strings"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
@@ -117,4 +118,16 @@ func DetectHARole(node *api.Node) bool {
 		glog.V(2).Infof("%s is a HA node and will be marked Non Suspendable.", node.Name)
 	}
 	return isHANode
+}
+
+// GetNodeCPUFrequency gets hosting node CPU frequency from EntityMetricSink.
+func GetNodeCPUFrequency(nodeName string, metricsSink *metrics.EntityMetricSink) (float64, error) {
+	cpuFrequencyUID := metrics.GenerateEntityStateMetricUID(metrics.NodeType, nodeName, metrics.CpuFrequency)
+	cpuFrequencyMetric, err := metricsSink.GetMetric(cpuFrequencyUID)
+	if err != nil {
+		err := fmt.Errorf("failed to get cpu frequency from sink for node %s: %v", nodeName, err)
+		return 0.0, err
+	}
+	cpuFrequency := cpuFrequencyMetric.GetValue().(float64)
+	return cpuFrequency, nil
 }

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
@@ -67,10 +67,8 @@ func (maxUsageDataAggregator *maxUsageDataAggregator) Aggregate(resourceMetrics 
 		return 0.0, 0.0, 0.0, err
 	}
 	maxUsed := 0.0
-	peak := 0.0
 	for _, usedPoint := range resourceMetrics.Used {
 		maxUsed = math.Max(maxUsed, usedPoint.Value)
-		peak = math.Max(peak, usedPoint.Value)
 	}
-	return resourceMetrics.Capacity, maxUsed, peak, nil
+	return resourceMetrics.Capacity, maxUsed, maxUsed, nil
 }

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
@@ -2,7 +2,7 @@ package aggregation
 
 import (
 	"fmt"
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"math"
 )
 
@@ -23,9 +23,9 @@ var (
 // ContainerUsageDataAggregator interface represents a type of container usage data aggregator
 type ContainerUsageDataAggregator interface {
 	String() string
-	// Aggregate aggregates commodities usage data based on the given list of commodity DTOs of a commodity type and
-	// aggregation strategy, and returns aggregated capacity, used and peak values.
-	Aggregate(containerCommodities []*proto.CommodityDTO) (float64, float64, float64, error)
+	// Aggregate aggregates commodities usage data based on the given aggregation strategy and ContainerMetrics with
+	// capacity value and multiple usage data points, and returns aggregated capacity, used and peak values.
+	Aggregate(resourceMetrics *repository.ContainerMetrics) (float64, float64, float64, error)
 }
 
 // ---------------- Average usage data aggregation strategy ----------------
@@ -37,23 +37,19 @@ func (avgUsageDataAggregator *avgUsageDataAggregator) String() string {
 	return avgUsageDataAggregator.aggregationStrategy
 }
 
-func (avgUsageDataAggregator *avgUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64, error) {
-	if len(commodities) == 0 {
-		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty", avgUsageDataAggregator)
+func (avgUsageDataAggregator *avgUsageDataAggregator) Aggregate(resourceMetrics *repository.ContainerMetrics) (float64, float64, float64, error) {
+	if len(resourceMetrics.Used) == 0 {
+		err := fmt.Errorf("error to aggregate container usage data using %s: used data points list is empty", avgUsageDataAggregator)
 		return 0.0, 0.0, 0.0, err
 	}
-	capacitySum := 0.0
 	usedSum := 0.0
-	peakSum := 0.0
-	for _, commodity := range commodities {
-		capacitySum += *commodity.Capacity
-		usedSum += *commodity.Used
-		peakSum += *commodity.Peak
+	peak := 0.0
+	for _, usedPoint := range resourceMetrics.Used {
+		usedSum += usedPoint.Value
+		peak = math.Max(peak, usedPoint.Value)
 	}
-	avgCapacity := capacitySum / float64(len(commodities))
-	avgUsed := usedSum / float64(len(commodities))
-	avgPeak := peakSum / float64(len(commodities))
-	return avgCapacity, avgUsed, avgPeak, nil
+	avgUsed := usedSum / float64(len(resourceMetrics.Used))
+	return resourceMetrics.Capacity, avgUsed, peak, nil
 }
 
 // ---------------- Max usage data aggregation strategy ----------------
@@ -65,18 +61,16 @@ func (maxUsageDataAggregator *maxUsageDataAggregator) String() string {
 	return maxUsageDataAggregator.aggregationStrategy
 }
 
-func (maxUsageDataAggregator *maxUsageDataAggregator) Aggregate(commodities []*proto.CommodityDTO) (float64, float64, float64, error) {
-	if len(commodities) == 0 {
-		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty", maxUsageDataAggregator)
+func (maxUsageDataAggregator *maxUsageDataAggregator) Aggregate(resourceMetrics *repository.ContainerMetrics) (float64, float64, float64, error) {
+	if len(resourceMetrics.Used) == 0 {
+		err := fmt.Errorf("error to aggregate container usage data using %s: used data points list is empty", maxUsageDataAggregator)
 		return 0.0, 0.0, 0.0, err
 	}
-	maxCapacity := 0.0
 	maxUsed := 0.0
-	maxPeak := 0.0
-	for _, commodity := range commodities {
-		maxCapacity = math.Max(maxCapacity, *commodity.Capacity)
-		maxUsed = math.Max(maxUsed, *commodity.Used)
-		maxPeak = math.Max(maxPeak, *commodity.Peak)
+	peak := 0.0
+	for _, usedPoint := range resourceMetrics.Used {
+		maxUsed = math.Max(maxUsed, usedPoint.Value)
+		peak = math.Max(peak, usedPoint.Value)
 	}
-	return maxCapacity, maxUsed, maxPeak, nil
+	return resourceMetrics.Capacity, maxUsed, peak, nil
 }

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator_test.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator_test.go
@@ -12,6 +12,7 @@ var (
 		Used: []metrics.Point{
 			createContainerMetricPoint(1.0, 1),
 			createContainerMetricPoint(3.0, 2),
+			createContainerMetricPoint(2.0, 3),
 		},
 	}
 	emptyContainerMetrics = &repository.ContainerMetrics{

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator_test.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator_test.go
@@ -1,24 +1,29 @@
 package aggregation
 
 import (
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"testing"
 )
 
 var (
-	cpuCommType     = proto.CommodityDTO_VCPU
-	testCommodities = []*proto.CommodityDTO{
-		createCommodityDTO(cpuCommType, 2.0, 1.0, 1.0),
-		createCommodityDTO(cpuCommType, 4.0, 3.0, 3.0),
+	testContainerMetrics = &repository.ContainerMetrics{
+		Capacity: 4,
+		Used: []metrics.Point{
+			createContainerMetricPoint(1.0, 1),
+			createContainerMetricPoint(3.0, 2),
+		},
 	}
-	emptyCommodities []*proto.CommodityDTO
+	emptyContainerMetrics = &repository.ContainerMetrics{
+		Used: []metrics.Point{},
+	}
 )
 
 func Test_avgUsageDataAggregator_Aggregate(t *testing.T) {
 	testCases := []struct {
 		name                string
 		aggregationStrategy string
-		commodities         []*proto.CommodityDTO
+		containerMetrics    *repository.ContainerMetrics
 		capacity            float64
 		used                float64
 		peak                float64
@@ -27,16 +32,16 @@ func Test_avgUsageDataAggregator_Aggregate(t *testing.T) {
 		{
 			name:                "test aggregate average usage data",
 			aggregationStrategy: "average usage data strategy",
-			commodities:         testCommodities,
-			capacity:            3.0,
+			containerMetrics:    testContainerMetrics,
+			capacity:            4.0,
 			used:                2.0,
-			peak:                2.0,
+			peak:                3.0,
 			wantErr:             false,
 		},
 		{
 			name:                "test aggregate average usage data with empty commodities",
 			aggregationStrategy: "average usage data strategy",
-			commodities:         emptyCommodities,
+			containerMetrics:    emptyContainerMetrics,
 			capacity:            0.0,
 			used:                0.0,
 			peak:                0.0,
@@ -48,7 +53,7 @@ func Test_avgUsageDataAggregator_Aggregate(t *testing.T) {
 			avgUsageDataAggregator := &avgUsageDataAggregator{
 				aggregationStrategy: tt.aggregationStrategy,
 			}
-			aggregatedCap, aggregatedUsed, aggregatedPeak, err := avgUsageDataAggregator.Aggregate(tt.commodities)
+			aggregatedCap, aggregatedUsed, aggregatedPeak, err := avgUsageDataAggregator.Aggregate(tt.containerMetrics)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -70,7 +75,7 @@ func Test_maxUsageDataAggregator_Aggregate(t *testing.T) {
 	testCases := []struct {
 		name                string
 		aggregationStrategy string
-		commodities         []*proto.CommodityDTO
+		containerMetrics    *repository.ContainerMetrics
 		capacity            float64
 		used                float64
 		peak                float64
@@ -79,7 +84,7 @@ func Test_maxUsageDataAggregator_Aggregate(t *testing.T) {
 		{
 			name:                "test aggregate max usage data",
 			aggregationStrategy: "max usage data strategy",
-			commodities:         testCommodities,
+			containerMetrics:    testContainerMetrics,
 			capacity:            4.0,
 			used:                3.0,
 			peak:                3.0,
@@ -88,7 +93,7 @@ func Test_maxUsageDataAggregator_Aggregate(t *testing.T) {
 		{
 			name:                "test aggregate max usage data with empty commodities",
 			aggregationStrategy: "average usage data strategy",
-			commodities:         emptyCommodities,
+			containerMetrics:    emptyContainerMetrics,
 			capacity:            0.0,
 			used:                0.0,
 			peak:                0.0,
@@ -100,7 +105,7 @@ func Test_maxUsageDataAggregator_Aggregate(t *testing.T) {
 			maxUsageDataAggregator := &maxUsageDataAggregator{
 				aggregationStrategy: tt.aggregationStrategy,
 			}
-			aggregatedCap, aggregatedUsed, aggregatedPeak, err := maxUsageDataAggregator.Aggregate(tt.commodities)
+			aggregatedCap, aggregatedUsed, aggregatedPeak, err := maxUsageDataAggregator.Aggregate(tt.containerMetrics)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -118,11 +123,9 @@ func Test_maxUsageDataAggregator_Aggregate(t *testing.T) {
 	}
 }
 
-func createCommodityDTO(commodityType proto.CommodityDTO_CommodityType, capacity, used, peak float64) *proto.CommodityDTO {
-	return &proto.CommodityDTO{
-		CommodityType: &commodityType,
-		Capacity:      &capacity,
-		Used:          &used,
-		Peak:          &peak,
+func createContainerMetricPoint(value float64, timestamp int64) metrics.Point {
+	return metrics.Point{
+		Value:     value,
+		Timestamp: timestamp,
 	}
 }

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
@@ -59,8 +59,12 @@ func (allDataAggregator *allUtilizationDataAggregator) Aggregate(resourceMetrics
 		}
 		lastTimestamp = int64(math.Max(float64(lastTimestamp), float64(usedPoint.Timestamp)))
 	}
-	samplingDuration := int32(lastTimestamp - firstTimestamp)
-	return utilizationDataPoints, lastTimestamp, samplingDuration, nil
+	// Calculate interval between data points
+	var dataInterval int32
+	if len(utilizationDataPoints) > 1 {
+		dataInterval = int32(lastTimestamp-firstTimestamp) / int32(len(utilizationDataPoints)-1)
+	}
+	return utilizationDataPoints, lastTimestamp, dataInterval, nil
 }
 
 // ---------------- Max utilization data aggregation strategy ----------------

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
@@ -2,7 +2,7 @@ package aggregation
 
 import (
 	"fmt"
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"math"
 )
 
@@ -23,9 +23,10 @@ var (
 // ContainerUtilizationDataAggregator interface represents a type of container utilization data aggregator
 type ContainerUtilizationDataAggregator interface {
 	String() string
-	// Aggregate aggregates commodities utilization data based on the given list of commodity DTOs of a commodity type
-	// and aggregation strategy, and returns aggregated utilization data points.
-	Aggregate(commodities []*proto.CommodityDTO) ([]float64, error)
+	// Aggregate aggregates commodities utilization data based on the given aggregation strategy and ContainerMetrics with
+	// capacity value and multiple usage data points, and returns aggregated utilization data points, last point timestamp
+	// and duration of collecting given metrics points (difference between last timestamp and first timestamp).
+	Aggregate(resourceMetrics *repository.ContainerMetrics) ([]float64, int64, int32, error)
 }
 
 // ---------------- All utilization data aggregation strategy ----------------
@@ -37,24 +38,29 @@ func (allDataAggregator *allUtilizationDataAggregator) String() string {
 	return allDataAggregator.aggregationStrategy
 }
 
-func (allDataAggregator *allUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO) ([]float64, error) {
-	if len(commodities) == 0 {
-		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty", allDataAggregator)
-		return []float64{}, err
+func (allDataAggregator *allUtilizationDataAggregator) Aggregate(resourceMetrics *repository.ContainerMetrics) ([]float64, int64, int32, error) {
+	if len(resourceMetrics.Used) == 0 {
+		err := fmt.Errorf("error aggregating container utilization data using %s: used data points list is empty", allDataAggregator)
+		return []float64{}, 0, 0, err
+	}
+	capacity := resourceMetrics.Capacity
+	if capacity == 0.0 {
+		err := fmt.Errorf("error aggregating container utilization data using %s: capacity is 0", allDataAggregator)
+		return []float64{}, 0, 0, err
 	}
 	var utilizationDataPoints []float64
-	for _, commodity := range commodities {
-		used := *commodity.Used
-		capacity := *commodity.Capacity
-		if capacity == 0.0 {
-			err := fmt.Errorf("error to aggregate %s commodities using %s : capacity is 0", commodity.CommodityType,
-				allDataAggregator)
-			return []float64{}, err
-		}
-		utilization := used / capacity * 100
+	var firstTimestamp int64
+	var lastTimestamp int64
+	for _, usedPoint := range resourceMetrics.Used {
+		utilization := usedPoint.Value / capacity * 100
 		utilizationDataPoints = append(utilizationDataPoints, utilization)
+		if firstTimestamp == 0 || usedPoint.Timestamp < firstTimestamp {
+			firstTimestamp = usedPoint.Timestamp
+		}
+		lastTimestamp = int64(math.Max(float64(lastTimestamp), float64(usedPoint.Timestamp)))
 	}
-	return utilizationDataPoints, nil
+	samplingDuration := int32(lastTimestamp - firstTimestamp)
+	return utilizationDataPoints, lastTimestamp, samplingDuration, nil
 }
 
 // ---------------- Max utilization data aggregation strategy ----------------
@@ -66,22 +72,22 @@ func (maxDataAggregator *maxUtilizationDataAggregator) String() string {
 	return maxDataAggregator.aggregationStrategy
 }
 
-func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(commodities []*proto.CommodityDTO) ([]float64, error) {
-	if len(commodities) == 0 {
-		err := fmt.Errorf("error to aggregate commodities using %s : commodities list is empty", maxDataAggregator)
-		return []float64{}, err
+func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(resourceMetrics *repository.ContainerMetrics) ([]float64, int64, int32, error) {
+	if len(resourceMetrics.Used) == 0 {
+		err := fmt.Errorf("error aggregating container utilization data using %s: used data points list is empty", maxDataAggregator)
+		return []float64{}, 0, 0, err
 	}
-	maxUtilization := 0.0
-	for _, commodity := range commodities {
-		used := *commodity.Used
-		capacity := *commodity.Capacity
-		if capacity == 0.0 {
-			err := fmt.Errorf("error to aggregate %s commodities using %s : capacity is 0", commodity.CommodityType,
-				maxDataAggregator)
-			return []float64{}, err
-		}
-		utilization := used / capacity * 100
+	var maxUtilization float64
+	var lastTimestamp int64
+	capacity := resourceMetrics.Capacity
+	if capacity == 0.0 {
+		err := fmt.Errorf("error aggregating container utilization data using %s: capacity is 0", maxDataAggregator)
+		return []float64{}, 0, 0, err
+	}
+	for _, usedPoint := range resourceMetrics.Used {
+		utilization := usedPoint.Value / capacity * 100
 		maxUtilization = math.Max(utilization, maxUtilization)
+		lastTimestamp = int64(math.Max(float64(lastTimestamp), float64(usedPoint.Timestamp)))
 	}
-	return []float64{maxUtilization}, nil
+	return []float64{maxUtilization}, lastTimestamp, 0, nil
 }

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator_test.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator_test.go
@@ -13,16 +13,16 @@ func Test_allUtilizationDataAggregator_Aggregate(t *testing.T) {
 		containerMetrics    *repository.ContainerMetrics
 		points              []float64
 		lastPointTimestamp  int64
-		samplingDuration    int32
+		dataInterval        int32
 		wantErr             bool
 	}{
 		{
 			name:                "test aggregate all utilization data",
 			aggregationStrategy: "all utilization data strategy",
 			containerMetrics:    testContainerMetrics,
-			points:              []float64{25.0, 75.0},
-			lastPointTimestamp:  2,
-			samplingDuration:    1,
+			points:              []float64{25.0, 75.0, 50.0},
+			lastPointTimestamp:  3,
+			dataInterval:        1,
 			wantErr:             false,
 		},
 		{
@@ -31,7 +31,7 @@ func Test_allUtilizationDataAggregator_Aggregate(t *testing.T) {
 			containerMetrics:    emptyContainerMetrics,
 			points:              []float64{},
 			lastPointTimestamp:  0,
-			samplingDuration:    0,
+			dataInterval:        0,
 			wantErr:             true,
 		},
 	}
@@ -40,7 +40,7 @@ func Test_allUtilizationDataAggregator_Aggregate(t *testing.T) {
 			allDataAggregator := &allUtilizationDataAggregator{
 				aggregationStrategy: tt.aggregationStrategy,
 			}
-			points, lastPointTimestamp, samplingDuration, err := allDataAggregator.Aggregate(tt.containerMetrics)
+			points, lastPointTimestamp, dataInterval, err := allDataAggregator.Aggregate(tt.containerMetrics)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -51,8 +51,8 @@ func Test_allUtilizationDataAggregator_Aggregate(t *testing.T) {
 			if lastPointTimestamp != tt.lastPointTimestamp {
 				t.Errorf("Aggregate() lastPointTimestamp = %v, want %v", lastPointTimestamp, tt.lastPointTimestamp)
 			}
-			if samplingDuration != tt.samplingDuration {
-				t.Errorf("Aggregate() samplingDuration = %v, want %v", samplingDuration, tt.samplingDuration)
+			if dataInterval != tt.dataInterval {
+				t.Errorf("Aggregate() dataInterval = %v, want %v", dataInterval, tt.dataInterval)
 			}
 		})
 	}
@@ -65,7 +65,7 @@ func Test_maxUtilizationDataAggregator_Aggregate(t *testing.T) {
 		containerMetrics    *repository.ContainerMetrics
 		points              []float64
 		lastPointTimestamp  int64
-		samplingDuration    int32
+		dataInterval        int32
 		wantErr             bool
 	}{
 		{
@@ -73,8 +73,8 @@ func Test_maxUtilizationDataAggregator_Aggregate(t *testing.T) {
 			aggregationStrategy: "max utilization data strategy",
 			containerMetrics:    testContainerMetrics,
 			points:              []float64{75.0},
-			lastPointTimestamp:  2,
-			samplingDuration:    0,
+			lastPointTimestamp:  3,
+			dataInterval:        0,
 			wantErr:             false,
 		},
 		{
@@ -83,7 +83,7 @@ func Test_maxUtilizationDataAggregator_Aggregate(t *testing.T) {
 			containerMetrics:    emptyContainerMetrics,
 			points:              []float64{},
 			lastPointTimestamp:  0,
-			samplingDuration:    0,
+			dataInterval:        0,
 			wantErr:             true,
 		},
 	}
@@ -92,7 +92,7 @@ func Test_maxUtilizationDataAggregator_Aggregate(t *testing.T) {
 			maxDataAggregator := &maxUtilizationDataAggregator{
 				aggregationStrategy: tt.aggregationStrategy,
 			}
-			points, lastPointTimestamp, samplingDuration, err := maxDataAggregator.Aggregate(tt.containerMetrics)
+			points, lastPointTimestamp, dataInterval, err := maxDataAggregator.Aggregate(tt.containerMetrics)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -103,8 +103,8 @@ func Test_maxUtilizationDataAggregator_Aggregate(t *testing.T) {
 			if lastPointTimestamp != tt.lastPointTimestamp {
 				t.Errorf("Aggregate() lastPointTimestamp = %v, want %v", lastPointTimestamp, tt.lastPointTimestamp)
 			}
-			if samplingDuration != tt.samplingDuration {
-				t.Errorf("Aggregate() samplingDuration = %v, want %v", samplingDuration, tt.samplingDuration)
+			if dataInterval != tt.dataInterval {
+				t.Errorf("Aggregate() dataInterval = %v, want %v", dataInterval, tt.dataInterval)
 			}
 		})
 	}

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator_test.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator_test.go
@@ -1,7 +1,7 @@
 package aggregation
 
 import (
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"reflect"
 	"testing"
 )
@@ -10,22 +10,28 @@ func Test_allUtilizationDataAggregator_Aggregate(t *testing.T) {
 	testCases := []struct {
 		name                string
 		aggregationStrategy string
-		commodities         []*proto.CommodityDTO
+		containerMetrics    *repository.ContainerMetrics
 		points              []float64
+		lastPointTimestamp  int64
+		samplingDuration    int32
 		wantErr             bool
 	}{
 		{
 			name:                "test aggregate all utilization data",
 			aggregationStrategy: "all utilization data strategy",
-			commodities:         testCommodities,
-			points:              []float64{50.0, 75.0},
+			containerMetrics:    testContainerMetrics,
+			points:              []float64{25.0, 75.0},
+			lastPointTimestamp:  2,
+			samplingDuration:    1,
 			wantErr:             false,
 		},
 		{
 			name:                "test aggregate all utilization data with empty commodities",
 			aggregationStrategy: "all utilization data strategy",
-			commodities:         emptyCommodities,
+			containerMetrics:    emptyContainerMetrics,
 			points:              []float64{},
+			lastPointTimestamp:  0,
+			samplingDuration:    0,
 			wantErr:             true,
 		},
 	}
@@ -34,13 +40,19 @@ func Test_allUtilizationDataAggregator_Aggregate(t *testing.T) {
 			allDataAggregator := &allUtilizationDataAggregator{
 				aggregationStrategy: tt.aggregationStrategy,
 			}
-			points, err := allDataAggregator.Aggregate(tt.commodities)
+			points, lastPointTimestamp, samplingDuration, err := allDataAggregator.Aggregate(tt.containerMetrics)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(points, tt.points) {
 				t.Errorf("Aggregate() got = %v, want %v", points, tt.points)
+			}
+			if lastPointTimestamp != tt.lastPointTimestamp {
+				t.Errorf("Aggregate() lastPointTimestamp = %v, want %v", lastPointTimestamp, tt.lastPointTimestamp)
+			}
+			if samplingDuration != tt.samplingDuration {
+				t.Errorf("Aggregate() samplingDuration = %v, want %v", samplingDuration, tt.samplingDuration)
 			}
 		})
 	}
@@ -50,22 +62,28 @@ func Test_maxUtilizationDataAggregator_Aggregate(t *testing.T) {
 	testCases := []struct {
 		name                string
 		aggregationStrategy string
-		commodities         []*proto.CommodityDTO
+		containerMetrics    *repository.ContainerMetrics
 		points              []float64
+		lastPointTimestamp  int64
+		samplingDuration    int32
 		wantErr             bool
 	}{
 		{
 			name:                "test aggregate max utilization data",
 			aggregationStrategy: "max utilization data strategy",
-			commodities:         testCommodities,
+			containerMetrics:    testContainerMetrics,
 			points:              []float64{75.0},
+			lastPointTimestamp:  2,
+			samplingDuration:    0,
 			wantErr:             false,
 		},
 		{
 			name:                "test aggregate all utilization data with empty commodities",
 			aggregationStrategy: "all utilization data strategy",
-			commodities:         emptyCommodities,
+			containerMetrics:    emptyContainerMetrics,
 			points:              []float64{},
+			lastPointTimestamp:  0,
+			samplingDuration:    0,
 			wantErr:             true,
 		},
 	}
@@ -74,13 +92,19 @@ func Test_maxUtilizationDataAggregator_Aggregate(t *testing.T) {
 			maxDataAggregator := &maxUtilizationDataAggregator{
 				aggregationStrategy: tt.aggregationStrategy,
 			}
-			points, err := maxDataAggregator.Aggregate(tt.commodities)
+			points, lastPointTimestamp, samplingDuration, err := maxDataAggregator.Aggregate(tt.containerMetrics)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Aggregate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(points, tt.points) {
 				t.Errorf("Aggregate() got = %v, want %v", points, tt.points)
+			}
+			if lastPointTimestamp != tt.lastPointTimestamp {
+				t.Errorf("Aggregate() lastPointTimestamp = %v, want %v", lastPointTimestamp, tt.lastPointTimestamp)
+			}
+			if samplingDuration != tt.samplingDuration {
+				t.Errorf("Aggregate() samplingDuration = %v, want %v", samplingDuration, tt.samplingDuration)
 			}
 		})
 	}

--- a/pkg/discovery/worker/container_spec_metrics_collector.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector.go
@@ -1,0 +1,145 @@
+package worker
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	api "k8s.io/api/core/v1"
+)
+
+var (
+	resourceTypes = []metrics.ResourceType{
+		metrics.CPU,
+		metrics.Memory,
+		metrics.CPURequest,
+		metrics.MemoryRequest,
+	}
+)
+
+// Collect list of ContainerSpecMetrics data from pods by the given discovery worker. Each ContainerSpecMetrics stores
+// resource capacity value and multiple usage data points from sampling discoveries for container replicas which belong
+// to the same ContainerSpec.
+type ContainerSpecMetricsCollector struct {
+	podList     []*api.Pod
+	metricsSink *metrics.EntityMetricSink
+}
+
+func NewContainerSpecMetricsCollector(metricsSink *metrics.EntityMetricSink, podList []*api.Pod) *ContainerSpecMetricsCollector {
+	metricsCollector := &ContainerSpecMetricsCollector{
+		podList:     podList,
+		metricsSink: metricsSink,
+	}
+	return metricsCollector
+}
+
+// CollectContainerSpecMetrics collects list of ContainerSpecMetrics including resource capacity value and multiple
+// usage data points from sampling discoveries for container replicas which belong to the same ContainerSpec.
+func (collector *ContainerSpecMetricsCollector) CollectContainerSpecMetrics() ([]*repository.ContainerSpecMetrics, error) {
+	var containerSpecMetricsList []*repository.ContainerSpecMetrics
+	for _, pod := range collector.podList {
+		// Create ContainerSpecMetrics only if Pod is deployed by a K8s controller
+		if util.HasController(pod) {
+			controllerUID, err := util.GetControllerUID(pod, collector.metricsSink)
+			if err != nil {
+				glog.Errorf("Error getting controller UID from pod %s, %v", pod.Name, err)
+				continue
+			}
+			nodeCPUFrequency, err := util.GetNodeCPUFrequency(util.NodeKeyFromPodFunc(pod), collector.metricsSink)
+			if err != nil {
+				glog.Errorf("failed to build ContainerDTOs for pod[%s]: %v", pod.Name, err)
+				continue
+			}
+			podMId := util.PodMetricIdAPI(pod)
+			for _, container := range pod.Spec.Containers {
+				// Create ContainerSpecMetrics object to collect resource metrics of each individual container replica for a
+				// ContainerSpec entity. ContainerSpecMetrics entity includes resource capacity value and multiple resource
+				// usage data points from sampling discoveries for a certain type of container replicas.
+				containerSpecId := util.ContainerSpecIdFunc(controllerUID, container.Name)
+				containerSpecMetrics := repository.NewContainerSpecMetrics(pod.Namespace, controllerUID, container.Name,
+					containerSpecId)
+
+				isCpuRequestSet := !container.Resources.Requests.Cpu().IsZero()
+				isMemRequestSet := !container.Resources.Requests.Memory().IsZero()
+				containerMId := util.ContainerMetricId(podMId, container.Name)
+				collector.collectContainerMetrics(containerSpecMetrics, containerMId, nodeCPUFrequency, isCpuRequestSet, isMemRequestSet)
+
+				containerSpecMetricsList = append(containerSpecMetricsList, containerSpecMetrics)
+			}
+		}
+	}
+	return containerSpecMetricsList, nil
+}
+
+// collectContainerMetrics collects container metrics from metricsSink and stores them in the given ContainerSpecMetrics
+func (collector *ContainerSpecMetricsCollector) collectContainerMetrics(containerSpecMetric *repository.ContainerSpecMetrics,
+	containerMId string, nodeCPUFrequency float64, isCpuRequestSet, isMemRequestSet bool) {
+	for _, resourceType := range resourceTypes {
+		if resourceType == metrics.CPURequest && !isCpuRequestSet || resourceType == metrics.MemoryRequest && !isMemRequestSet {
+			// If CPU/Memory request is not set on container, no need to collect request resource metrics
+			glog.V(4).Infof("Container %s has no %s set", containerMId, resourceType)
+			continue
+		}
+		usedMetricValue, err := collector.getResourceMetricValue(containerMId, resourceType, metrics.Used, nodeCPUFrequency)
+		if err != nil {
+			glog.Errorf("Error getting resource %s value for container %s %s: %v", metrics.Used, containerMId, resourceType, err)
+			continue
+		}
+		usedValPoints, ok := usedMetricValue.([]metrics.Point)
+		if !ok {
+			glog.Errorf("Error getting resource %s value for container %s %s: usedMetricValue is %t not '[]metrics.Point' type",
+				metrics.Used, containerMId, resourceType, usedMetricValue)
+			continue
+		}
+		capacityMetricValue, err := collector.getResourceMetricValue(containerMId, resourceType, metrics.Capacity, nodeCPUFrequency)
+		if err != nil {
+			glog.Errorf("Error getting resource %s value for container %s %s", metrics.Capacity, containerMId, resourceType)
+			continue
+		}
+		capVal, ok := capacityMetricValue.(float64)
+		if !ok {
+			glog.Errorf("Error getting resource %s value for container %s %s: capacityMetricValue is %t not 'float64' type",
+				metrics.Capacity, containerMId, resourceType, capacityMetricValue)
+			continue
+		}
+		containerResourceMetrics := repository.NewContainerMetrics(capVal, usedValPoints)
+		containerMetrics, exists := containerSpecMetric.ContainerMetrics[resourceType]
+		if !exists {
+			containerSpecMetric.ContainerMetrics[resourceType] = containerResourceMetrics
+		} else {
+			// Resource capacity of the same resource type is always the same for container replicas so no need to update.
+			// Append resource used data points to containerMetrics.
+			containerMetrics.Used = append(containerMetrics.Used, containerResourceMetrics.Used...)
+		}
+	}
+}
+
+func (collector *ContainerSpecMetricsCollector) getResourceMetricValue(containerMId string, rType metrics.ResourceType,
+	mType metrics.MetricProp, nodeCPUFrequency float64) (interface{}, error) {
+	metricUID := metrics.GenerateEntityResourceMetricUID(metrics.ContainerType, containerMId, rType, mType)
+	resourceMetric, err := collector.metricsSink.GetMetric(metricUID)
+	if err != nil {
+		return nil, fmt.Errorf("missing metrics %s", metricUID)
+	}
+	switch resourceMetric.GetValue().(type) {
+	case []metrics.Point:
+		metricPoints, _ := resourceMetric.GetValue().([]metrics.Point)
+		if metrics.IsCPUType(rType) {
+			// If resource is CPU type, convert values expressed in number of cores to MHz
+			for i := range metricPoints {
+				metricPoints[i].Value *= nodeCPUFrequency
+			}
+		}
+		return metricPoints, nil
+	case float64:
+		metricValue := resourceMetric.GetValue().(float64)
+		if metrics.IsCPUType(rType) {
+			// If resource is CPU type, convert metricValue expressed in number of cores to MHz
+			metricValue *= nodeCPUFrequency
+		}
+		return metricValue, nil
+	default:
+		return nil, fmt.Errorf("unsupported metric value type: %t", resourceMetric.GetValue())
+	}
+}

--- a/pkg/discovery/worker/container_spec_metrics_collector_test.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector_test.go
@@ -1,0 +1,216 @@
+package worker
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	discoveryutil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/turbonomic/kubeturbo/pkg/util"
+	api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+)
+
+const (
+	containerFoo  = "containerFoo"
+	containerBar  = "containerBar"
+	controllerUID = "controllerUID"
+
+	containerFooCPUCap   = 5.0
+	containerFooCPUUsed1 = 2.0
+	containerFooCPUUsed2 = 4.0
+	containerFooMemCap   = 400.0
+	containerFooMemUsed1 = 200.0
+	containerFooMemUsed2 = 300.0
+
+	containerBarCPURequestCap   = 4.0
+	containerBarCPURequestUsed1 = 1.0
+	containerBarCPURequestUsed2 = 2.0
+	containerBarMemRequestCap   = 400.0
+	containerBarMemRequestUsed1 = 100.0
+	containerBarMemRequestUsed2 = 200.0
+)
+
+var (
+	testPod4 = &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "pod",
+			UID:       "pod-UID",
+			OwnerReferences: []metav1.OwnerReference{
+				mockOwnerReference(util.KindDeployment, "controller", controllerUID),
+			},
+		},
+		Spec: api.PodSpec{
+			NodeName: "node",
+			Containers: []api.Container{
+				{
+					Name: containerFoo,
+				},
+			},
+		},
+	}
+	testPod5 = &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "pod",
+			UID:       "pod-UID",
+			OwnerReferences: []metav1.OwnerReference{
+				mockOwnerReference(util.KindDeployment, "controller", controllerUID),
+			},
+		},
+		Spec: api.PodSpec{
+			NodeName: "node",
+			Containers: []api.Container{
+				{
+					Name: containerBar,
+					Resources: api.ResourceRequirements{
+						Requests: buildResource(containerBarCPURequestCap, int64(containerBarCPURequestCap)),
+					},
+				},
+			},
+		},
+	}
+
+	ownerUIDMetric      = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod4), metrics.OwnerUID, controllerUID)
+	podNodeCPUFrequency = metrics.NewEntityStateMetric(metrics.NodeType, discoveryutil.NodeKeyFromPodFunc(testPod4), metrics.CpuFrequency, cpuFrequency)
+
+	containerFooCPUCapMetric = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerFoo), metrics.CPU, metrics.Capacity, containerFooCPUCap)
+	containerFooCPUUsedMetric1 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerFoo), metrics.CPU, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerFooCPUUsed1, 1),
+		})
+	containerFooCPUUsedMetric2 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerFoo), metrics.CPU, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerFooCPUUsed2, 2),
+		})
+	containerFooMemCapMetric = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerFoo), metrics.Memory, metrics.Capacity, containerFooMemCap)
+	containerFooMemUsedMetric1 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerFoo), metrics.Memory, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerFooMemUsed1, 1),
+		})
+	containerFooMemUsedMetric2 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerFoo), metrics.Memory, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerFooMemUsed2, 2),
+		})
+
+	containerBarCPURequestCapMetric = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.CPURequest, metrics.Capacity, containerBarCPURequestCap)
+	containerBarCPURequestUsedMetric1 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.CPURequest, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerBarCPURequestUsed1, 1),
+		})
+	containerBarCPURequestUsedMetric2 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.CPURequest, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerBarCPURequestUsed2, 2),
+		})
+	containerBarMemRequestCapMetric = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.MemoryRequest, metrics.Capacity, containerBarMemRequestCap)
+	containerBarMemRequestUsedMetric1 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.MemoryRequest, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerBarMemRequestUsed1, 1),
+		})
+	containerBarMemRequestUsedMetric2 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.MemoryRequest, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerBarMemRequestUsed2, 2),
+		})
+)
+
+func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithoutRequestMetrics(t *testing.T) {
+	pods := []*api.Pod{testPod4}
+	metricsSink := metrics.NewEntityMetricSink().WithMaxMetricPointsSize(10)
+	// Add pod owner UID and node CPU frequency metrics
+	metricsSink.AddNewMetricEntries(ownerUIDMetric, podNodeCPUFrequency)
+
+	// Add and update containerFoo CPU and memory metrics
+	metricsSink.AddNewMetricEntries(containerFooCPUCapMetric, containerFooCPUUsedMetric1, containerFooMemCapMetric, containerFooMemUsedMetric1)
+	metricsSink.UpdateMetricEntry(containerFooCPUUsedMetric2)
+	metricsSink.UpdateMetricEntry(containerFooMemUsedMetric2)
+
+	containerSpecMetricsCollector := NewContainerSpecMetricsCollector(metricsSink, pods)
+	containerSpecMetricsList, _ := containerSpecMetricsCollector.CollectContainerSpecMetrics()
+
+	expectedContainerSpecMetricsFoo := &repository.ContainerSpecMetrics{
+		Namespace:         namespace,
+		ControllerUID:     controllerUID,
+		ContainerSpecName: containerFoo,
+		ContainerSpecId:   discoveryutil.ContainerSpecIdFunc(controllerUID, containerFoo),
+		ContainerReplicas: 1,
+		ContainerMetrics: map[metrics.ResourceType]*repository.ContainerMetrics{
+			metrics.CPU: {
+				Capacity: cpuFrequency * containerFooCPUCap,
+				Used: []metrics.Point{
+					createContainerMetricPoint(cpuFrequency*containerFooCPUUsed1, 1),
+					createContainerMetricPoint(cpuFrequency*containerFooCPUUsed2, 2),
+				},
+			},
+			metrics.Memory: {
+				Capacity: containerFooMemCap,
+				Used: []metrics.Point{
+					createContainerMetricPoint(containerFooMemUsed1, 1),
+					createContainerMetricPoint(containerFooMemUsed2, 2),
+				},
+			},
+		},
+	}
+	assert.EqualValues(t, 1, len(containerSpecMetricsList))
+	assert.Equal(t, containerFoo, containerSpecMetricsList[0].ContainerSpecName)
+	if !reflect.DeepEqual(expectedContainerSpecMetricsFoo, containerSpecMetricsList[0]) {
+		t.Errorf("Test case failed: CollectContainerSpecMetrics():\nexpected:\n%++v\nactual:\n%++v", expectedContainerSpecMetricsFoo, containerSpecMetricsList[0])
+	}
+}
+
+func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithRequestMetrics(t *testing.T) {
+	pods := []*api.Pod{testPod5}
+	metricsSink := metrics.NewEntityMetricSink().WithMaxMetricPointsSize(10)
+	// Add pod owner UID and node CPU frequency metrics
+	metricsSink.AddNewMetricEntries(ownerUIDMetric, podNodeCPUFrequency)
+
+	// Add and update containerFoo CPURequest and MemoryRequest metrics
+	metricsSink.AddNewMetricEntries(containerBarCPURequestCapMetric, containerBarCPURequestUsedMetric1, containerBarMemRequestCapMetric, containerBarMemRequestUsedMetric1)
+	metricsSink.UpdateMetricEntry(containerBarCPURequestUsedMetric2)
+	metricsSink.UpdateMetricEntry(containerBarMemRequestUsedMetric2)
+
+	containerSpecMetricsCollector := NewContainerSpecMetricsCollector(metricsSink, pods)
+	containerSpecMetricsList, _ := containerSpecMetricsCollector.CollectContainerSpecMetrics()
+
+	expectedContainerSpecMetricsBar := &repository.ContainerSpecMetrics{
+		Namespace:         namespace,
+		ControllerUID:     controllerUID,
+		ContainerSpecName: containerBar,
+		ContainerSpecId:   discoveryutil.ContainerSpecIdFunc(controllerUID, containerBar),
+		ContainerReplicas: 1,
+		ContainerMetrics: map[metrics.ResourceType]*repository.ContainerMetrics{
+			metrics.CPURequest: {
+				Capacity: cpuFrequency * containerBarCPURequestCap,
+				Used: []metrics.Point{
+					createContainerMetricPoint(cpuFrequency*containerBarCPURequestUsed1, 1),
+					createContainerMetricPoint(cpuFrequency*containerBarCPURequestUsed2, 2),
+				},
+			},
+			metrics.MemoryRequest: {
+				Capacity: containerBarMemRequestCap,
+				Used: []metrics.Point{
+					createContainerMetricPoint(containerBarMemRequestUsed1, 1),
+					createContainerMetricPoint(containerBarMemRequestUsed2, 2),
+				},
+			},
+		},
+	}
+	assert.EqualValues(t, 1, len(containerSpecMetricsList))
+	assert.Equal(t, containerBar, containerSpecMetricsList[0].ContainerSpecName)
+	if !reflect.DeepEqual(expectedContainerSpecMetricsBar, containerSpecMetricsList[0]) {
+		t.Errorf("Test case failed: CollectContainerSpecMetrics():\nexpected:\n%++v\nactual:\n%++v", expectedContainerSpecMetricsBar, containerSpecMetricsList[0])
+	}
+}

--- a/pkg/discovery/worker/controller_metrics_collector.go
+++ b/pkg/discovery/worker/controller_metrics_collector.go
@@ -138,7 +138,7 @@ func (collector *ControllerMetricsCollector) updateQuotaResourcesUsed(kubeContro
 		if metrics.IsCPUType(resourceType) {
 			// For CPU resources, convert the usage values expressed in cores to MHz based on the CPU frequency of the
 			// corresponding node where the given pod is located
-			cpuFrequency, err := collector.getNodeCPUFrequency(pod)
+			cpuFrequency, err := util.GetNodeCPUFrequency(util.NodeKeyFromPodFunc(pod), collector.metricsSink)
 			if err != nil {
 				glog.Errorf("Error getting node cpuFrequency from pod %s: %v", podKey, err)
 				continue
@@ -160,17 +160,4 @@ func (collector *ControllerMetricsCollector) updateQuotaResourcesUsed(kubeContro
 		}
 		existingResource.Used += resourceUsed
 	}
-}
-
-// Get hosting node CPU frequency.
-func (collector *ControllerMetricsCollector) getNodeCPUFrequency(pod *api.Pod) (float64, error) {
-	key := util.NodeKeyFromPodFunc(pod)
-	cpuFrequencyUID := metrics.GenerateEntityStateMetricUID(metrics.NodeType, key, metrics.CpuFrequency)
-	cpuFrequencyMetric, err := collector.metricsSink.GetMetric(cpuFrequencyUID)
-	if err != nil {
-		err := fmt.Errorf("failed to get cpu frequency from sink for node %s: %v", key, err)
-		return 0.0, err
-	}
-	cpuFrequency := cpuFrequencyMetric.GetValue().(float64)
-	return cpuFrequency, nil
 }

--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -11,7 +11,6 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
 	api "k8s.io/api/core/v1"
-	"math"
 	"time"
 )
 
@@ -162,7 +161,12 @@ func (d *SamplingDispatcher) ScheduleDispatch(nodes []*api.Node) {
 			select {
 			case <-d.samplingDone:
 				elapsedTime := time.Now().Sub(d.timestamp).Seconds()
-				samples := int(math.Min(float64(d.config.samples), float64(d.collectedSamples)))
+				var samples int
+				if d.config.samples < d.collectedSamples {
+					samples = d.config.samples
+				} else {
+					samples = d.collectedSamples
+				}
 				glog.V(2).Infof("Collected %v usage data samples from kubelet in %v seconds since last full discovery.", samples, elapsedTime)
 				d.collectedSamples = 0
 				return

--- a/pkg/discovery/worker/k8s_discovery_worker_test.go
+++ b/pkg/discovery/worker/k8s_discovery_worker_test.go
@@ -30,7 +30,7 @@ func TestBuildDTOsWithMissingMetrics(t *testing.T) {
 
 	currTask := task.NewTask().WithNodes([]*api.Node{node}).WithPods([]*api.Pod{pod})
 
-	_, _, _, err = worker.buildDTOs(currTask)
+	_, _, err = worker.buildDTOs(currTask)
 	if err != nil {
 		t.Errorf("Error while building DTOs: %v", err)
 	}

--- a/pkg/discovery/worker/result_collector.go
+++ b/pkg/discovery/worker/result_collector.go
@@ -15,14 +15,14 @@ type ResultCollector struct {
 }
 
 type DiscoveryResult struct {
-	EntityDTOs       []*proto.EntityDTO
-	NamespaceMetrics []*repository.NamespaceMetrics
-	EntityGroups     []*repository.EntityGroup
-	KubeControllers  []*repository.KubeController
-	ContainerSpecs   []*repository.ContainerSpec
-	PodEntitiesMap   map[string]*repository.KubePod
-	SuccessCount     int
-	ErrorCount       int
+	EntityDTOs           []*proto.EntityDTO
+	NamespaceMetrics     []*repository.NamespaceMetrics
+	EntityGroups         []*repository.EntityGroup
+	KubeControllers      []*repository.KubeController
+	ContainerSpecMetrics []*repository.ContainerSpecMetrics
+	PodEntitiesMap       map[string]*repository.KubePod
+	SuccessCount         int
+	ErrorCount           int
 }
 
 func NewResultCollector(maxWorkerNumber int) *ResultCollector {
@@ -67,7 +67,7 @@ func (rc *ResultCollector) Collect(count int) *DiscoveryResult {
 					// K8s controller data from different workers
 					result.KubeControllers = append(result.KubeControllers, taskResult.KubeControllers()...)
 					// ContainerSpecs with individual container replica commodities data from different discovery workers
-					result.ContainerSpecs = append(result.ContainerSpecs, taskResult.ContainerSpecs()...)
+					result.ContainerSpecMetrics = append(result.ContainerSpecMetrics, taskResult.ContainerSpecMetrics()...)
 				}
 				wg.Done()
 			}


### PR DESCRIPTION
JIRA: https://vmturbo.atlassian.net/browse/OM-61197

**Intent**:
Update utilization data for container spec entity based on collected multiple usage data samples.

**Background**:
1. New sampling discoveries have been introduced to collect more usage data samples for VM, Pod, Container and ApplicationComponent by scraping kubelet more frequently.
2. Resource usage and peak data for the entity types above are calculated based the additional data samples.

This PR is the last major change to support more frequent data samples in kubeturbo to update utilization data of container spec entities by making using of the collected multiple data samples so as to provide more precise container resizing recommendations.

**Implementation**:
1. Change `ContainerSpec` struct to `ContainerSpecMetrics` struct with `ContainerMetrics` struct to represent the object for collecting container spec metrics with multiple container replicas metrics data points.
2. Remove the logic of creating `ContainerSpec` objects in `container_dto_builder.go`.
3. Create new `container_spec_metrics_collector.go` to collect resource capacity value and multiple resource usage data points for container replicas in each full discovery worker.
4. Combine `ContainerMetrics` used data points which belong to the same ContainerSpecMetrics discovered from different full discovery workers in `container_spec_discovery_worker.go`.
5. Update the logic in `container_spec_entity_dto_builder.go` to construct utilization data of container spec entity dto with multiple data samples in stead of one data sample.
6. Update `container_usage_data_aggregator.go` and `container_utilization_data_aggregator.go` to pass in `ContainerMetrics` with multiple usage data samples and aggregate usage/utilization data. By default usage data is the average of all collected container replicas usage of the same container spec, and utilization data points contains all container replicas usage data samples since last full discovery.
7. Change the resource metric value from `metrics.Points` to `[]metrics.Point` where each `metrics.Point` contains usage value and timestamp when the usage value is collected.

**Unit Tests**:
Updated unit tests and all tests are passed.

**Testing Done**:
**1. For **VIrtualMachine** commodity data**,

- 1.1 Before the whole changes of data sampling, here's a VM entity dto:
```
entityDTO {
  entityType: VIRTUAL_MACHINE
  id: "3c2910f0-2c62-4d57-a13d-569081f6aa17"
  displayName: "pt-k8s-master-2"
  commoditiesSold {
    commodityType: VCPU
    used: 1287.164931884286
    capacity: 10655.112
    peak: 1287.164931884286
    resizable: false
  }
  commoditiesSold {
    commodityType: VMEM
    used: 3230584.0
    capacity: 1.6398004E7
    peak: 3230584.0
    resizable: false
  }
```
where used and peak are always the same for resource commodities.

- 1.2 After the whole changes of data sampling, here's the corresponding VM entity dto:
```
entityDTO {
  entityType: VIRTUAL_MACHINE
  id: "3c2910f0-2c62-4d57-a13d-569081f6aa17"
  displayName: "pt-k8s-master-2"
  commoditiesSold {
    commodityType: VCPU
    used: 1196.5503725508838
    capacity: 10655.112
    peak: 1611.33108609876
    resizable: false
  }
  commoditiesSold {
    commodityType: VMEM
    used: 3234180.8
    capacity: 1.6398004E7
    peak: 3235072.0
    resizable: false
  }
```
where peak is differentiated from used value for resource commodities.

---
**2. For ContainerPod commodity data**,

- 2.1 Before the whole changes of data sampling, here's a pod entity dto:
```
entityDTO {
  entityType: CONTAINER_POD
  id: "3eea40ac-1b85-48e7-9e94-9f4e02c91c29"
  displayName: "turbo/kubeturbo-arsen-upgrade-644fc4db7c-w2fkj"
  commoditiesSold {
    commodityType: VCPU
    used: 0.814953577542
    capacity: 15982.667999999998
    peak: 0.814953577542
    resizable: false
  }
  commoditiesSold {
    commodityType: VMEM
    used: 20588.0
    capacity: 1.6397588E7
    peak: 20588.0
    resizable: false
  }
```
where used and peak are always the same.

- 2.2 After the changes, here's the corresponding pod entity dto:
```
entityDTO {
  entityType: CONTAINER_POD
  id: "3eea40ac-1b85-48e7-9e94-9f4e02c91c29"
  displayName: "turbo/kubeturbo-arsen-upgrade-644fc4db7c-w2fkj"
  commoditiesSold {
    commodityType: VCPU
    used: 2.8786322067906
    capacity: 15982.667999999998
    peak: 20.492433498887998
    resizable: false
  }
  commoditiesSold {
    commodityType: VMEM
    used: 20508.8
    capacity: 1.6397588E7
    peak: 20516.0
    resizable: false
  }
```
where used and peak values are different.

---
**3. For Container commodity data**,

- 3.1 Before changes:
```
entityDTO {
  entityType: CONTAINER
  id: "0f65d4d3-2c32-4f69-9f32-a4597ccc5c95-1"
  displayName: "monitoring/node-exporter-s5ntq/kube-rbac-proxy"
  commoditiesSold {
    commodityType: VCPU
    used: 1.0836168990659998
    capacity: 53.27556
    peak: 1.0836168990659998
    resizable: true
  }
  commoditiesSold {
    commodityType: VMEM
    used: 16696.0
    capacity: 40960.0
    peak: 16696.0
    resizable: true
  }
  commoditiesSold {
    commodityType: VCPU_REQUEST
    used: 1.0836168990659998
    capacity: 26.63778
    peak: 1.0836168990659998
    resizable: true
  }
  commoditiesSold {
    commodityType: VMEM_REQUEST
    used: 16696.0
    capacity: 20480.0
    peak: 16696.0
    resizable: true
  }
```

- 3.2 After changes:
```
entityDTO {
  entityType: CONTAINER
  id: "0f65d4d3-2c32-4f69-9f32-a4597ccc5c95-1"
  displayName: "monitoring/node-exporter-s5ntq/kube-rbac-proxy"
  commoditiesSold {
    commodityType: VCPU
    used: 1.2692060416151998
    capacity: 53.27556
    peak: 2.958932593734
    resizable: true
  }
  commoditiesSold {
    commodityType: VMEM
    used: 16559.2
    capacity: 40960.0
    peak: 16604.0
    resizable: true
  }
  commoditiesSold {
    commodityType: VCPU_REQUEST
    used: 1.2692060416151998
    capacity: 26.63778
    peak: 2.958932593734
    resizable: true
  }
  commoditiesSold {
    commodityType: VMEM_REQUEST
    used: 16559.2
    capacity: 20480.0
    peak: 16604.0
    resizable: true
  }
```

---
**4. For ApplicationComponent commodity data**,

- 4.1 Before changes:
```
entityDTO {
  entityType: APPLICATION_COMPONENT
  id: "App-e5516272-4240-431a-8d0e-e1b83a996e7e-2"
  displayName: "App-monitoring/prometheus-k8s-1/rules-configmap-reloader"
  commoditiesBought {
    providerId: "e5516272-4240-431a-8d0e-e1b83a996e7e-2"
    bought {
      commodityType: VCPU
      used: 0.006081405173999999
      peak: 0.006081405173999999
    }
    bought {
      commodityType: VMEM
      used: 5168.0
      peak: 5168.0
    }
```

- 4.2 After changes:
```
entityDTO {
  entityType: APPLICATION_COMPONENT
  id: "App-e5516272-4240-431a-8d0e-e1b83a996e7e-2"
  displayName: "App-monitoring/prometheus-k8s-1/rules-configmap-reloader"
  commoditiesSold {
    commodityType: APPLICATION
    key: "cb248341-ffc4-4a80-8513-1152977ba611-2"
    capacity: 100000.0
  }
  commoditiesBought {
    providerId: "e5516272-4240-431a-8d0e-e1b83a996e7e-2"
    bought {
      commodityType: VCPU
      used: 0.014935004112599999
      peak: 0.14370815932199998
    }
    bought {
      commodityType: VMEM
      used: 5186.4
      peak: 5192.0
    }
```

---
**5. For ContainerSpec entity**

- 5.1 Before changes, here's entity dto of a ContainerSpec with one container replica:
```
entityDTO {
  entityType: CONTAINER_SPEC
  id: "0761a65a-7f2f-49df-9f2f-5b86024791f4/prometheus"
  displayName: "prometheus"
  commoditiesSold {
    commodityType: VCPU
    used: 162.77071941093598
    capacity: 15982.667999999998
    peak: 162.77071941093598
    active: true
    resizable: true
    utilizationData {
      point: 1.0184202
      lastPointTimestampMs: 1597196174149
      intervalMs: 0
    }
  }
  commoditiesSold {
    commodityType: VMEM
    used: 637196.0
    capacity: 1.6397572E7
    peak: 637196.0
    active: true
    resizable: true
    utilizationData {
      point: 3.8859167686533103
      lastPointTimestampMs: 1597196174149
      intervalMs: 0
    }
  }
```
where used and peak values are same and utilizationData has only one point.

- 5.2 After changes, here's the corresponding entity dto of the ContainerSpec with one container replica:
```
entityDTO {
  entityType: CONTAINER_SPEC
  id: "0761a65a-7f2f-49df-9f2f-5b86024791f4/prometheus"
  displayName: "prometheus"
  commoditiesSold {
    commodityType: VCPU
    used: 213.1093339071918
    capacity: 15982.667999999998
    peak: 380.551845511266
    active: true
    resizable: true
    utilizationData {
      point: 0.8913513
      point: 0.86388245
      point: 1.8296162833333334
      point: 1.2034350333333335
      point: 2.2074865999999997
      point: 1.1176684
      point: 1.0257308833333334
      point: 0.9222266499999999
      point: 2.3810282833333334
      point: 0.8913513
      lastPointTimestampMs: 1597195063836
      intervalMs: 53305
    }
  }
  commoditiesSold {
    commodityType: VMEM
    used: 633227.6
    capacity: 1.6397572E7
    peak: 637604.0
    active: true
    resizable: true
    utilizationData {
      point: 3.8884049419023743
      point: 3.8496918934095854
      point: 3.8509359800341176
      point: 3.85071643533567
      point: 3.8504724967818404
      point: 3.8506188599141384
      point: 3.8511067370217984
      point: 3.8503261336495425
      point: 3.8864778273271186
      point: 3.8884049419023743
      lastPointTimestampMs: 1597195063836
      intervalMs: 53305
    }
  }
```
where used and peak values are different, and there are 10 data points in utilization data with intervalMs 53331 milliseconds (53 seconds which is around 1 mins)