### PR TITLE
Fix failed action merge execution

### DIFF
--- a/pkg/action/executor/workload_controller_resizer.go
+++ b/pkg/action/executor/workload_controller_resizer.go
@@ -153,16 +153,23 @@ func (r *WorkloadControllerResizer) getChildPod(parentKind, namespace, name stri
 	if err != nil {
 		return nil, err
 	}
+
+	noPodFoundError := fmt.Errorf("could not find any matching pod for %s %s/%s", parentKind, namespace, name)
 	if podsList == nil {
-		return nil, fmt.Errorf("could not find any matching pod for %s %s/%s", parentKind, namespace, name)
+		return nil, noPodFoundError
 	}
 	if len(podsList.Items) < 1 {
-		return nil, fmt.Errorf("could not find any matching pod for %s %s/%s", parentKind, namespace, name)
+		return nil, noPodFoundError
 	}
 
-	pod := podsList.Items[0]
-	//return the first matching pod
-	return &pod, err
+	for _, pod := range podsList.Items {
+		if pod.Spec.NodeName != "" {
+			// Return the first matching pod with a valid nodeName
+			return &pod, err
+		}
+	}
+
+	return nil, noPodFoundError
 
 }
 


### PR DESCRIPTION
Fixes https://vmturbo.atlassian.net/browse/OM-62724.
The original pod did not consider possibility of pods which won't have a valid nodename assigned, for example pending pods.