### PR TITLE
Store correct pod grand parent controller info in cache.

### DIFF
--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -344,7 +344,7 @@ func (s *ClusterScraper) GetPodGrandparentInfo(pod *api.Pod, ignoreCache bool) (
 	if rsOwnerReferences != nil && len(rsOwnerReferences) > 0 {
 		gkind, gname, guid := util.ParseOwnerReferences(rsOwnerReferences)
 		if len(gkind) > 0 && len(gname) > 0 && len(guid) > 0 {
-			s.cacheControllerInfo(podControllerInfoKey, kind, name, uid)
+			s.cacheControllerInfo(podControllerInfoKey, gkind, gname, guid)
 			return gkind, gname, guid, obj, namespacedClient, nil
 		}
 	}


### PR DESCRIPTION
JIRA: https://vmturbo.atlassian.net/browse/OM-62504

**Problem**:
After updating latest kubeturbo image, all Deployment WorkloadControllers are incorrectly discovered as ReplicaSet, where name, kind and UID are changed which furthermore causes changes of ContainerSpec ID and historical commodity data are lost on ContainerSpec.

**Diagnosis**:
It turns out that in @irfanurrehman's commit, there's an unexpected change in `GetPodGrandparentInfo` func in `cluster_info_scraper`: 
https://github.com/turbonomic/kubeturbo/pull/468/files#diff-2567a60b841bdac5b755686da05e2239R347

Looks this is an accident change during the merge. Sorry @irfanurrehman, I didn't notice this when reviewing your code.

When pod has parent and grand parent like pod -> ReplicaSet -> Deployment or pod -> ReplicationController -> DeploymentConfig, we use grand parent info as the controller of the pod. But in the accident change, pod parent info instead of grand parent info is incorrectly stored in the cache so that ReplicaSet is discovered as WorkloadController not Deployment.

**Solution**:
Store correct pod grand parent controller info into cache.

**Testing Done**:
Before the change, all Deployment WorkloadControllers were incorrectly discovered as ReplicaSet:
<img width="1366" alt="Screen Shot 2020-09-10 at 10 35 40" src="https://user-images.githubusercontent.com/23689754/92749989-a3da0c00-f354-11ea-9d5f-c4f58259611b.png">
After the change, all Deployment WorkloadController are correctly discovered as Deployment:
<img width="1361" alt="Screen Shot 2020-09-10 at 10 39 15" src="https://user-images.githubusercontent.com/23689754/92750054-b3f1eb80-f354-11ea-8d31-0c6490d64d21.png">
and historical data are back in the corresponding ContainerSpec:
<img width="1362" alt="Screen Shot 2020-09-10 at 11 01 17" src="https://user-images.githubusercontent.com/23689754/92750403-06330c80-f355-11ea-864e-d1eee1514947.png">
