### PR TITLE
Feature gates

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -2,6 +2,7 @@ package dtofactory
 
 import (
 	"fmt"
+
 	api "k8s.io/api/core/v1"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
@@ -9,10 +10,13 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/turbonomic/kubeturbo/pkg/features"
 	v1 "k8s.io/api/core/v1"
 
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/golang/glog"
 )
@@ -237,8 +241,10 @@ func (builder *podEntityDTOBuilder) buildDTOs(pods []*api.Pod, resCommTypeSold,
 			"Pod %v: controllable: %v, suspendable: %v, provisionable: %v, monitored: %v, power state %v",
 			displayName, controllable, suspendable, provisionable, monitored, powerState)
 
-		// Commodities bought from volume mounts
-		builder.buyCommoditiesFromVolumes(pod, mounts, entityDTOBuilder)
+		if utilfeature.DefaultFeatureGate.Enabled(features.PersistentVolumes) {
+			// Commodities bought from volume mounts
+			builder.buyCommoditiesFromVolumes(pod, mounts, entityDTOBuilder)
+		}
 		// entities' properties.
 		properties, err := builder.getPodProperties(pod, mounts)
 		if err != nil {

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -12,10 +12,13 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/turbonomic/kubeturbo/pkg/features"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 // KubeletMonitor is a resource monitoring worker.
@@ -216,7 +219,9 @@ func (m *KubeletMonitor) parsePodStats(podStats []stats.PodStats, timestamp int6
 		if m.isFullDiscovery {
 			m.genNumConsumersUsedMetrics(metrics.PodType, key)
 			m.genFSMetrics(metrics.PodType, key, ephemeralFsCapacity, ephemeralFsUsed)
-			m.parseVolumeStats(pod.VolumeStats, key)
+			if utilfeature.DefaultFeatureGate.Enabled(features.PersistentVolumes) {
+				m.parseVolumeStats(pod.VolumeStats, key)
+			}
 		}
 	}
 }

--- a/pkg/features/config.go
+++ b/pkg/features/config.go
@@ -1,17 +1,5 @@
 package features
 
-type FeatureGatesConfig struct {
-	Name          string            `json:"name"`
-	Configuration ConfigurationMode `json:"configuration"`
-}
-
-type ConfigurationMode string
-
-const (
-	ConfigurationEnabled  ConfigurationMode = "Enabled"
-	ConfigurationDisabled ConfigurationMode = "Disabled"
-)
-
 type FeatureGates struct {
-	Features []FeatureGatesConfig `json:"features,omitempty"`
+	DisabledFeatures []string `json:"disabledFeatures,omitempty"`
 }

--- a/pkg/features/config.go
+++ b/pkg/features/config.go
@@ -1,0 +1,17 @@
+package features
+
+type FeatureGatesConfig struct {
+	Name          string            `json:"name"`
+	Configuration ConfigurationMode `json:"configuration"`
+}
+
+type ConfigurationMode string
+
+const (
+	ConfigurationEnabled  ConfigurationMode = "Enabled"
+	ConfigurationDisabled ConfigurationMode = "Disabled"
+)
+
+type FeatureGates struct {
+	Features []FeatureGatesConfig `json:"features,omitempty"`
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -14,7 +14,7 @@ const (
 	// MyFeature featuregate.Feature = "MyFeature"
 
 	// owner: @irfanurrehman
-	// alpha:
+	// beta:
 	//
 	// Persistent volumes support.
 	PersistentVolumes utilfeature.Feature = "PersistentVolumes"

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,36 @@
+package features
+
+import (
+	"github.com/golang/glog"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+)
+
+const (
+	// Every feature gate should add method here following this template:
+	//
+	// // owner: @username
+	// // alpha:
+	// MyFeature featuregate.Feature = "MyFeature"
+
+	// owner: @irfanurrehman
+	// alpha:
+	//
+	// Persistent volumes support.
+	PersistentVolumes utilfeature.Feature = "PersistentVolumes"
+)
+
+func init() {
+	if err := utilfeature.DefaultFeatureGate.Add(DefaultKubeturboFeatureGates); err != nil {
+		glog.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+// DefaultKubeturboFeatureGates consists of all known kubeturbo-specific
+// feature keys.  To add a new feature, define a key for it above and
+// add it here.
+// Ref: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+// Note: We use the config to feed the values, not the command line params.
+var DefaultKubeturboFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
+	PersistentVolumes: {Default: true, PreRelease: utilfeature.Beta},
+}

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master"
+	"github.com/turbonomic/kubeturbo/pkg/features"
 	"github.com/turbonomic/kubeturbo/pkg/registration"
 	"github.com/turbonomic/turbo-go-sdk/pkg/probe"
 	"github.com/turbonomic/turbo-go-sdk/pkg/service"
@@ -35,6 +36,7 @@ type K8sTAPServiceSpec struct {
 	*detectors.MasterNodeDetectors    `json:"masterNodeDetectors,omitempty"`
 	*detectors.DaemonPodDetectors     `json:"daemonPodDetectors,omitempty"`
 	*detectors.HANodeConfig           `json:"HANodeConfig,omitempty"`
+	*features.FeatureGates            `json:"featureGates,omitempty"`
 }
 
 func ParseK8sTAPServiceSpec(configFile string, defaultTargetName string) (*K8sTAPServiceSpec, error) {


### PR DESCRIPTION
This adds a feature gating mechanism to kubeturbo.
Additionally keeps the persistent volumes feature gated, but enabled by default.
I have used the config in place of a command line flag as I personally feel that the command line flags are overflowing. We should probably think of moving more flags to config.