### PR TITLE
Correct aggregated commodity capacity on ContainerSpec.

### DIFF
--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
@@ -21,21 +21,21 @@ func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
 		ContainerReplicas: 2,
 		ContainerMetrics: map[metrics.ResourceType]*repository.ContainerMetrics{
 			metrics.CPU: {
-				Capacity: 4.0,
+				Capacity: []float64{3.0, 4.0},
 				Used: []metrics.Point{
 					createContainerMetricPoint(1.0, 1),
 					createContainerMetricPoint(3.0, 2),
 				},
 			},
 			metrics.Memory: {
-				Capacity: 4.0,
+				Capacity: []float64{3.0, 4.0},
 				Used: []metrics.Point{
 					createContainerMetricPoint(1.0, 1),
 					createContainerMetricPoint(3.0, 2),
 				},
 			},
 			metrics.MemoryRequest: {
-				Capacity: 4.0,
+				Capacity: []float64{3.0, 4.0},
 				Used: []metrics.Point{
 					createContainerMetricPoint(1.0, 1),
 					createContainerMetricPoint(3.0, 2),

--- a/pkg/discovery/repository/entity_metrics.go
+++ b/pkg/discovery/repository/entity_metrics.go
@@ -67,11 +67,11 @@ func (namespaceMetrics *NamespaceMetrics) UpdateQuotaSoldUsed(quotaSoldUsed map[
 // ContainerMetrics collects resource capacity and multiple usage data samples for container replicas which belong to the
 // same ContainerSpec.
 type ContainerMetrics struct {
-	Capacity float64
+	Capacity []float64
 	Used     []metrics.Point
 }
 
-func NewContainerMetrics(capacity float64, used []metrics.Point) *ContainerMetrics {
+func NewContainerMetrics(capacity []float64, used []metrics.Point) *ContainerMetrics {
 	return &ContainerMetrics{
 		Capacity: capacity,
 		Used:     used,

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator_test.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator_test.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	testContainerMetrics = &repository.ContainerMetrics{
-		Capacity: 4,
+		Capacity: []float64{3, 4},
 		Used: []metrics.Point{
 			createContainerMetricPoint(1.0, 1),
 			createContainerMetricPoint(3.0, 2),

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
@@ -39,17 +39,11 @@ func (allDataAggregator *allUtilizationDataAggregator) String() string {
 }
 
 func (allDataAggregator *allUtilizationDataAggregator) Aggregate(resourceMetrics *repository.ContainerMetrics) ([]float64, int64, int32, error) {
-	if len(resourceMetrics.Used) == 0 || len(resourceMetrics.Capacity) == 0 {
-		err := fmt.Errorf("error aggregating container utilization data using %s: used or capacity data points list is empty", allDataAggregator)
+	isValid, err := isResourceMetricsValid(resourceMetrics, allDataAggregator)
+	if !isValid || err != nil {
 		return []float64{}, 0, 0, err
 	}
-	// Use the max of resource capacity values from all container replicas.
-	// CPU capacity has been converted from milli-cores to MHz. This will make the aggregated CPU capacity on container
-	// spec more consistent if container replicas are on different nodes with different CPU frequency.
-	capacity := 0.0
-	for _, capVal := range resourceMetrics.Capacity {
-		capacity = math.Max(capacity, capVal)
-	}
+	capacity := getResourceCapacity(resourceMetrics)
 	if capacity == 0.0 {
 		err := fmt.Errorf("error aggregating container utilization data using %s: capacity is 0", allDataAggregator)
 		return []float64{}, 0, 0, err
@@ -85,17 +79,11 @@ func (maxDataAggregator *maxUtilizationDataAggregator) String() string {
 }
 
 func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(resourceMetrics *repository.ContainerMetrics) ([]float64, int64, int32, error) {
-	if len(resourceMetrics.Used) == 0 || len(resourceMetrics.Capacity) == 0 {
-		err := fmt.Errorf("error aggregating container utilization data using %s: used or capacity data points list is empty", maxDataAggregator)
+	isValid, err := isResourceMetricsValid(resourceMetrics, maxDataAggregator)
+	if !isValid || err != nil {
 		return []float64{}, 0, 0, err
 	}
-	// Use the max of resource capacity values from all container replicas.
-	// CPU capacity has been converted from milli-cores to MHz. This will make the aggregated CPU capacity on container
-	// spec more consistent if container replicas are on different nodes with different CPU frequency.
-	capacity := 0.0
-	for _, capVal := range resourceMetrics.Capacity {
-		capacity = math.Max(capacity, capVal)
-	}
+	capacity := getResourceCapacity(resourceMetrics)
 	if capacity == 0.0 {
 		err := fmt.Errorf("error aggregating container utilization data using %s: capacity is 0", maxDataAggregator)
 		return []float64{}, 0, 0, err

--- a/pkg/discovery/worker/aggregation/util.go
+++ b/pkg/discovery/worker/aggregation/util.go
@@ -1,0 +1,25 @@
+package aggregation
+
+import (
+	"fmt"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"math"
+)
+
+func isResourceMetricsValid(resourceMetrics *repository.ContainerMetrics, dataAggregator interface{}) (bool, error) {
+	if len(resourceMetrics.Used) == 0 || len(resourceMetrics.Capacity) == 0 {
+		return false, fmt.Errorf("error aggregating container data using %s: used or capacity data points list is empty", dataAggregator)
+	}
+	return true, nil
+}
+
+// Use the max of resource capacity values from all container replicas.
+// CPU capacity has been converted from milli-cores to MHz. This will make the aggregated CPU capacity on container
+// spec more consistent if container replicas are on different nodes with different CPU frequency.
+func getResourceCapacity(resourceMetrics *repository.ContainerMetrics) float64 {
+	capacity := 0.0
+	for _, capVal := range resourceMetrics.Capacity {
+		capacity = math.Max(capacity, capVal)
+	}
+	return capacity
+}

--- a/pkg/discovery/worker/container_spec_discovery_worker_test.go
+++ b/pkg/discovery/worker/container_spec_discovery_worker_test.go
@@ -41,15 +41,17 @@ func Test_k8sContainerSpecDiscoveryWorker_createContainerSpecMetricsMap(t *testi
 		ContainerReplicas: 1,
 		ContainerMetrics: map[metrics.ResourceType]*repository.ContainerMetrics{
 			cpuResourceType: {
-				Capacity: 2.0,
+				Capacity: []float64{2.0},
 				Used: []metrics.Point{
 					createContainerMetricPoint(1.0, 1),
+					createContainerMetricPoint(1.0, 2),
 				},
 			},
 			memResourceType: {
-				Capacity: 2.0,
+				Capacity: []float64{2.0},
 				Used: []metrics.Point{
 					createContainerMetricPoint(1.0, 1),
+					createContainerMetricPoint(1.0, 2),
 				},
 			},
 		},
@@ -62,14 +64,16 @@ func Test_k8sContainerSpecDiscoveryWorker_createContainerSpecMetricsMap(t *testi
 		ContainerReplicas: 1,
 		ContainerMetrics: map[metrics.ResourceType]*repository.ContainerMetrics{
 			cpuResourceType: {
-				Capacity: 2.0,
+				Capacity: []float64{3.0},
 				Used: []metrics.Point{
+					createContainerMetricPoint(2.0, 1),
 					createContainerMetricPoint(2.0, 2),
 				},
 			},
 			memResourceType: {
-				Capacity: 2.0,
+				Capacity: []float64{3.0},
 				Used: []metrics.Point{
+					createContainerMetricPoint(2.0, 1),
 					createContainerMetricPoint(2.0, 2),
 				},
 			},
@@ -84,16 +88,20 @@ func Test_k8sContainerSpecDiscoveryWorker_createContainerSpecMetricsMap(t *testi
 		ContainerReplicas: 2,
 		ContainerMetrics: map[metrics.ResourceType]*repository.ContainerMetrics{
 			cpuResourceType: {
-				Capacity: 2.0,
+				Capacity: []float64{2.0, 3.0},
 				Used: []metrics.Point{
 					createContainerMetricPoint(1.0, 1),
+					createContainerMetricPoint(1.0, 2),
+					createContainerMetricPoint(2.0, 1),
 					createContainerMetricPoint(2.0, 2),
 				},
 			},
 			memResourceType: {
-				Capacity: 2.0,
+				Capacity: []float64{2.0, 3.0},
 				Used: []metrics.Point{
 					createContainerMetricPoint(1.0, 1),
+					createContainerMetricPoint(1.0, 2),
+					createContainerMetricPoint(2.0, 1),
 					createContainerMetricPoint(2.0, 2),
 				},
 			},

--- a/pkg/discovery/worker/container_spec_metrics_collector.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector.go
@@ -103,15 +103,8 @@ func (collector *ContainerSpecMetricsCollector) collectContainerMetrics(containe
 				metrics.Capacity, containerMId, resourceType, capacityMetricValue)
 			continue
 		}
-		containerResourceMetrics := repository.NewContainerMetrics(capVal, usedValPoints)
-		containerMetrics, exists := containerSpecMetric.ContainerMetrics[resourceType]
-		if !exists {
-			containerSpecMetric.ContainerMetrics[resourceType] = containerResourceMetrics
-		} else {
-			// Resource capacity of the same resource type is always the same for container replicas so no need to update.
-			// Append resource used data points to containerMetrics.
-			containerMetrics.Used = append(containerMetrics.Used, containerResourceMetrics.Used...)
-		}
+		containerResourceMetrics := repository.NewContainerMetrics([]float64{capVal}, usedValPoints)
+		containerSpecMetric.ContainerMetrics[resourceType] = containerResourceMetrics
 	}
 }
 

--- a/pkg/discovery/worker/container_spec_metrics_collector_test.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector_test.go
@@ -16,6 +16,7 @@ const (
 	containerFoo  = "containerFoo"
 	containerBar  = "containerBar"
 	controllerUID = "controllerUID"
+	nodeName      = "node"
 
 	containerFooCPUCap   = 5.0
 	containerFooCPUUsed1 = 2.0
@@ -36,14 +37,14 @@ var (
 	testPod4 = &api.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "pod",
-			UID:       "pod-UID",
+			Name:      "pod4",
+			UID:       "pod4-UID",
 			OwnerReferences: []metav1.OwnerReference{
 				mockOwnerReference(util.KindDeployment, "controller", controllerUID),
 			},
 		},
 		Spec: api.PodSpec{
-			NodeName: "node",
+			NodeName: nodeName,
 			Containers: []api.Container{
 				{
 					Name: containerFoo,
@@ -54,14 +55,35 @@ var (
 	testPod5 = &api.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "pod",
-			UID:       "pod-UID",
+			Name:      "pod5",
+			UID:       "pod5-UID",
 			OwnerReferences: []metav1.OwnerReference{
 				mockOwnerReference(util.KindDeployment, "controller", controllerUID),
 			},
 		},
 		Spec: api.PodSpec{
-			NodeName: "node",
+			NodeName: nodeName,
+			Containers: []api.Container{
+				{
+					Name: containerBar,
+					Resources: api.ResourceRequirements{
+						Requests: buildResource(containerBarCPURequestCap, int64(containerBarCPURequestCap)),
+					},
+				},
+			},
+		},
+	}
+	testPod6 = &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "pod6",
+			UID:       "pod6-UID",
+			OwnerReferences: []metav1.OwnerReference{
+				mockOwnerReference(util.KindDeployment, "controller", controllerUID),
+			},
+		},
+		Spec: api.PodSpec{
+			NodeName: nodeName,
 			Containers: []api.Container{
 				{
 					Name: containerBar,
@@ -73,8 +95,10 @@ var (
 		},
 	}
 
-	ownerUIDMetric      = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod4), metrics.OwnerUID, controllerUID)
-	podNodeCPUFrequency = metrics.NewEntityStateMetric(metrics.NodeType, discoveryutil.NodeKeyFromPodFunc(testPod4), metrics.CpuFrequency, cpuFrequency)
+	pod4OwnerUIDMetric  = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod4), metrics.OwnerUID, controllerUID)
+	pod5OwnerUIDMetric  = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod5), metrics.OwnerUID, controllerUID)
+	pod6OwnerUIDMetric  = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod6), metrics.OwnerUID, controllerUID)
+	podNodeCPUFrequency = metrics.NewEntityStateMetric(metrics.NodeType, nodeName, metrics.CpuFrequency, cpuFrequency)
 
 	containerFooCPUCapMetric = metrics.NewEntityResourceMetric(metrics.ContainerType,
 		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerFoo), metrics.CPU, metrics.Capacity, containerFooCPUCap)
@@ -102,26 +126,50 @@ var (
 		})
 
 	containerBarCPURequestCapMetric = metrics.NewEntityResourceMetric(metrics.ContainerType,
-		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.CPURequest, metrics.Capacity, containerBarCPURequestCap)
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod5), containerBar), metrics.CPURequest, metrics.Capacity, containerBarCPURequestCap)
 	containerBarCPURequestUsedMetric1 = metrics.NewEntityResourceMetric(metrics.ContainerType,
-		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.CPURequest, metrics.Used,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod5), containerBar), metrics.CPURequest, metrics.Used,
 		[]metrics.Point{
 			createContainerMetricPoint(containerBarCPURequestUsed1, 1),
 		})
 	containerBarCPURequestUsedMetric2 = metrics.NewEntityResourceMetric(metrics.ContainerType,
-		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.CPURequest, metrics.Used,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod5), containerBar), metrics.CPURequest, metrics.Used,
 		[]metrics.Point{
 			createContainerMetricPoint(containerBarCPURequestUsed2, 2),
 		})
 	containerBarMemRequestCapMetric = metrics.NewEntityResourceMetric(metrics.ContainerType,
-		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.MemoryRequest, metrics.Capacity, containerBarMemRequestCap)
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod5), containerBar), metrics.MemoryRequest, metrics.Capacity, containerBarMemRequestCap)
 	containerBarMemRequestUsedMetric1 = metrics.NewEntityResourceMetric(metrics.ContainerType,
-		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.MemoryRequest, metrics.Used,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod5), containerBar), metrics.MemoryRequest, metrics.Used,
 		[]metrics.Point{
 			createContainerMetricPoint(containerBarMemRequestUsed1, 1),
 		})
 	containerBarMemRequestUsedMetric2 = metrics.NewEntityResourceMetric(metrics.ContainerType,
-		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerBar), metrics.MemoryRequest, metrics.Used,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod5), containerBar), metrics.MemoryRequest, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerBarMemRequestUsed2, 2),
+		})
+	containerBarCPURequestCapMetric2 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod6), containerBar), metrics.CPURequest, metrics.Capacity, containerBarCPURequestCap)
+	containerBarCPURequestUsedMetric3 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod6), containerBar), metrics.CPURequest, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerBarCPURequestUsed1, 1),
+		})
+	containerBarCPURequestUsedMetric4 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod6), containerBar), metrics.CPURequest, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerBarCPURequestUsed2, 2),
+		})
+	containerBarMemRequestCapMetric2 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod6), containerBar), metrics.MemoryRequest, metrics.Capacity, containerBarMemRequestCap)
+	containerBarMemRequestUsedMetric3 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod6), containerBar), metrics.MemoryRequest, metrics.Used,
+		[]metrics.Point{
+			createContainerMetricPoint(containerBarMemRequestUsed1, 1),
+		})
+	containerBarMemRequestUsedMetric4 = metrics.NewEntityResourceMetric(metrics.ContainerType,
+		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod6), containerBar), metrics.MemoryRequest, metrics.Used,
 		[]metrics.Point{
 			createContainerMetricPoint(containerBarMemRequestUsed2, 2),
 		})
@@ -131,7 +179,7 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithoutReques
 	pods := []*api.Pod{testPod4}
 	metricsSink := metrics.NewEntityMetricSink().WithMaxMetricPointsSize(10)
 	// Add pod owner UID and node CPU frequency metrics
-	metricsSink.AddNewMetricEntries(ownerUIDMetric, podNodeCPUFrequency)
+	metricsSink.AddNewMetricEntries(pod4OwnerUIDMetric, podNodeCPUFrequency)
 
 	// Add and update containerFoo CPU and memory metrics
 	metricsSink.AddNewMetricEntries(containerFooCPUCapMetric, containerFooCPUUsedMetric1, containerFooMemCapMetric, containerFooMemUsedMetric1)
@@ -149,14 +197,14 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithoutReques
 		ContainerReplicas: 1,
 		ContainerMetrics: map[metrics.ResourceType]*repository.ContainerMetrics{
 			metrics.CPU: {
-				Capacity: cpuFrequency * containerFooCPUCap,
+				Capacity: []float64{cpuFrequency * containerFooCPUCap},
 				Used: []metrics.Point{
 					createContainerMetricPoint(cpuFrequency*containerFooCPUUsed1, 1),
 					createContainerMetricPoint(cpuFrequency*containerFooCPUUsed2, 2),
 				},
 			},
 			metrics.Memory: {
-				Capacity: containerFooMemCap,
+				Capacity: []float64{containerFooMemCap},
 				Used: []metrics.Point{
 					createContainerMetricPoint(containerFooMemUsed1, 1),
 					createContainerMetricPoint(containerFooMemUsed2, 2),
@@ -172,15 +220,19 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithoutReques
 }
 
 func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithRequestMetrics(t *testing.T) {
-	pods := []*api.Pod{testPod5}
+	pods := []*api.Pod{testPod5, testPod6}
 	metricsSink := metrics.NewEntityMetricSink().WithMaxMetricPointsSize(10)
 	// Add pod owner UID and node CPU frequency metrics
-	metricsSink.AddNewMetricEntries(ownerUIDMetric, podNodeCPUFrequency)
+	metricsSink.AddNewMetricEntries(pod5OwnerUIDMetric, pod6OwnerUIDMetric, podNodeCPUFrequency)
 
 	// Add and update containerFoo CPURequest and MemoryRequest metrics
-	metricsSink.AddNewMetricEntries(containerBarCPURequestCapMetric, containerBarCPURequestUsedMetric1, containerBarMemRequestCapMetric, containerBarMemRequestUsedMetric1)
+	metricsSink.AddNewMetricEntries(containerBarCPURequestCapMetric, containerBarCPURequestUsedMetric1,
+		containerBarMemRequestCapMetric, containerBarMemRequestUsedMetric1, containerBarCPURequestCapMetric2,
+		containerBarCPURequestUsedMetric3, containerBarMemRequestCapMetric2, containerBarMemRequestUsedMetric3)
 	metricsSink.UpdateMetricEntry(containerBarCPURequestUsedMetric2)
 	metricsSink.UpdateMetricEntry(containerBarMemRequestUsedMetric2)
+	metricsSink.UpdateMetricEntry(containerBarCPURequestUsedMetric4)
+	metricsSink.UpdateMetricEntry(containerBarMemRequestUsedMetric4)
 
 	containerSpecMetricsCollector := NewContainerSpecMetricsCollector(metricsSink, pods)
 	containerSpecMetricsList, _ := containerSpecMetricsCollector.CollectContainerSpecMetrics()
@@ -193,14 +245,14 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithRequestMe
 		ContainerReplicas: 1,
 		ContainerMetrics: map[metrics.ResourceType]*repository.ContainerMetrics{
 			metrics.CPURequest: {
-				Capacity: cpuFrequency * containerBarCPURequestCap,
+				Capacity: []float64{cpuFrequency * containerBarCPURequestCap},
 				Used: []metrics.Point{
 					createContainerMetricPoint(cpuFrequency*containerBarCPURequestUsed1, 1),
 					createContainerMetricPoint(cpuFrequency*containerBarCPURequestUsed2, 2),
 				},
 			},
 			metrics.MemoryRequest: {
-				Capacity: containerBarMemRequestCap,
+				Capacity: []float64{containerBarMemRequestCap},
 				Used: []metrics.Point{
 					createContainerMetricPoint(containerBarMemRequestUsed1, 1),
 					createContainerMetricPoint(containerBarMemRequestUsed2, 2),
@@ -208,9 +260,12 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithRequestMe
 			},
 		},
 	}
-	assert.EqualValues(t, 1, len(containerSpecMetricsList))
+	assert.EqualValues(t, 2, len(containerSpecMetricsList))
 	assert.Equal(t, containerBar, containerSpecMetricsList[0].ContainerSpecName)
 	if !reflect.DeepEqual(expectedContainerSpecMetricsBar, containerSpecMetricsList[0]) {
 		t.Errorf("Test case failed: CollectContainerSpecMetrics():\nexpected:\n%++v\nactual:\n%++v", expectedContainerSpecMetricsBar, containerSpecMetricsList[0])
+	}
+	if !reflect.DeepEqual(expectedContainerSpecMetricsBar, containerSpecMetricsList[1]) {
+		t.Errorf("Test case failed: CollectContainerSpecMetrics():\nexpected:\n%++v\nactual:\n%++v", expectedContainerSpecMetricsBar, containerSpecMetricsList[1])
 	}
 }


### PR DESCRIPTION
**Intent**:
This is to fix part of the issue in JIRA: https://vmturbo.atlassian.net/browse/OM-62598.

**Problem and Diagnosis**:
CPU commodity capacity and usage are converted from milli-cores to MHz based on node CPU frequency. When there are multiple container replicas belonging to the same container spec and those container replicas are on different nodes with different CPU frequency, aggregated CPU commodity capacity on container spec varies from different discoveries.

This is because in previous logic, when aggregating CPU commodity capacity, we always use the resource capacity from the first container. And order is not guaranteed for container replicas of the same container spec, so CPU commodity capacity could be different from different discoveries for the same container spec.

**Solution**:
1. Instead of using the resource capacity from the first container, collect resource capacity value of each individual container instance in `ContainerMetrics` of `ContainerSpecMetrics` in `container_spec_metrics_collector.go`.  Note that in previous logic, there was:
```
containerMetrics.Used = append(containerMetrics.Used, containerResourceMetrics.Used...)
```
We don't actually need to append used data points to `containerMetrics` of `containerSpecMetric` because it just simply collects each individual container capacity and used data points data here.

2. In `container_spec_discovery_worker.go`, append capacity values from container replicas belonging to the same container spec discovered from different nodes.

3. In `container_usage_data_aggregator.go` and `container_utilization_data_aggregator.go`, use max of capacity values from all container replicas as the aggregated capacity value on container spec. Max is better than average here because when any container is rescheduled on a different node with different CPU frequency, average CPU capacity value would be changed. Note that it's still not guaranteed CPU capacity will always be consistent because max capacity could still be changed if container is rescheduled on a different node with larger CPU frequency. Using max value here will be more consistent. 

4. Updated unit tests.

**Testing Done**:
It's not easy to reproduce the scenario where different container replicas are on different nodes with different CPU frequency.
Make sure the changes didn't break anything. ContainerSpec commodity used, peak and utilizationData are set properly as before. Commodity capacity values in discovery entity DTOs are consistent in different discovery cycles. Here's discovery entity dto data of a container spec with 2 container replicas after the changes, where capacity value is consistent after multiple discoveries:
```
entityDTO {
  entityType: CONTAINER_SPEC
  id: "dae49cbe-f80f-4ee6-b61a-af1b48810c5c/cpu-mem-load-up"
  displayName: "cpu-mem-load-up"
  commoditiesSold {
    commodityType: VCPU
    used: 2089.6981156081642
    capacity: 2131.0224
    peak: 2117.78390282004
    active: true
    resizable: true
    utilizationData {
      point: 98.502996375
      point: 98.722195625
      point: 98.2995105
      point: 97.139004625
      point: 97.66716675
      point: 99.37877250000001
      point: 98.64722525
      point: 95.604298
      point: 98.651853
      point: 98.32470962500001
      point: 98.345640625
      point: 99.20541625
      point: 98.78926650000001
      point: 97.92553900000001
      point: 98.77287137500001
      point: 97.31368387500001
      point: 97.82096825
      point: 96.17998725
      point: 98.020709
      point: 97.90465675
      lastPointTimestampMs: 1600830177582
      intervalMs: 28396
    }
  }
```