### PR TITLE
Add pod move support for pods with persistent volumes

### DIFF
--- a/pkg/action/executor/constants.go
+++ b/pkg/action/executor/constants.go
@@ -8,6 +8,9 @@ const (
 	defaultRetryLess = 3
 	defaultRetryMore = 55
 
+	defaultRetrySleepInterval = time.Second * 3
+	defaultRetryShortTimeout  = time.Second * 10
+
 	defaultWaitLockTimeOut = time.Second * 300
 	defaultWaitLockSleep   = time.Second * 10
 

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -36,7 +36,7 @@ type controllerSpec struct {
 // newK8sControllerUpdaterViaPod returns a k8sControllerUpdater based on the parent kind of a pod
 func newK8sControllerUpdaterViaPod(clusterScraper *cluster.ClusterScraper, pod *api.Pod, ormClient *resourcemapping.ORMClient) (*k8sControllerUpdater, error) {
 	// Find parent kind of the pod
-	kind, name, _, err := clusterScraper.GetPodGrandparentInfo(pod)
+	kind, name, _, _, _, err := clusterScraper.GetPodGrandparentInfo(pod, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get parent info of pod %s/%s: %v", pod.Namespace, pod.Name, err)
 	}

--- a/pkg/action/executor/move_util.go
+++ b/pkg/action/executor/move_util.go
@@ -1,13 +1,19 @@
 package executor
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/action/util"
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	podutil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	commonutil "github.com/turbonomic/kubeturbo/pkg/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,23 +77,34 @@ func genNewPodName(oldPod *api.Pod) string {
 }
 
 // Move pod to node nodeName in four steps:
-//  step1: create a clone pod of the original pod (without labels)
-//  step2: wait until the cloned pod is ready
-//  step3: delete the original pod
-//  step4: add the labels to the cloned pod
-func movePod(client *kclient.Clientset, pod *api.Pod, nodeName string, retryNum int) (*api.Pod, error) {
-	podClient := client.CoreV1().Pods(pod.Namespace)
+//  stepA1: create a clone pod of the original pod (without labels)
+//  stepA2: wait until the cloned pod is ready
+//  stepA3: delete the original pod
+//  stepA4: add the labels to the cloned pod
+// If a pod has a persistent volume attached the steps are different:
+//  stepB1: create a clone pod of the original pod (without labels)
+//  stepB2: if the parent has parent (rs has deployment) pause the rollout
+//  stepB3: change the scheduler of parent to non-default (turbo-scheduler)
+//  stepB4: delete the original pod
+//  stepB5: wait until the cloned pod is ready
+//  stepB6: add the labels to the cloned pod
+//  stepB7: change the scheduler of parent back to to default-scheduler
+//  stepB8: if the parent has parent, unpause the rollout
+// TODO: add support for operator controlled parent or parent's parent.
+func movePod(clusterScraper *cluster.ClusterScraper, pod *api.Pod, nodeName,
+	parentKind, parentName string, retryNum int) (*api.Pod, error) {
+	podClient := clusterScraper.Clientset.CoreV1().Pods(pod.Namespace)
 	//NOTE: do deep-copy if the original pod may be modified outside this function
 	labels := pod.Labels
 
-	//1. create a clone pod--podC of the original pod--podA
-	npod, err := createClonePod(client, pod, nodeName)
+	//step A1/B1. create a clone pod--podC of the original pod--podA
+	npod, err := createClonePod(clusterScraper.Clientset, pod, nodeName)
 	if err != nil {
 		glog.Errorf("Move pod failed: failed to create a clone pod: %v", err)
 		return nil, err
 	}
 
-	//delete the clone pod if this action fails
+	//delete the clone pod if any of the below action fails
 	flag := false
 	defer func() {
 		if !flag {
@@ -97,22 +114,77 @@ func movePod(client *kclient.Clientset, pod *api.Pod, nodeName string, retryNum 
 		}
 	}()
 
-	//2 wait until podC gets ready
-	err = podutil.WaitForPodReady(client, npod.Namespace, npod.Name, nodeName,
+	podUsingVolume := isPodUsingVolume(pod)
+	// Special handling for pods with volumes
+	if podUsingVolume {
+		// We still support replicaset and replication controllers as parents,
+		// however both of them could further have a parent (deploy or deploy config).
+		parent, grandParent, pClient, gPClient, gPKind, err :=
+			getParentAndGrandParentInfo(clusterScraper, pod, parentKind)
+		if err != nil {
+			return nil, err
+		}
+
+		if grandParent != nil {
+			pause := true
+			unpause := false
+			// step B8: (via defer)
+			defer func() {
+				glog.V(3).Infof("Unpausing pods controller: %s for pod: %s", gPKind, pod.Name)
+				resourceRollout(gPClient, grandParent, unpause)
+			}()
+
+			// step B2:
+			glog.V(3).Infof("Pausing pods controller: %s for pod: %s", gPKind, pod.Name)
+			err := resourceRollout(gPClient, grandParent, pause)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		valid := true
+		invalid := false
+		// step B7: (via defer)
+		defer func() {
+			glog.V(3).Infof("Updating scheduler of %s for pod %s back to default.", parentKind, pod.Name)
+			changeScheduler(pClient, parent, valid)
+
+		}()
+		// step B3:
+		glog.V(3).Infof("Updating scheduler of %s for pod %s to unknown (turbo-scheduler).", parentKind, pod.Name)
+		changeScheduler(pClient, parent, invalid)
+
+		// step A3/B4:
+		// We optimistically delete the original pod (PodA), so that the new pod can
+		// bind to the volume.
+		// TODO: This is not an ideal way of doing things, and users should be
+		// encouraged to rather disable move actions on pods which use volumes
+		// via a config either in kubeturbo or driven from server UI.
+		delOpt := &metav1.DeleteOptions{}
+		if err := podClient.Delete(pod.Name, delOpt); err != nil {
+			glog.Errorf("Move pod warning: failed to delete original pod: %v", err)
+			return nil, err
+		}
+	}
+
+	//step A2/B5: wait until podC gets ready
+	err = podutil.WaitForPodReady(clusterScraper.Clientset, npod.Namespace, npod.Name, nodeName,
 		retryNum, defaultPodCreateSleep)
 	if err != nil {
 		glog.Errorf("Wait for cloned Pod ready timeout: %v", err)
 		return nil, err
 	}
 
-	//3. delete the original pod--podA
-	delOpt := &metav1.DeleteOptions{}
-	if err := podClient.Delete(pod.Name, delOpt); err != nil {
-		glog.Errorf("Move pod warning: failed to delete original pod: %v", err)
-		return nil, err
+	if !podUsingVolume {
+		// step A3: delete the original pod--podA
+		delOpt := &metav1.DeleteOptions{}
+		if err := podClient.Delete(pod.Name, delOpt); err != nil {
+			glog.Errorf("Move pod warning: failed to delete original pod: %v", err)
+			return nil, err
+		}
 	}
 
-	//4. add labels to podC
+	// step A4/B6: add labels to podC
 	xpod, err := podClient.Get(npod.Name, metav1.GetOptions{})
 	if err != nil {
 		glog.Errorf("Move pod failed: failed to get the cloned pod: %v", err)
@@ -130,6 +202,118 @@ func movePod(client *kclient.Clientset, pod *api.Pod, nodeName string, retryNum 
 
 	flag = true
 	return xpod, nil
+}
+
+func isPodUsingVolume(pod *api.Pod) bool {
+	for _, vol := range pod.Spec.Volumes {
+		// Exactly one of these would be non nil at a given point in time.
+		if vol.PersistentVolumeClaim != nil ||
+			// We do not currently have a mechanism to test below.
+			// Also the preferred way by any provider is now anyways
+			// via a persistent volume claim.
+			vol.GCEPersistentDisk != nil ||
+			vol.AWSElasticBlockStore != nil ||
+			vol.AzureDisk != nil ||
+			vol.CephFS != nil ||
+			vol.Cinder != nil ||
+			vol.PortworxVolume != nil ||
+			vol.StorageOS != nil ||
+			vol.VsphereVolume != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func getParentAndGrandParentInfo(clusterScraper *cluster.ClusterScraper, pod *api.Pod,
+	parentKind string) (*unstructured.Unstructured, *unstructured.Unstructured,
+	dynamic.ResourceInterface, dynamic.ResourceInterface, string, error) {
+	gPkind, name, _, parent, nsParentClient, err := clusterScraper.GetPodGrandparentInfo(pod, false)
+	if err != nil {
+		return nil, nil, nil, nil, gPkind, fmt.Errorf("Error getting pods final owner: %v", err)
+	}
+
+	if gPkind != parentKind {
+		var res schema.GroupVersionResource
+		switch gPkind {
+		case commonutil.KindDeployment:
+			res = schema.GroupVersionResource{
+				Group:    commonutil.K8sAPIDeploymentGV.Group,
+				Version:  commonutil.K8sAPIDeploymentGV.Version,
+				Resource: commonutil.DeploymentResName}
+		case commonutil.KindDeploymentConfig:
+			res = schema.GroupVersionResource{
+				Group:    commonutil.OpenShiftAPIDeploymentConfigGV.Group,
+				Version:  commonutil.OpenShiftAPIDeploymentConfigGV.Version,
+				Resource: commonutil.DeploymentConfigResName}
+		default:
+			err = fmt.Errorf("Unsupported pods controller kind: %s while moving pod", gPkind)
+			glog.Error(err.Error())
+			return nil, nil, nil, nil, gPkind, err
+		}
+
+		nsGpClient := clusterScraper.DynamicClient.Resource(res).Namespace(pod.Namespace)
+		gParent, err := nsGpClient.Get(name, metav1.GetOptions{})
+		if err != nil {
+			glog.Errorf("Failed to get pods controller: %s[%v/%v]: %v", gPkind, pod.Namespace, name, err)
+			return nil, nil, nil, nil, gPkind, err
+		}
+		// TODO: add support for operator owned controllers.
+		// As of now we fail if we observe that grandparent has an owner (assuming its an operator)
+		// Actually a parent, eg. a replicaset although unlikely can also be controlled by an operator.
+		if len(gParent.GetOwnerReferences()) > 0 {
+			glog.Errorf("The parent's parent is probably controlled by an operator."+
+				"\nFailing podmove for %s[%v/%v]: %v", gPkind, pod.Namespace, name, err)
+			return nil, nil, nil, nil, gPkind, fmt.Errorf("failing pod move")
+		}
+		return parent, gParent, nsParentClient, nsGpClient, gPkind, nil
+	}
+
+	// This means that the parent itself is the final owner and there is
+	// no controller controlling the parent, i.e. no grand parent.
+	return nil, nil, nil, nil, "", nil
+}
+
+// resourceRollout pauses/unpauses the rollout of a deployment or a deploymentconfig
+func resourceRollout(client dynamic.ResourceInterface, obj *unstructured.Unstructured, pause bool) error {
+	// Avoid mutating the passed object
+	objCopy := obj.DeepCopy()
+	kind := obj.GetKind()
+	name := obj.GetName()
+	if err := unstructured.SetNestedField(objCopy.Object, pause, "spec", "paused"); err != nil {
+		return fmt.Errorf("error pausing %s %s: %v", kind, name, err)
+	}
+
+	_, err := client.Update(objCopy, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("error pausing %s %s: %v", kind, name, err)
+	}
+	return nil
+}
+
+// changeScheduler sets the scheduler value to default or unsets it to an invalid one
+func changeScheduler(client dynamic.ResourceInterface, obj *unstructured.Unstructured, valid bool) error {
+	objCopy := obj.DeepCopy()
+	kind := obj.GetKind()
+	name := obj.GetName()
+
+	if valid {
+		if err := unstructured.SetNestedField(objCopy.Object, "default-scheduler",
+			"spec", "template", "spec", "schedulerName"); err != nil {
+			return fmt.Errorf("error setting scheduler to default-scheduler for %s %s: %v", kind, name, err)
+		}
+	} else {
+		if err := unstructured.SetNestedField(objCopy.Object, "turbo-scheduler",
+			"spec", "template", "spec", "schedulerName"); err != nil {
+			return fmt.Errorf("error setting scheduler to unknown (turbo-scheduler) for %s %s: %v", kind, name, err)
+		}
+	}
+
+	_, err := client.Update(objCopy, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("error updating scheduler name for %s %s: %v", kind, name, err)
+	}
+	return nil
 }
 
 func createClonePod(client *kclient.Clientset, pod *api.Pod, nodeName string) (*api.Pod, error) {

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -324,8 +324,8 @@ func (s *ClusterScraper) GetPodGrandparentInfo(pod *api.Pod, ignoreCache bool) (
 			Resource: commonutil.ReplicationControllerResName}
 	case commonutil.KindReplicaSet:
 		res = schema.GroupVersionResource{
-			Group:    commonutil.K8sAPIDeploymentGV.Group,
-			Version:  commonutil.K8sAPIDeploymentGV.Version,
+			Group:    commonutil.K8sAPIReplicasetGV.Group,
+			Version:  commonutil.K8sAPIReplicasetGV.Version,
 			Resource: commonutil.ReplicaSetResName}
 	default:
 		s.cacheControllerInfo(podControllerInfoKey, kind, name, uid)
@@ -343,7 +343,7 @@ func (s *ClusterScraper) GetPodGrandparentInfo(pod *api.Pod, ignoreCache bool) (
 	rsOwnerReferences := obj.GetOwnerReferences()
 	if rsOwnerReferences != nil && len(rsOwnerReferences) > 0 {
 		gkind, gname, guid := util.ParseOwnerReferences(rsOwnerReferences)
-		if len(gkind) > 0 && len(gname) > 0 {
+		if len(gkind) > 0 && len(gname) > 0 && len(guid) > 0 {
 			s.cacheControllerInfo(podControllerInfoKey, kind, name, uid)
 			return gkind, gname, guid, obj, namespacedClient, nil
 		}

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -8,6 +8,7 @@ import (
 
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -286,26 +287,31 @@ func (s *ClusterScraper) GetPVCs(namespace string, opts metav1.ListOptions) ([]*
 	return pvcs, nil
 }
 
-// GetPodGrandparentInfo gets grandParent (parent's parent) information of a pod: kind, name and uid
-// If pod's parent does not have parent, then return pod's parent info.
+// GetPodGrandparentInfo gets grandParent (parent's parent) information of a pod: kind, name, uid
+// If parent does not have parent, then return parent info.
 // Note: if parent kind is "ReplicaSet", then its parent's parent can be a "Deployment"
 //       or if its a "ReplicationController" its parent could be "DeploymentConfig" (as in openshift).
-func (s *ClusterScraper) GetPodGrandparentInfo(pod *api.Pod) (string, string, string, error) {
-	// Get pod controller info from cache if exists
+// The function also returns the retrieved parent and parents crud interface for use by the callers.
+func (s *ClusterScraper) GetPodGrandparentInfo(pod *api.Pod, ignoreCache bool) (string, string,
+	string, *unstructured.Unstructured, dynamic.ResourceInterface, error) {
 	podControllerInfoKey := util.PodControllerInfoKey(pod)
-	controllerInfoCache, exists := s.cache.Get(podControllerInfoKey)
-	if exists {
-		controllerInfo, ok := controllerInfoCache.(kubeControllerInfo)
-		if !ok {
-			return "", "", "", fmt.Errorf("error getting controller info cache data: controllerInfoCache is '%t' not 'kubeControllerInfo'",
-				controllerInfoCache)
+	if !ignoreCache {
+		// Get pod controller info from cache if exists
+		controllerInfoCache, exists := s.cache.Get(podControllerInfoKey)
+		if exists {
+			controllerInfo, ok := controllerInfoCache.(kubeControllerInfo)
+			if !ok {
+				return "", "", "", nil, nil, fmt.Errorf("error getting controller info cache data: controllerInfoCache is '%t' not 'kubeControllerInfo'",
+					controllerInfoCache)
+			}
+			return controllerInfo.kind, controllerInfo.name, controllerInfo.uid, nil, nil, nil
 		}
-		return controllerInfo.kind, controllerInfo.name, controllerInfo.uid, nil
 	}
-	//1. get Parent info: kind, name and uid;
+
+	//1. get Parent info: kind and name;
 	kind, name, uid, err := util.GetPodParentInfo(pod)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", nil, nil, err
 	}
 
 	//2. if parent is "ReplicaSet" or "ReplicationController", check parent's parent
@@ -318,30 +324,33 @@ func (s *ClusterScraper) GetPodGrandparentInfo(pod *api.Pod) (string, string, st
 			Resource: commonutil.ReplicationControllerResName}
 	case commonutil.KindReplicaSet:
 		res = schema.GroupVersionResource{
-			Group:    commonutil.K8sAPIReplicasetGV.Group,
-			Version:  commonutil.K8sAPIReplicasetGV.Version,
+			Group:    commonutil.K8sAPIDeploymentGV.Group,
+			Version:  commonutil.K8sAPIDeploymentGV.Version,
 			Resource: commonutil.ReplicaSetResName}
 	default:
 		s.cacheControllerInfo(podControllerInfoKey, kind, name, uid)
-		return kind, name, uid, nil
+		return kind, name, uid, nil, nil, nil
 	}
 
-	obj, err := s.DynamicClient.Resource(res).Namespace(pod.Namespace).Get(name, metav1.GetOptions{})
+	namespacedClient := s.DynamicClient.Resource(res).Namespace(pod.Namespace)
+	obj, err := namespacedClient.Get(name, metav1.GetOptions{})
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to get %s[%v/%v]: %v", kind, pod.Namespace, name, err)
+		err = fmt.Errorf("Failed to get %s[%v/%v]: %v", kind, pod.Namespace, name, err)
+		glog.Error(err.Error())
+		return "", "", "", nil, nil, err
 	}
 	//2.2 get parent's parent info by parsing ownerReferences:
 	rsOwnerReferences := obj.GetOwnerReferences()
 	if rsOwnerReferences != nil && len(rsOwnerReferences) > 0 {
 		gkind, gname, guid := util.ParseOwnerReferences(rsOwnerReferences)
-		if len(gkind) > 0 && len(gname) > 0 && len(guid) > 0 {
-			s.cacheControllerInfo(podControllerInfoKey, gkind, gname, guid)
-			return gkind, gname, guid, nil
+		if len(gkind) > 0 && len(gname) > 0 {
+			s.cacheControllerInfo(podControllerInfoKey, kind, name, uid)
+			return gkind, gname, guid, obj, namespacedClient, nil
 		}
 	}
 
 	s.cacheControllerInfo(podControllerInfoKey, kind, name, uid)
-	return kind, name, uid, nil
+	return kind, name, uid, obj, namespacedClient, nil
 }
 
 func (s *ClusterScraper) cacheControllerInfo(podControllerInfoKey, kind, name, uid string) {

--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -234,7 +234,7 @@ func (m *ClusterMonitor) getPodOwner(pod *api.Pod) (*PodOwner, error) {
 	key := util.PodKeyFunc(pod)
 	glog.V(4).Infof("begin to generate pod[%s]'s Owner metric.", key)
 
-	kind, parentName, uid, err := m.clusterClient.GetPodGrandparentInfo(pod)
+	kind, parentName, uid, _, _, err := m.clusterClient.GetPodGrandparentInfo(pod, false)
 	if err != nil {
 		return nil, fmt.Errorf("error getting pod owner: %v", err)
 	}

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -257,7 +257,6 @@ func ParseOwnerReferences(owners []metav1.OwnerReference) (string, string, strin
 // GetPodParentInfo gets parent information of a pod: kind, name, uid
 func GetPodParentInfo(pod *api.Pod) (string, string, string, error) {
 	//1. check ownerReferences:
-
 	if pod.OwnerReferences != nil && len(pod.OwnerReferences) > 0 {
 		kind, name, uid := ParseOwnerReferences(pod.OwnerReferences)
 		if len(kind) > 0 && len(name) > 0 {

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -164,7 +164,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 		config.DiscoverySamples, config.DiscoverySampleIntervalSec)
 
 	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.KubeletClient,
-		probeConfig.ClusterScraper, config.SccSupport, config.ORMClient)
+		probeConfig.ClusterScraper, config.SccSupport, config.ORMClient, config.failVolumePodMoves)
 
 	// Kubernetes Probe Registration Client
 	registrationClient := registration.NewK8sRegistrationClient(registrationClientConfig, config.tapSpec.K8sTargetConfig)

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -47,6 +47,8 @@ type Config struct {
 	containerUtilizationDataAggStrategy string
 	// Strategy to aggregate Container usage data on ContainerSpec entity
 	containerUsageDataAggStrategy string
+
+	failVolumePodMoves bool
 }
 
 func NewVMTConfig2() *Config {
@@ -159,5 +161,10 @@ func (c *Config) WithContainerUtilizationDataAggStrategy(containerUtilizationDat
 
 func (c *Config) WithContainerUsageDataAggStrategy(containerUsageDataAggStrategy string) *Config {
 	c.containerUsageDataAggStrategy = containerUsageDataAggStrategy
+	return c
+}
+
+func (c *Config) WithVolumePodMoveConfig(failVolumePodMoves bool) *Config {
+	c.failVolumePodMoves = failVolumePodMoves
 	return c
 }

--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -43,7 +43,7 @@ var _ = Describe("Action Executor", func() {
 
 			cluster.NewClusterScraper(kubeClient, dynamicClient)
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(kubeClient, dynamicClient), nil, nil)
+				cluster.NewClusterScraper(kubeClient, dynamicClient), nil, nil, true)
 
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 		}


### PR DESCRIPTION
This has turned out to be a large peice of work and also almost barely/hackably doable.
There are couple of things this PR doesn't do as of now and I intend to follow on:
- XL pods with volumes manged by operator are still not movable as this mechanism needs to update the parent and parents parent (both replicaset and deployment), in which deployment is controlled by operator and thus can be updated only via the operator. This is also doable but involves much more work where we will need to expose the deployments `spec.paused` field also from the operator in addition to setting up the code to update the operator via the operator resource mapping. Which also means that it won't work if the ORM is not already installed and CR setup with resource mapping together with the operator.
- The get pods parent and parent's parent methods are not neat and can be improved, I will at some point want to update them to something like a `podInfoGetter` in utils, which will support getting relevent info to relevant callers.

I would not want this to be this hacky, but I have this as the only feasible way of doing podmoves for a volume attached pod as of now (tried mutiple things). I might be missing something, so suggestions are certainly welcome. 

cc @enlinxu @esara 