### PR TITLE
Skip the container specs if not found in parents or pods specs

### DIFF
--- a/pkg/action/executor/k8s_controller.go
+++ b/pkg/action/executor/k8s_controller.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"fmt"
+
 	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
 
 	apicorev1 "k8s.io/api/core/v1"
@@ -26,8 +27,9 @@ type k8sController interface {
 // - podSpec: The pod template of a controller to update for consistent resize
 // Note: Use pointer for in-place update
 type k8sControllerSpec struct {
-	replicas *int32
-	podSpec  *apicorev1.PodSpec
+	replicas       *int32
+	podSpec        *apicorev1.PodSpec
+	controllerName string
 }
 
 type parentController struct {
@@ -63,8 +65,9 @@ func (c *parentController) get(name string) (*k8sControllerSpec, error) {
 	c.obj = obj
 	int32Replicas := int32(replicas)
 	return &k8sControllerSpec{
-		replicas: &int32Replicas,
-		podSpec:  &podSpec,
+		replicas:       &int32Replicas,
+		podSpec:        &podSpec,
+		controllerName: fmt.Sprintf("%s-%s", kind, objName),
 	}, nil
 }
 

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -163,7 +163,7 @@ func (c *k8sControllerUpdater) reconcile(current *k8sControllerSpec, desired *co
 	}
 	glog.V(4).Infof("Try to update resources for container indexes: %s in pod %v/%v's spec.",
 		indexes, c.namespace, c.podName)
-	updated, err := updateResourceAmount(current.podSpec, desired.resizeSpecs)
+	updated, err := updateResourceAmount(current.podSpec, desired.resizeSpecs, current.controllerName)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Fixes https://vmturbo.atlassian.net/browse/OM-61698.
This will skip the sidecar container, in turn letting the action succeed. The drawback would be that if the sidecar container is also using limits/resources and action is on that, it won't be changed.