### PR TITLE
Improve Kubeturbo discovery performance by caching pod ownerReferences during cluster monitoring

### DIFF
--- a/pkg/action/action_handler_test.go
+++ b/pkg/action/action_handler_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/turbonomic/kubeturbo/pkg/action/executor"
 	"github.com/turbonomic/kubeturbo/pkg/action/util"
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
 	"github.com/turbonomic/kubeturbo/pkg/turbostore"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
@@ -111,7 +112,7 @@ func newActionHandlerConfig() *ActionHandlerConfig {
 	config := &ActionHandlerConfig{}
 
 	config.StopEverything = make(chan struct{})
-	config.kubeClient = &client.Clientset{}
+	config.clusterScraper = cluster.NewClusterScraper(&client.Clientset{}, nil)
 	config.kubeletClient = &kubeclient.KubeletClient{}
 
 	return config

--- a/pkg/action/executor/action_executor.go
+++ b/pkg/action/executor/action_executor.go
@@ -3,11 +3,10 @@ package executor
 import (
 	"github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset"
 	"github.com/turbonomic/kubeturbo/pkg/action/util"
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	api "k8s.io/api/core/v1"
-	"k8s.io/client-go/dynamic"
-	kclient "k8s.io/client-go/kubernetes"
 )
 
 type TurboActionExecutorInput struct {
@@ -26,20 +25,18 @@ type TurboActionExecutor interface {
 }
 
 type TurboK8sActionExecutor struct {
-	kubeClient    *kclient.Clientset
-	dynamicClient dynamic.Interface
-	cApiClient    *clientset.Clientset
-	podManager    util.IPodManager
-	ormClient     *resourcemapping.ORMClient
+	clusterScraper *cluster.ClusterScraper
+	cApiClient     *clientset.Clientset
+	podManager     util.IPodManager
+	ormClient      *resourcemapping.ORMClient
 }
 
-func NewTurboK8sActionExecutor(kubeClient *kclient.Clientset, dynamicClient dynamic.Interface, cApiClient *clientset.Clientset,
+func NewTurboK8sActionExecutor(clusterScraper *cluster.ClusterScraper, cApiClient *clientset.Clientset,
 	podManager util.IPodManager, ormSpec *resourcemapping.ORMClient) TurboK8sActionExecutor {
 	return TurboK8sActionExecutor{
-		kubeClient:    kubeClient,
-		dynamicClient: dynamicClient,
-		cApiClient:    cApiClient,
-		podManager:    podManager,
-		ormClient:     ormSpec,
+		clusterScraper: clusterScraper,
+		cApiClient:     cApiClient,
+		podManager:     podManager,
+		ormClient:      ormSpec,
 	}
 }

--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -30,7 +30,7 @@ func (h *HorizontalScaler) Execute(input *TurboActionExecutorInput) (*TurboActio
 		return nil, err
 	}
 	//2. Prepare controllerUpdater
-	controllerUpdater, err := newK8sControllerUpdaterViaPod(h.kubeClient, h.dynamicClient, pod, h.ormClient)
+	controllerUpdater, err := newK8sControllerUpdaterViaPod(h.clusterScraper, pod, h.ormClient)
 	if err != nil {
 		glog.Errorf("Failed to create controllerUpdater: %v", err)
 		return &TurboActionExecutorOutput{}, err

--- a/pkg/action/executor/machine_scale_executor.go
+++ b/pkg/action/executor/machine_scale_executor.go
@@ -48,7 +48,7 @@ func (s *MachineActionExecutor) Execute(vmDTO *TurboActionExecutorInput) (*Turbo
 	}
 	// Get on with it.
 	controller, key, err := newController(s.cAPINamespace, nodeName, diff, actionType,
-		s.executor.cApiClient, s.executor.kubeClient)
+		s.executor.cApiClient, s.executor.clusterScraper.Clientset)
 	if err != nil {
 		return nil, err
 	} else if key == nil {

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -69,21 +69,21 @@ func (r *ReScheduler) getNode(action *proto.ActionItemDTO) (*api.Node, error) {
 	}
 
 	//3. get node from properties
-	node, err := util.GetNodeFromProperties(r.kubeClient, hostSE.GetEntityProperties())
+	node, err := util.GetNodeFromProperties(r.clusterScraper.Clientset, hostSE.GetEntityProperties())
 	if err == nil {
 		glog.V(2).Infof("Get node(%v) from properties.", node.Name)
 		return node, nil
 	}
 
 	//4. get node by displayName
-	node, err = util.GetNodebyName(r.kubeClient, hostSE.GetDisplayName())
+	node, err = util.GetNodebyName(r.clusterScraper.Clientset, hostSE.GetDisplayName())
 	if err == nil {
 		glog.V(2).Infof("Get node(%v) by displayName.", node.Name)
 		return node, nil
 	}
 
 	//5. get node by UUID
-	node, err = util.GetNodebyUUID(r.kubeClient, hostSE.GetId())
+	node, err = util.GetNodebyUUID(r.clusterScraper.Clientset, hostSE.GetId())
 	if err == nil {
 		glog.V(2).Infof("Get node(%v) by UUID(%v).", node.Name, hostSE.GetId())
 		return node, nil
@@ -92,15 +92,15 @@ func (r *ReScheduler) getNode(action *proto.ActionItemDTO) (*api.Node, error) {
 	//6. get node by IP
 	vmIPs := getVMIps(hostSE)
 	if len(vmIPs) > 0 {
-		node, err = util.GetNodebyIP(r.kubeClient, vmIPs)
+		node, err = util.GetNodebyIP(r.clusterScraper.Clientset, vmIPs)
 		if err == nil {
 			glog.V(2).Infof("Get node(%v) by IP.", hostSE.GetDisplayName())
 			return node, nil
 		}
-		err = fmt.Errorf("Failed to get node %s by IP %+v: %v",
+		err = fmt.Errorf("failed to get node %s by IP %+v: %v",
 			hostSE.GetDisplayName(), vmIPs, err)
 	} else {
-		err = fmt.Errorf("Failed to get node %s: IPs are empty",
+		err = fmt.Errorf("failed to get node %s: IPs are empty",
 			hostSE.GetDisplayName())
 	}
 	glog.Errorf("%v.", err)
@@ -178,7 +178,7 @@ func (r *ReScheduler) reSchedule(pod *api.Pod, node *api.Node) (*api.Pod, error)
 	}
 
 	//2. move
-	return movePod(r.kubeClient, pod, nodeName, defaultRetryMore)
+	return movePod(r.clusterScraper.Clientset, pod, nodeName, defaultRetryMore)
 }
 
 func getVMIps(entity *proto.EntityDTO) []string {

--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -71,7 +71,7 @@ func NewContainerResizer(ae TurboK8sActionExecutor, kubeletClient *kubeclient.Ku
 // get node cpu frequency, in MHz;
 func (r *ContainerResizer) getNodeCPUFrequency(host string) (float64, error) {
 	// always access kubelet via node IP
-	node, err := util.GetNodebyName(r.kubeClient, host)
+	node, err := util.GetNodebyName(r.clusterScraper.Clientset, host)
 	if err != nil {
 		return 1, fmt.Errorf("failed to get node by name: %v", err)
 	}
@@ -246,8 +246,7 @@ func (r *ContainerResizer) Execute(input *TurboActionExecutorInput) (*TurboActio
 
 	// execute the Action
 	npod, err := resizeContainer(
-		r.kubeClient,
-		r.dynamicClient,
+		r.clusterScraper,
 		pod,
 		spec,
 		actionItem.GetConsistentScalingCompliance(),

--- a/pkg/discovery/configs/probe_config.go
+++ b/pkg/discovery/configs/probe_config.go
@@ -1,11 +1,10 @@
 package configs
 
 import (
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 )
 
 type ProbeConfig struct {
@@ -15,10 +14,8 @@ type ProbeConfig struct {
 	// Config for one or more monitoring clients
 	MonitoringConfigs []monitoring.MonitorWorkerConfig
 
-	// Rest Client for the kubernetes server API
-	ClusterClient *kubernetes.Clientset
-	// Dynamic client for the kubernetes server API
-	DynamicClient dynamic.Interface
+	// ClusterScraper contains rest client (ClientSet) and dynamic client (DynamicClient) for the kubernetes server API
+	ClusterScraper *cluster.ClusterScraper
 	// Rest Client for the kubelet module in each node
 	NodeClient *kubeclient.KubeletClient
 }

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -101,7 +101,7 @@ type K8sDiscoveryClient struct {
 }
 
 func NewK8sDiscoveryClient(config *DiscoveryClientConfig) *K8sDiscoveryClient {
-	k8sClusterScraper := cluster.NewClusterScraper(config.probeConfig.ClusterClient, config.probeConfig.DynamicClient)
+	k8sClusterScraper := config.probeConfig.ClusterScraper
 
 	// for discovery tasks
 	clusterProcessor := processor.NewClusterProcessor(k8sClusterScraper, config.probeConfig.NodeClient,

--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -2,6 +2,7 @@ package master
 
 import (
 	"fmt"
+	client "k8s.io/client-go/kubernetes"
 	"testing"
 
 	"github.com/golang/glog"
@@ -146,7 +147,7 @@ func TestGenNodeResourceMetrics(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to create clusterMonitor: %v", err)
 	}
-	clusterMonitor.clusterClient = &cluster.ClusterScraper{}
+	clusterMonitor.clusterClient = cluster.NewClusterScraper(&client.Clientset{}, nil)
 	clusterMonitor.sink = metrics.NewEntityMetricSink()
 	clusterMonitor.nodeList = []*api.Node{node}
 	clusterMonitor.nodePodMap = make(map[string][]*api.Pod)

--- a/pkg/discovery/monitoring/master/config.go
+++ b/pkg/discovery/monitoring/master/config.go
@@ -3,19 +3,15 @@ package master
 import (
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
-	"k8s.io/client-go/dynamic"
-
-	"k8s.io/client-go/kubernetes"
 )
 
 type ClusterMonitorConfig struct {
 	clusterInfoScraper *cluster.ClusterScraper
 }
 
-func NewClusterMonitorConfig(kclient *kubernetes.Clientset, dynamicClient dynamic.Interface) *ClusterMonitorConfig {
-	k8sClusterScraper := cluster.NewClusterScraper(kclient, dynamicClient)
+func NewClusterMonitorConfig(clusterScraper *cluster.ClusterScraper) *ClusterMonitorConfig {
 	return &ClusterMonitorConfig{
-		clusterInfoScraper: k8sClusterScraper,
+		clusterInfoScraper: clusterScraper,
 	}
 }
 

--- a/pkg/discovery/util/key_func.go
+++ b/pkg/discovery/util/key_func.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	appIdPrefix = "App"
+	appIdPrefix             = "App"
+	controllerInfoKeyPrefix = "controllerInfo"
 )
 
 func PodMetricId(pod *stats.PodReference) string {
@@ -123,4 +124,8 @@ func PodVolumeMetricId(podKey, volName string) string {
 
 func VolumeKeyFunc(vol *api.PersistentVolume) string {
 	return vol.Name
+}
+
+func PodControllerInfoKey(pod *api.Pod) string {
+	return fmt.Sprintf("%s-%s", controllerInfoKeyPrefix, string(pod.UID))
 }


### PR DESCRIPTION
JIRA: https://vmturbo.atlassian.net/browse/OM-61188

**Intent**:
In cluster monitoring, we invoke api call in every discover for pod owner info, which is actually very expensive. We should introduce cache for those metadata kind of information, to avoid repeated api call without new information.

**Implementation**:
1. In `cluster_info_scraper.go`, create a `cache`(`turbostore.ITurboCache` type) in `ClusterScraper` struct with expiration duration as `defaultCacheTTL` (24 hours). `TurboCache` is an existing struct which makes use of cache library https://github.com/patrickmn/go-cache. The cached data will be cleaned up after `defaultCacheTTL` (24 hours). Meanwhile the lock inside go-cache library is a `sync.RWMutex`, which is very efficient in the case where there are more reads than writes.
2. Move the main logic from `GetPodGrandInfo` func in `pod_util` to `GetPodGrandparentInfo` in `cluster_info_scraper`. And use cache data inside `GetPodGrandparentInfo` func if exists.
3. There are 2 places which call `GetPodGrandparentInfo` func: 1) `ClusterMonitor::getPodOwner` in `cluster_monitor` and 2)`newK8sControllerUpdaterViaPod` func in `k8s_controller_updater`. Refactor the code to use the same `clusterScraper` (with the same cache) in both places.

**Testing Done**:

1. After the changes, controller kind is still shown correctly in UI:
<img width="1148" alt="Screen Shot 2020-08-17 at 01 43 04" src="https://user-images.githubusercontent.com/23689754/90361006-1c39ff80-e02b-11ea-8152-84b915d3d799.png">
And action on WorkloadController can still be executed successfully.

---
2. As for performance improvement, used [pprof](https://golang.org/pkg/net/http/pprof/) tool to profile CPU performance by running kubeturbo of cluster `K8s 1.18.5 in DC11` locally

**Environment**:
macOS
CPU: 2.5 GHz Intel Core i7

Before and after changes run such command:
```
go tool pprof http://127.0.0.1:10265/debug/pprof/profile?seconds=10
```
and then trigger a rediscovery to profile the runtime of each functions during discovery.

**Evidence**:
By repeating the above steps multiple times,
- before the change, `ClusterMonitor::Do` func runs around 30ms, where getPodOwner takes almost the whole 30ms:
```
      flat  flat%   sum%        cum   cum%
         0     0%   100%       30ms  7.32%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).Do
         0     0%   100%       30ms  7.32%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).RetrieveClusterStat
         0     0%   100%       30ms  7.32%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).findNodeStates
         0     0%   100%       30ms  7.32%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).genNodePodsMetrics
         0     0%   100%       30ms  7.32%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).genNodeResourceMetrics
         0     0%   100%       30ms  7.32%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).getPodOwner
```

- after the change, `ClusterMonitor::Do` func runs much faster with no more than 10 ms:
```
      flat  flat%   sum%        cum   cum%
         0     0%   100%       10ms  3.12%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).Do
         0     0%   100%       10ms  3.12%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).RetrieveClusterStat
         0     0%   100%       10ms  3.12%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).findNodeStates
         0     0%   100%       10ms  3.12%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).genNodePodsMetrics
         0     0%   100%       10ms  3.12%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).genNodeResourceMetrics
         0     0%   100%       10ms  3.12%  github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master.(*ClusterMonitor).genOwnerMetrics
```
where `getPodOwner` func runs much faster than 10ms (looks the functions less than 10 ms are not shown in the profiling results)