### PR TITLE
Copy pod spec from parent in pod move actions

### DIFF
--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -301,7 +301,7 @@ func clonePodWithNewSize(client *kclient.Clientset, pod *k8sapi.Pod, spec *conta
 
 	//1. copy pod
 	npod := &k8sapi.Pod{}
-	copyPodWithoutLabel(pod, npod)
+	copyPodWithoutLabel(pod, npod, true)
 	npod.Spec.NodeName = pod.Spec.NodeName
 	npod.Name = genNewPodName(pod)
 	// this annotation can be used for future garbage collection if action is interrupted


### PR DESCRIPTION
Solves https://vmturbo.atlassian.net/browse/OM-61699.
Additionally this copies podSpec always from the parents `spec/template/spec` into the new pods spec, as the pods are supposed to be created from the parents podSpec anyways.