### PR TITLE
Add volume to vm relationship to show connection in unstitched env

### DIFF
--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -236,6 +236,9 @@ func (m *KubeletMonitor) parseVolumeStats(volStats []stats.VolumeStats, podKey s
 		// TODO: Generate used on etype pod and capacity on etype volume once
 		// etype volume is in place
 		m.genPVMetrics(metrics.PodType, volKey, capacity, used)
+		// We store the same metric against a virtual volume type to be used
+		// to build the buy sell relationship between nodes and volumes
+		m.genPVMetrics(metrics.VolumeType, volKey, capacity, used)
 
 		glog.V(4).Infof("Volume Usage of %s mounted by pod %s is %.3f Megabytes", volStat.Name, podKey, used)
 		glog.V(4).Infof("Volume Capacity of %s mounted by pod %s is %.3f Megabytes", volStat.Name, podKey, capacity)

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -28,6 +28,8 @@ type KubeCluster struct {
 	// Map of namespace qualified pod name wrt to the volumes they mount.
 	// This map will not feature volumes which are not mounted by any pods.
 	PodToVolumesMap map[string][]MountedVolume
+	// Map of node names to the attached volumes.
+	NodeToVolumesMap map[string][]NodeVolume
 }
 
 type PodVolume struct {
@@ -35,11 +37,25 @@ type PodVolume struct {
 	QualifiedPodName string
 	// Name used by the pod to mount the volume.
 	MountName string
+	// Name of the node this volume attaches to.
+	// This information is to avoid evaluating the pods node when needed
+	// or instead storing the whole pod spec/status here.
+	NodeName string
 }
 
+// Volumes info when mapping to a pod
 type MountedVolume struct {
 	UsedVolume *v1.PersistentVolume
 	MountName  string
+}
+
+// Volumes info when mapping to a node
+type NodeVolume struct {
+	MountedVolume
+	// Namespace qualified pod name this volume is used by.
+	// This facilitates retrieving volume usage metrics when needed for
+	// the node commodity data which actually come from the pod stats.
+	QualifiedPodName string
 }
 
 // Volume metrics reported for a given pod

--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -216,6 +216,7 @@ func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_Re
 		return nil, fmt.Errorf("stitching property type %s is not supported", s.stitchType)
 	}
 	usedAndCapacityPropertyNames := []string{builder.PropertyCapacity, builder.PropertyUsed}
+	usedAndPeakPropertyNames := []string{builder.PropertyUsed, builder.PropertyPeak}
 	vcpuUsedAndCapacityPropertyNames := []string{builder.PropertyCapacity, builder.PropertyUsed, builder.PropertyPeak}
 	capacityOnlyPropertyNames := []string{builder.PropertyCapacity}
 	replacementEntityMetaDataBuilder.PatchSellingWithProperty(proto.CommodityDTO_CLUSTER, capacityOnlyPropertyNames).
@@ -229,7 +230,8 @@ func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_Re
 		PatchSellingWithProperty(proto.CommodityDTO_VCPU_REQUEST_QUOTA, usedAndCapacityPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_VMEM_REQUEST_QUOTA, usedAndCapacityPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_NUMBER_CONSUMERS, usedAndCapacityPropertyNames).
-		PatchSellingWithProperty(proto.CommodityDTO_VSTORAGE, usedAndCapacityPropertyNames)
+		PatchSellingWithProperty(proto.CommodityDTO_VSTORAGE, usedAndCapacityPropertyNames).
+		PatchBuyingWithProperty(proto.CommodityDTO_STORAGE_AMOUNT, usedAndPeakPropertyNames)
 	meta := replacementEntityMetaDataBuilder.Build()
 	return meta, nil
 }

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -369,8 +369,10 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 	nodes := currTask.NodeList()
 	cluster := currTask.Cluster()
 	var podToVolsMap map[string][]repository.MountedVolume
+	var nodeToVolsMap map[string][]repository.NodeVolume
 	if cluster != nil {
 		podToVolsMap = cluster.PodToVolumesMap
+		nodeToVolsMap = cluster.NodeToVolumesMap
 	}
 
 	for _, node := range nodes {
@@ -384,7 +386,7 @@ func (worker *k8sDiscoveryWorker) buildDTOs(currTask *task.Task) ([]*proto.Entit
 
 	// 1. build entityDTOs for nodes
 	nodeEntityDTOBuilder := dtofactory.NewNodeEntityDTOBuilder(worker.sink, stitchingManager)
-	nodeEntityDTOs, err := nodeEntityDTOBuilder.BuildEntityDTOs(nodes)
+	nodeEntityDTOs, err := nodeEntityDTOBuilder.BuildEntityDTOs(nodes, nodeToVolsMap)
 	if err != nil {
 		glog.Errorf("Error while creating node entityDTOs: %v", err)
 		// TODO Node discovery fails, directly return?


### PR DESCRIPTION
This partly fixes https://vmturbo.atlassian.net/browse/OM-62195.
The commodity can also be stitched to reflect the used value against those reported for the virtual machine too. It does not work though. So if unstitched the vm will report right values, but after stitching vm shows used same as capacity. I think the stitching is useful and will try to figure out some way of doing that.