### PR TITLE
Support scheduled but unready pods

### DIFF
--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -149,7 +149,7 @@ func (builder *containerDTOBuilder) BuildEntityDTOs(pods []*api.Pod) []*proto.En
 			commoditiesSold, err := builder.getCommoditiesSold(name, containerId, containerMId, nodeCPUFrequency,
 				isCpuLimitSet, isMemLimitSet, isCpuRequestSet, isMemRequestSet)
 			if err != nil {
-				glog.Errorf("failed to create commoditiesSold for container[%s]: %v", name, err)
+				glog.Warningf("failed to create commoditiesSold for container[%s]: %v", name, err)
 				continue
 			}
 			ebuilder.SellsCommodities(commoditiesSold)
@@ -158,7 +158,7 @@ func (builder *containerDTOBuilder) BuildEntityDTOs(pods []*api.Pod) []*proto.En
 			commoditiesBought, err := builder.getCommoditiesBought(podId, name, containerMId, nodeCPUFrequency,
 				isCpuLimitSet, isMemLimitSet, isCpuRequestSet, isMemRequestSet)
 			if err != nil {
-				glog.Errorf("failed to create commoditiesBought for container[%s]: %v", name, err)
+				glog.Warningf("failed to create commoditiesBought for container[%s]: %v", name, err)
 				continue
 			}
 			provider := sdkbuilder.CreateProvider(proto.EntityDTO_CONTAINER_POD, podId)
@@ -173,13 +173,23 @@ func (builder *containerDTOBuilder) BuildEntityDTOs(pods []*api.Pod) []*proto.En
 
 			truep := true
 			controllable := util.Controllable(pod)
-			ebuilder.ConsumerPolicy(&proto.EntityDTO_ConsumerPolicy{
-				ProviderMustClone: &truep,
-				Controllable:      &controllable,
-			})
+			monitored := true
+			powerState := proto.EntityDTO_POWERED_ON
+			if !util.PodIsReady(pod) {
+				controllable = false
+				monitored = false
+				powerState = proto.EntityDTO_POWERSTATE_UNKNOWN
+			}
 
 			//4. build entityDTO
-			dto, err := ebuilder.Create()
+			dto, err := ebuilder.
+				ConsumerPolicy(&proto.EntityDTO_ConsumerPolicy{
+					ProviderMustClone: &truep,
+					Controllable:      &controllable,
+				}).
+				Monitored(monitored).
+				WithPowerState(powerState).
+				Create()
 			if err != nil {
 				glog.Errorf("failed to build Container[%s] entityDTO: %v", name, err)
 			}
@@ -197,51 +207,36 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 
 	var result []*proto.CommodityDTO
 	containerEntityType := metrics.ContainerType
-
 	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, cpuCommodities...)
+
 	//1a. vCPU
 	cpuAttrSetter := NewCommodityAttrSetter()
 	cpuAttrSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(isCpuLimitSet) }, metrics.CPU)
-
-	cpuCommodities, err := builder.getResourceCommoditiesSold(containerEntityType, containerMId, cpuCommoditySold, converter, cpuAttrSetter)
-	if err != nil {
-		return nil, err
-	}
+	cpuCommodities := builder.getResourceCommoditiesSold(containerEntityType, containerMId, cpuCommoditySold, converter, cpuAttrSetter)
+	result = append(result, cpuCommodities...)
 
 	//1b. vMem
 	memAttrSetter := NewCommodityAttrSetter()
 	memAttrSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(isMemLimitSet) }, metrics.Memory)
+	memCommodities := builder.getResourceCommoditiesSold(containerEntityType, containerMId, memCommoditySold, nil, memAttrSetter)
+	result = append(result, memCommodities...)
 
-	memCommodities, err := builder.getResourceCommoditiesSold(containerEntityType, containerMId, memCommoditySold, nil, memAttrSetter)
-	if err != nil {
-		return nil, err
+	if len(result) != len(commoditySold) {
+		return nil, fmt.Errorf("mismatch num of commodities (%d Vs. %d) for container:%s, %s",
+			len(result), len(commoditySold), containerName, containerMId)
 	}
-
-	commodities := append(cpuCommodities, memCommodities...)
-	if len(commodities) != len(commoditySold) {
-		err = fmt.Errorf("mismatch num of commodities (%d Vs. %d) for container:%s, %s", len(commodities), len(commoditySold), containerName, containerMId)
-		glog.Error(err)
-		return nil, err
-	}
-	result = append(result, commodities...)
 
 	//1c. vCPURequest
 	// Container sells vCPURequest commodity only if CPU request is set on the container
 	if isCpuRequestSet {
-		cpuRequestCommodities, err := builder.createCommoditiesSold(containerEntityType, cpuRequestCommodity, containerMId, converter, true)
-		if err != nil {
-			return nil, err
-		}
+		cpuRequestCommodities := builder.createCommoditiesSold(containerEntityType, cpuRequestCommodity, containerMId, converter, true)
 		result = append(result, cpuRequestCommodities...)
 	}
 
 	//1d. vMemRequest
 	// Container sells vMemRequest commodity only if memory request is set on the container
 	if isMemRequestSet {
-		memRequestCommodities, err := builder.createCommoditiesSold(containerEntityType, memRequestCommodity, containerMId, nil, true)
-		if err != nil {
-			return nil, err
-		}
+		memRequestCommodities := builder.createCommoditiesSold(containerEntityType, memRequestCommodity, containerMId, nil, true)
 		result = append(result, memRequestCommodities...)
 	}
 
@@ -260,11 +255,10 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 
 // createCommoditiesSold creates a slice of resource commodities sold of the given resourceType.
 func (builder *containerDTOBuilder) createCommoditiesSold(entityType metrics.DiscoveredEntityType,
-	resourceTypes []metrics.ResourceType, containerMId string, converter *converter, isResizable bool) ([]*proto.CommodityDTO, error) {
+	resourceTypes []metrics.ResourceType, containerMId string, converter *converter, isResizable bool) []*proto.CommodityDTO {
 	attrSetter := NewCommodityAttrSetter()
 	attrSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(isResizable) }, resourceTypes...)
-	commoditiesSold, err := builder.getResourceCommoditiesSold(entityType, containerMId, resourceTypes, converter, attrSetter)
-	return commoditiesSold, err
+	return builder.getResourceCommoditiesSold(entityType, containerMId, resourceTypes, converter, attrSetter)
 }
 
 // vCPU, vMem, vCPURequest, vMemRequest, vCPULimitQuota, vCPURequestQuota, vMemLimitQuota, vMemRequestQuota and VMPMAccess
@@ -280,14 +274,10 @@ func (builder *containerDTOBuilder) getCommoditiesBought(podId, containerName, c
 	attributeSetter := NewCommodityAttrSetter()
 	attributeSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(true) }, metrics.CPU, metrics.Memory)
 
-	commodities, err := builder.getResourceCommoditiesBought(containerEntityType, containerMId, commodityBought, converter, attributeSetter)
-	if err != nil {
-		return nil, err
-	}
+	commodities := builder.getResourceCommoditiesBought(containerEntityType, containerMId, commodityBought, converter, attributeSetter)
 	if len(commodities) != len(commodityBought) {
-		err = fmt.Errorf("mismatch num of commidities (%d Vs. %d) for container:%s, %s", len(commodities), len(commodityBought), containerName, containerMId)
-		glog.Error(err)
-		return nil, err
+		return nil, fmt.Errorf("mismatch num of commidities (%d Vs. %d) for container:%s, %s",
+			len(commodities), len(commodityBought), containerName, containerMId)
 	}
 	result = append(result, commodities...)
 
@@ -299,10 +289,7 @@ func (builder *containerDTOBuilder) getCommoditiesBought(podId, containerName, c
 			return nil, err
 		}
 		result = append(result, cpuRequestCommBought)
-		cpuRequestQuotaCommBought, err := builder.createCommoditiesBought(containerEntityType, cpuRequestQuotaCommodityBought, containerMId, converter)
-		if err != nil {
-			return nil, err
-		}
+		cpuRequestQuotaCommBought := builder.createCommoditiesBought(containerEntityType, cpuRequestQuotaCommodityBought, containerMId, converter)
 		result = append(result, cpuRequestQuotaCommBought...)
 	}
 
@@ -314,30 +301,21 @@ func (builder *containerDTOBuilder) getCommoditiesBought(podId, containerName, c
 			return nil, err
 		}
 		result = append(result, memRequestCommSold)
-		memRequestQuotaCommBought, err := builder.createCommoditiesBought(containerEntityType, memoryRequestQuotaCommodityBought, containerMId, nil)
-		if err != nil {
-			return nil, err
-		}
+		memRequestQuotaCommBought := builder.createCommoditiesBought(containerEntityType, memoryRequestQuotaCommodityBought, containerMId, nil)
 		result = append(result, memRequestQuotaCommBought...)
 	}
 
 	//1d. vCPULimitQuota
 	// Container buys vCPULimitQuota commodity only if CPU limit is set on the container
 	if isCpuLimitSet {
-		cpuLimitQuotaCommBought, err := builder.createCommoditiesBought(containerEntityType, cpuLimitQuotaCommodityBought, containerMId, converter)
-		if err != nil {
-			return nil, err
-		}
+		cpuLimitQuotaCommBought := builder.createCommoditiesBought(containerEntityType, cpuLimitQuotaCommodityBought, containerMId, converter)
 		result = append(result, cpuLimitQuotaCommBought...)
 	}
 
 	//1e. vMemoryLimitQuota
 	// Container buys vMemoryLimitQuota commodity only if memory limit is set on the container
 	if isMemLimitSet {
-		memLimitQuotaCommBought, err := builder.createCommoditiesBought(containerEntityType, memoryLimitQuotaCommodityBought, containerMId, nil)
-		if err != nil {
-			return nil, err
-		}
+		memLimitQuotaCommBought := builder.createCommoditiesBought(containerEntityType, memoryLimitQuotaCommodityBought, containerMId, nil)
 		result = append(result, memLimitQuotaCommBought...)
 	}
 
@@ -359,35 +337,27 @@ func (builder *containerDTOBuilder) createRequestCommodityBought(entityType metr
 	resourceType metrics.ResourceType, containerMId string, converter *converter) (*proto.CommodityDTO, error) {
 	cType, exist := rTypeMapping[resourceType]
 	if !exist {
-		glog.Errorf("%s::%s cannot build bought commodity %s : Unsupported commodity type",
+		return nil, fmt.Errorf("%s::%s cannot build bought commodity %s : Unsupported commodity type",
 			entityType, containerMId, resourceType)
-
 	}
 	commBoughtBuilder := sdkbuilder.NewCommodityDTOBuilder(cType)
 	// Used value of request commodity bought by the container is the configured resource requests capacity
 	metricValue, err := builder.metricValue(entityType, containerMId, resourceType, metrics.Capacity, converter)
 	if err != nil {
-		glog.Errorf("%s::%s cannot build bought commodity %s : %v", entityType, containerMId, resourceType, err)
 		return nil, err
 	}
 	commBoughtBuilder.Used(metricValue.Avg)
 	commBoughtBuilder.Peak(metricValue.Peak)
 	commBoughtBuilder.Resizable(true)
-	commBought, err := commBoughtBuilder.Create()
-	if err != nil {
-		glog.Errorf("%s::%s cannot build bought commodity %s : %v", entityType, containerMId, resourceType, err)
-		return nil, err
-	}
-	return commBought, nil
+	return commBoughtBuilder.Create()
 }
 
 // createCommoditiesBought creates a slice of resource commodities bought of the given resourceType.
 func (builder *containerDTOBuilder) createCommoditiesBought(entityType metrics.DiscoveredEntityType,
-	resourceTypes []metrics.ResourceType, containerMId string, converter *converter) ([]*proto.CommodityDTO, error) {
+	resourceTypes []metrics.ResourceType, containerMId string, converter *converter) []*proto.CommodityDTO {
 	attrSetter := NewCommodityAttrSetter()
 	attrSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(true) }, resourceTypes...)
-	commoditiesBought, err := builder.getResourceCommoditiesBought(entityType, containerMId, resourceTypes, converter, attrSetter)
-	return commoditiesBought, err
+	return builder.getResourceCommoditiesBought(entityType, containerMId, resourceTypes, converter, attrSetter)
 }
 
 func (builder *containerDTOBuilder) getContainerProperties(pod *api.Pod, index int) []*proto.EntityDTO_EntityProperty {

--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -92,7 +92,7 @@ func (builder *containerDTOBuilder) getNodeCPUFrequency(pod *api.Pod) (float64, 
 	return cpuFrequency, nil
 }
 
-func (builder *containerDTOBuilder) BuildDTOs(pods []*api.Pod) ([]*proto.EntityDTO, error) {
+func (builder *containerDTOBuilder) BuildEntityDTOs(pods []*api.Pod) []*proto.EntityDTO {
 	var result []*proto.EntityDTO
 
 	for _, pod := range pods {
@@ -188,7 +188,7 @@ func (builder *containerDTOBuilder) BuildDTOs(pods []*api.Pod) ([]*proto.EntityD
 		}
 	}
 
-	return result, nil
+	return result
 }
 
 // vCPU, vMem, vCPURequest, vMemRequest and Application are sold by Container.

--- a/pkg/discovery/dtofactory/container_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_dto_builder_test.go
@@ -122,9 +122,8 @@ func Test_containerDTOBuilder_BuildDTOs_layeredOver(t *testing.T) {
 	}
 
 	containerDTOBuilder := NewContainerDTOBuilder(mockMetricsSink())
-	containerDTOs, err := containerDTOBuilder.BuildDTOs([]*api.Pod{testPod})
+	containerDTOs := containerDTOBuilder.BuildEntityDTOs([]*api.Pod{testPod})
 
-	assert.Nil(t, err)
 	assert.Equal(t, 2, len(containerDTOs))
 	for _, containerDTO := range containerDTOs {
 		if *containerDTO.DisplayName == util.ContainerNameFunc(testPod, &containerFoo) {

--- a/pkg/discovery/dtofactory/general_builder_test.go
+++ b/pkg/discovery/dtofactory/general_builder_test.go
@@ -151,7 +151,7 @@ func TestBuildCommSold(t *testing.T) {
 
 	eType := metrics.PodType
 	resourceTypesList := []metrics.ResourceType{metrics.CPU, metrics.Memory}
-	commSoldList, err := dtoBuilder.getResourceCommoditiesSold(eType, pod1, resourceTypesList, cpuConverter, nil)
+	commSoldList := dtoBuilder.getResourceCommoditiesSold(eType, pod1, resourceTypesList, cpuConverter, nil)
 	commMap := make(map[proto.CommodityDTO_CommodityType]*proto.CommodityDTO)
 
 	for _, commSold := range commSoldList {
@@ -163,7 +163,6 @@ func TestBuildCommSold(t *testing.T) {
 		commSold, _ := commMap[cType]
 		assert.NotNil(t, commSold)
 		fmt.Printf("%++v\n", commSold)
-		fmt.Printf("%++v\n", err)
 	}
 }
 
@@ -177,7 +176,7 @@ func TestBuildCommBought(t *testing.T) {
 
 	eType := metrics.PodType
 	resourceTypesList := []metrics.ResourceType{metrics.CPU, metrics.Memory}
-	commBoughtList, err := dtoBuilder.getResourceCommoditiesBought(eType, pod1, resourceTypesList, cpuConverter, nil)
+	commBoughtList := dtoBuilder.getResourceCommoditiesBought(eType, pod1, resourceTypesList, cpuConverter, nil)
 	commMap := make(map[proto.CommodityDTO_CommodityType]*proto.CommodityDTO)
 
 	for _, commBought := range commBoughtList {
@@ -189,7 +188,6 @@ func TestBuildCommBought(t *testing.T) {
 		commBought, _ := commMap[cType]
 		assert.NotNil(t, commBought)
 		fmt.Printf("%++v\n", commBought)
-		fmt.Printf("%++v\n", err)
 	}
 }
 

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -60,7 +60,7 @@ func NewNodeEntityDTOBuilder(sink *metrics.EntityMetricSink, stitchingManager *s
 }
 
 // Build entityDTOs based on the given node list.
-func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) ([]*proto.EntityDTO, error) {
+func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) []*proto.EntityDTO {
 	var result []*proto.EntityDTO
 	for _, node := range nodes {
 		// id.
@@ -146,10 +146,10 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) ([]*prot
 
 		result = append(result, entityDto)
 
-		glog.V(3).Infof("node dto : %++v\n", entityDto)
+		glog.V(4).Infof("Node DTO : %+v", entityDto)
 	}
 
-	return result, nil
+	return result
 }
 
 // Build the sold commodityDTO by each node. They include:

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -171,10 +171,7 @@ func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node) ([]*
 		metrics.CPU, metrics.CPURequest)
 
 	// Resource Commodities
-	resourceCommoditiesSold, err := builder.getResourceCommoditiesSold(metrics.NodeType, key, nodeResourceCommoditiesSold, converter, nil)
-	if err != nil {
-		return nil, err
-	}
+	resourceCommoditiesSold := builder.getResourceCommoditiesSold(metrics.NodeType, key, nodeResourceCommoditiesSold, converter, nil)
 
 	// Disable vertical resize of the resource commodities for all nodes
 	for _, commSold := range resourceCommoditiesSold {

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -2,7 +2,6 @@ package dtofactory
 
 import (
 	"fmt"
-
 	api "k8s.io/api/core/v1"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
@@ -23,14 +22,24 @@ const (
 )
 
 var (
-	podResourceCommoditySold = []metrics.ResourceType{
+	pendingPodResCommTypeSold = []metrics.ResourceType{
+		metrics.CPURequest,
+		metrics.MemoryRequest,
+	}
+
+	pendingPodResCommTypeBoughtFromNode = []metrics.ResourceType{
+		metrics.CPURequest,
+		metrics.MemoryRequest,
+	}
+
+	runningPodResCommTypeSold = []metrics.ResourceType{
 		metrics.CPU,
 		metrics.Memory,
 		metrics.CPURequest,
 		metrics.MemoryRequest,
 	}
 
-	podResourceCommodityBoughtFromNode = []metrics.ResourceType{
+	runningPodResCommTypeBoughtFromNode = []metrics.ResourceType{
 		metrics.CPU,
 		metrics.Memory,
 		metrics.CPURequest,
@@ -40,7 +49,7 @@ var (
 		// TODO, add back provisioned commodity later
 	}
 
-	podQuotaCommodities = []metrics.ResourceType{
+	podQuotaCommType = []metrics.ResourceType{
 		metrics.CPULimitQuota,
 		metrics.MemoryLimitQuota,
 		metrics.CPURequestQuota,
@@ -53,20 +62,61 @@ type podEntityDTOBuilder struct {
 	stitchingManager *stitching.StitchingManager
 	nodeNameUIDMap   map[string]string
 	namespaceUIDMap  map[string]string
+	podToVolumesMap  map[string][]repository.MountedVolume
+	runningPods      []*api.Pod
+	pendingPods      []*api.Pod
 }
 
-func NewPodEntityDTOBuilder(sink *metrics.EntityMetricSink, stitchingManager *stitching.StitchingManager,
-	nodeNameUIDMap, namespaceUIDMap map[string]string) *podEntityDTOBuilder {
+func NewPodEntityDTOBuilder(sink *metrics.EntityMetricSink, stitchingManager *stitching.StitchingManager) *podEntityDTOBuilder {
 	return &podEntityDTOBuilder{
 		generalBuilder:   newGeneralBuilder(sink),
-		nodeNameUIDMap:   nodeNameUIDMap,
-		namespaceUIDMap:  namespaceUIDMap,
 		stitchingManager: stitchingManager,
+		nodeNameUIDMap:   make(map[string]string),
+		namespaceUIDMap:  make(map[string]string),
+		podToVolumesMap:  make(map[string][]repository.MountedVolume),
 	}
 }
 
+func (builder *podEntityDTOBuilder) WithNodeNameUIDMap(nodeNameUIDMap map[string]string) *podEntityDTOBuilder {
+	builder.nodeNameUIDMap = nodeNameUIDMap
+	return builder
+}
+
+func (builder *podEntityDTOBuilder) WithNameSpaceUIDMap(namespaceUIDMap map[string]string) *podEntityDTOBuilder {
+	builder.namespaceUIDMap = namespaceUIDMap
+	return builder
+}
+
+func (builder *podEntityDTOBuilder) WithPodToVolumesMap(podToVolumesMap map[string][]repository.MountedVolume) *podEntityDTOBuilder {
+	builder.podToVolumesMap = podToVolumesMap
+	return builder
+}
+
+func (builder *podEntityDTOBuilder) WithRunningPods(runningPods []*api.Pod) *podEntityDTOBuilder {
+	builder.runningPods = runningPods
+	return builder
+}
+
+func (builder *podEntityDTOBuilder) WithPendingPods(pendingPods []*api.Pod) *podEntityDTOBuilder {
+	builder.pendingPods = pendingPods
+	return builder
+}
+
+func (builder *podEntityDTOBuilder) BuildEntityDTOs() ([]*proto.EntityDTO, []*proto.EntityDTO) {
+	glog.V(3).Infof("Building DTOs for running pods...")
+	runningPodDTOs := builder.buildDTOs(
+		builder.runningPods, runningPodResCommTypeSold, runningPodResCommTypeBoughtFromNode)
+	glog.V(3).Infof("Built %d running pod DTOs.", len(runningPodDTOs))
+	glog.V(3).Infof("Building DTOs for pending pods...")
+	pendingPodDTOs := builder.buildDTOs(
+		builder.pendingPods, pendingPodResCommTypeSold, pendingPodResCommTypeBoughtFromNode)
+	glog.V(3).Infof("Built %d pending pod DTOs.", len(pendingPodDTOs))
+	return runningPodDTOs, pendingPodDTOs
+}
+
 // Build entityDTOs based on the given pod list.
-func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod, podToVolsMap map[string][]repository.MountedVolume) ([]*proto.EntityDTO, error) {
+func (builder *podEntityDTOBuilder) buildDTOs(pods []*api.Pod, resCommTypeSold,
+	resCommTypeBoughtFromNode []metrics.ResourceType) []*proto.EntityDTO {
 	var result []*proto.EntityDTO
 
 	for _, pod := range pods {
@@ -86,7 +136,7 @@ func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod, podToVolsMa
 			continue
 		}
 		// consumption resource commodities sold
-		commoditiesSold, err := builder.getPodCommoditiesSold(pod, cpuFrequency)
+		commoditiesSold, err := builder.getPodCommoditiesSold(pod, cpuFrequency, resCommTypeSold)
 		if err != nil {
 			glog.Errorf("Error when create commoditiesSold for pod %s: %s", displayName, err)
 			continue
@@ -101,7 +151,7 @@ func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod, podToVolsMa
 		entityDTOBuilder.SellsCommodities(commoditiesSold)
 
 		// commodities bought - from node provider
-		commoditiesBought, err := builder.getPodCommoditiesBought(pod, cpuFrequency)
+		commoditiesBought, err := builder.getPodCommoditiesBought(pod, cpuFrequency, resCommTypeBoughtFromNode)
 		if err != nil {
 			glog.Errorf("Error when create commoditiesBought for pod %s: %s", displayName, err)
 			continue
@@ -158,43 +208,50 @@ func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod, podToVolsMa
 			entityDTOBuilder.IsMovable(proto.EntityDTO_WORKLOAD_CONTROLLER, false)
 		}
 
-		// Commodities bought from volumes
-		err = builder.buyCommoditiesFromVolumes(pod, podToVolsMap[displayName], entityDTOBuilder)
-		if err != nil {
-			glog.Errorf("Error when creating commoditiesBought for pod %s: %v", displayName, err)
-			continue
+		mounts := builder.podToVolumesMap[displayName]
+		controllable := util.Controllable(pod)
+		monitored := true
+		suspendable := true
+		provisionable := true
+		powerState := proto.EntityDTO_POWERED_ON
+		// action eligibility for daemon pods
+		if daemon {
+			suspendable = false
+			provisionable = false
 		}
+		if util.PodIsPending(pod) {
+			mounts = nil
+			controllable = false
+			suspendable = false
+			provisionable = false
+			monitored = false
+			powerState = proto.EntityDTO_POWERSTATE_UNKNOWN
+		}
+		glog.V(4).Infof(
+			"Pod %v: controllable: %v, suspendable: %v, provisionable: %v, monitored: %v, power state %v",
+			displayName, controllable, suspendable, provisionable, monitored, powerState)
 
+		// Commodities bought from volume mounts
+		builder.buyCommoditiesFromVolumes(pod, mounts, entityDTOBuilder)
 		// entities' properties.
-		properties, err := builder.getPodProperties(pod, podToVolsMap[displayName])
+		properties, err := builder.getPodProperties(pod, mounts)
 		if err != nil {
 			glog.Errorf("Failed to get required pod properties: %s", err)
 			continue
 		}
-		entityDTOBuilder = entityDTOBuilder.WithProperties(properties)
 
-		controllable := util.Controllable(pod)
-		if !controllable {
-			glog.V(4).Infof("Pod %v is not controllable.", displayName)
-		}
-
-		entityDTOBuilder.ConsumerPolicy(&proto.EntityDTO_ConsumerPolicy{
-			Controllable: &controllable,
-			Daemon:       &daemon,
-		})
-
-		entityDTOBuilder = entityDTOBuilder.ContainerPodData(builder.createContainerPodData(pod))
-
-		entityDTOBuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
-
-		// action eligibility for daemon pods
-		if daemon {
-			entityDTOBuilder.IsProvisionable(false)
-			entityDTOBuilder.IsSuspendable(false)
-		}
-
-		// build entityDTO.
-		entityDto, err := entityDTOBuilder.Create()
+		entityDto, err := entityDTOBuilder.
+			WithProperties(properties).
+			ConsumerPolicy(&proto.EntityDTO_ConsumerPolicy{
+				Controllable: &controllable,
+				Daemon:       &daemon,
+			}).
+			Monitored(monitored).
+			ContainerPodData(builder.createContainerPodData(pod)).
+			WithPowerState(powerState).
+			IsProvisionable(provisionable).
+			IsSuspendable(suspendable).
+			Create()
 		if err != nil {
 			glog.Errorf("Failed to build Pod entityDTO: %s", err)
 			continue
@@ -203,35 +260,38 @@ func (builder *podEntityDTOBuilder) BuildEntityDTOs(pods []*api.Pod, podToVolsMa
 		result = append(result, entityDto)
 
 		if daemon {
-			glog.V(3).Infof("daemon pod dto:\n %++v\n", entityDto)
+			glog.V(4).Infof("Daemon pod DTO: %+v", entityDto)
 		} else {
-			glog.V(4).Infof("pod dto: %++v\n", entityDto)
+			glog.V(4).Infof("Pod DTO: %+v", entityDto)
 		}
 	}
 
-	return result, nil
+	return result
 }
 
 // VCPURequestQuota/VMemRequestQuota commodities.
 // Build the CommodityDTOs sold  by the pod for vCPU, vMem and VMPMAcces.
 // VMPMAccess is used to bind container to the hosting pod so the container is not moved out of the pod
-func (builder *podEntityDTOBuilder) getPodCommoditiesSold(pod *api.Pod, cpuFrequency float64) ([]*proto.CommodityDTO, error) {
+func (builder *podEntityDTOBuilder) getPodCommoditiesSold(
+	pod *api.Pod, cpuFrequency float64, resCommTypeSold []metrics.ResourceType) ([]*proto.CommodityDTO, error) {
 	var commoditiesSold []*proto.CommodityDTO
 
 	// cpu and cpu provisioned needs to be converted from number of cores to frequency.
-	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU, metrics.CPURequest)
+	converter := NewConverter().
+		Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU, metrics.CPURequest)
 
 	attributeSetter := NewCommodityAttrSetter()
-	attributeSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(false) }, podResourceCommoditySold...)
+	attributeSetter.Add(
+		func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(false) }, resCommTypeSold...)
 
 	// Resource Commodities
 	podMId := util.PodMetricIdAPI(pod)
-	resourceCommoditiesSold, err := builder.getResourceCommoditiesSold(metrics.PodType, podMId, podResourceCommoditySold, converter, attributeSetter)
+	resourceCommoditiesSold, err := builder.getResourceCommoditiesSold(metrics.PodType, podMId, resCommTypeSold, converter, attributeSetter)
 	if err != nil {
 		return nil, err
 	}
-	if len(resourceCommoditiesSold) != len(podResourceCommoditySold) {
-		err = fmt.Errorf("mismatch num of sold commodities (%d Vs. %d) for pod %s", len(resourceCommoditiesSold), len(podResourceCommoditySold), pod.Name)
+	if len(resourceCommoditiesSold) != len(resCommTypeSold) {
+		err = fmt.Errorf("mismatch num of sold commodities (%d Vs. %d) for pod %s", len(resourceCommoditiesSold), len(resCommTypeSold), pod.Name)
 		glog.Error(err)
 		return nil, err
 	}
@@ -263,16 +323,16 @@ func (builder *podEntityDTOBuilder) getPodQuotaCommoditiesSold(pod *api.Pod, cpu
 	}, metrics.CPULimitQuota, metrics.CPURequestQuota)
 
 	attributeSetter := NewCommodityAttrSetter()
-	attributeSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(false) }, podQuotaCommodities...)
+	attributeSetter.Add(func(commBuilder *sdkbuilder.CommodityDTOBuilder) { commBuilder.Resizable(false) }, podQuotaCommType...)
 
 	// Resource Commodities
 	podMId := util.PodMetricIdAPI(pod)
-	quotaCommoditiesSold, err := builder.getResourceCommoditiesSold(metrics.PodType, podMId, podQuotaCommodities, converter, attributeSetter)
+	quotaCommoditiesSold, err := builder.getResourceCommoditiesSold(metrics.PodType, podMId, podQuotaCommType, converter, attributeSetter)
 	if err != nil {
 		return nil, err
 	}
-	if len(quotaCommoditiesSold) != len(podQuotaCommodities) {
-		err = fmt.Errorf("mismatch num of sold commidities (%d Vs. %d) for pod %s", len(quotaCommoditiesSold), len(podQuotaCommodities), pod.Name)
+	if len(quotaCommoditiesSold) != len(podQuotaCommType) {
+		err = fmt.Errorf("mismatch num of sold commidities (%d Vs. %d) for pod %s", len(quotaCommoditiesSold), len(podQuotaCommType), pod.Name)
 		glog.Error(err)
 		return nil, err
 	}
@@ -281,7 +341,8 @@ func (builder *podEntityDTOBuilder) getPodQuotaCommoditiesSold(pod *api.Pod, cpu
 
 // Build the CommodityDTOs bought by the pod from the node provider.
 // Commodities bought are vCPU, vMem vmpm access, cluster
-func (builder *podEntityDTOBuilder) getPodCommoditiesBought(pod *api.Pod, cpuFrequency float64) ([]*proto.CommodityDTO, error) {
+func (builder *podEntityDTOBuilder) getPodCommoditiesBought(
+	pod *api.Pod, cpuFrequency float64, resCommTypeBoughtFromNode []metrics.ResourceType) ([]*proto.CommodityDTO, error) {
 	var commoditiesBought []*proto.CommodityDTO
 
 	// cpu and cpu provisioned needs to be converted from number of cores to frequency.
@@ -289,12 +350,12 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBought(pod *api.Pod, cpuFre
 
 	// Resource Commodities.
 	podMId := util.PodMetricIdAPI(pod)
-	resourceCommoditiesBought, err := builder.getResourceCommoditiesBought(metrics.PodType, podMId, podResourceCommodityBoughtFromNode, converter, nil)
+	resourceCommoditiesBought, err := builder.getResourceCommoditiesBought(metrics.PodType, podMId, resCommTypeBoughtFromNode, converter, nil)
 	if err != nil {
 		return nil, err
 	}
-	if len(resourceCommoditiesBought) != len(podResourceCommodityBoughtFromNode) {
-		err = fmt.Errorf("mismatch num of bought commidities from node (%d Vs. %d) for pod %s", len(resourceCommoditiesBought), len(podResourceCommodityBoughtFromNode), pod.Name)
+	if len(resourceCommoditiesBought) != len(resCommTypeBoughtFromNode) {
+		err = fmt.Errorf("mismatch num of bought commidities from node (%d Vs. %d) for pod %s", len(resourceCommoditiesBought), len(resCommTypeBoughtFromNode), pod.Name)
 		glog.Error(err)
 		return nil, err
 	}
@@ -345,7 +406,7 @@ func (builder *podEntityDTOBuilder) getQuotaCommoditiesBought(providerUID string
 	}, metrics.CPULimitQuota, metrics.CPURequestQuota)
 
 	// Resource Commodities.
-	for _, resourceType := range podQuotaCommodities {
+	for _, resourceType := range podQuotaCommType {
 		commBought, err := builder.getResourceCommodityBoughtWithKey(metrics.PodType, key,
 			resourceType, providerUID, converter, nil)
 		if err != nil {
@@ -359,7 +420,7 @@ func (builder *podEntityDTOBuilder) getQuotaCommoditiesBought(providerUID string
 }
 
 // Build the CommodityDTOs bought by the pod from the Volumes.
-func (builder *podEntityDTOBuilder) buyCommoditiesFromVolumes(pod *api.Pod, mounts []repository.MountedVolume, dtoBuilder *sdkbuilder.EntityDTOBuilder) error {
+func (builder *podEntityDTOBuilder) buyCommoditiesFromVolumes(pod *api.Pod, mounts []repository.MountedVolume, dtoBuilder *sdkbuilder.EntityDTOBuilder) {
 	podKey := util.PodKeyFunc(pod)
 
 	for _, mount := range mounts {
@@ -390,8 +451,6 @@ func (builder *podEntityDTOBuilder) buyCommoditiesFromVolumes(pod *api.Pod, moun
 		// Each pod mounts any given volume only once
 		dtoBuilder.BuysCommodities([]*proto.CommodityDTO{commBought})
 	}
-
-	return nil
 }
 
 // Get the properties of the pod. This includes property related to pod cluster property.
@@ -450,7 +509,7 @@ func (builder *podEntityDTOBuilder) createContainerPodData(pod *api.Pod) *proto.
 		}
 	}
 
-	if pod.Status.PodIP == "" {
+	if util.PodIsReady(pod) && pod.Status.PodIP == "" {
 		glog.Errorf("No IP found for pod %s", fullName)
 	}
 	return nil

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -73,8 +73,9 @@ func Test_podEntityDTOBuilder_createContainerPodData(t *testing.T) {
 	}
 }
 
-func testGetCommoditiesWithError(t *testing.T, f func(pod *api.Pod, cpuFrequency float64) ([]*proto.CommodityDTO, error)) {
-	if _, err := f(&api.Pod{}, 100.0); err == nil {
+func testGetCommoditiesWithError(t *testing.T,
+	f func(pod *api.Pod, cpuFrequency float64, resType []metrics.ResourceType) ([]*proto.CommodityDTO, error)) {
+	if _, err := f(&api.Pod{}, 100.0, runningPodResCommTypeSold); err == nil {
 		t.Errorf("Error thrown expected")
 	}
 }

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -75,7 +75,7 @@ func Test_podEntityDTOBuilder_createContainerPodData(t *testing.T) {
 
 func testGetCommoditiesWithError(t *testing.T,
 	f func(pod *api.Pod, cpuFrequency float64, resType []metrics.ResourceType) ([]*proto.CommodityDTO, error)) {
-	if _, err := f(&api.Pod{}, 100.0, runningPodResCommTypeSold); err == nil {
+	if _, err := f(createPodWithReadyCondition(), 100.0, runningPodResCommTypeSold); err == nil {
 		t.Errorf("Error thrown expected")
 	}
 }
@@ -89,5 +89,16 @@ func createPodWithIPs(podIP, hostIP string) *api.Pod {
 	return &api.Pod{
 		Status:     status,
 		ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+	}
+}
+
+func createPodWithReadyCondition() *api.Pod {
+	return &api.Pod{
+		Status: api.PodStatus{
+			Conditions: []api.PodCondition{{
+				Type:   api.PodReady,
+				Status: api.ConditionTrue,
+			}},
+		},
 	}
 }

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -17,13 +17,15 @@ const (
 )
 
 type Task struct {
-	uid      string
-	name     string
-	nodeList []*api.Node
-	podList  []*api.Pod
-	pvList   []*api.PersistentVolume
-	pvcList  []*api.PersistentVolumeClaim
-	cluster  *repository.ClusterSummary
+	uid         string
+	name        string
+	nodes       []*api.Node
+	pendingPods []*api.Pod
+	runningPods []*api.Pod
+	pods        []*api.Pod
+	pvs         []*api.PersistentVolume
+	pvcs        []*api.PersistentVolumeClaim
+	cluster     *repository.ClusterSummary
 }
 
 // Worker task is consisted of a list of nodes the worker must discover.
@@ -37,31 +39,43 @@ func NewTask() *Task {
 }
 
 // Assign nodes to the task.
-func (t *Task) WithNodes(nodeList []*api.Node) *Task {
-	t.nodeList = nodeList
+func (t *Task) WithNodes(nodes []*api.Node) *Task {
+	t.nodes = nodes
 	return t
 }
 
 func (t *Task) WithNode(node *api.Node) *Task {
-	t.nodeList = append(t.nodeList, node)
+	t.nodes = append(t.nodes, node)
 	return t
 }
 
 // Assign pods to the task.
-func (t *Task) WithPods(podList []*api.Pod) *Task {
-	t.podList = podList
+func (t *Task) WithPods(pods []*api.Pod) *Task {
+	t.pods = pods
+	return t
+}
+
+func (t *Task) WithRunningPods(runningPods []*api.Pod) *Task {
+	t.runningPods = runningPods
+	t.pods = append(t.pods, runningPods...)
+	return t
+}
+
+func (t *Task) WithPendingPods(pendingPods []*api.Pod) *Task {
+	t.pendingPods = pendingPods
+	t.pods = append(t.pods, pendingPods...)
 	return t
 }
 
 // Assign pvs to the task.
-func (t *Task) WithPVs(pvList []*api.PersistentVolume) *Task {
-	t.pvList = pvList
+func (t *Task) WithPVs(pvs []*api.PersistentVolume) *Task {
+	t.pvs = pvs
 	return t
 }
 
 // Assign pvcs to the task.
-func (t *Task) WithPVCs(pvcList []*api.PersistentVolumeClaim) *Task {
-	t.pvcList = pvcList
+func (t *Task) WithPVCs(pvcs []*api.PersistentVolumeClaim) *Task {
+	t.pvcs = pvcs
 	return t
 }
 
@@ -73,22 +87,30 @@ func (t *Task) WithCluster(cluster *repository.ClusterSummary) *Task {
 
 // Get node list from the task.
 func (t *Task) NodeList() []*api.Node {
-	return t.nodeList
+	return t.nodes
 }
 
 // Get pod list from the task.
 func (t *Task) PodList() []*api.Pod {
-	return t.podList
+	return t.pods
+}
+
+func (t *Task) RunningPodList() []*api.Pod {
+	return t.runningPods
+}
+
+func (t *Task) PendingPodList() []*api.Pod {
+	return t.pendingPods
 }
 
 // Get PV list from the task.
 func (t *Task) PVList() []*api.PersistentVolume {
-	return t.pvList
+	return t.pvs
 }
 
 // Get PVC list from the task.
 func (t *Task) PVCList() []*api.PersistentVolumeClaim {
-	return t.pvcList
+	return t.pvcs
 }
 
 func (t *Task) Cluster() *repository.ClusterSummary {
@@ -97,7 +119,7 @@ func (t *Task) Cluster() *repository.ClusterSummary {
 
 func (t *Task) String() string {
 	var nodes []string
-	for _, node := range t.nodeList {
+	for _, node := range t.nodes {
 		nodes = append(nodes, node.GetName())
 	}
 	return "[id: " + t.name + ", node: " + strings.Join(nodes, ",") + "]"

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -165,6 +165,19 @@ func PodIsReady(pod *api.Pod) bool {
 	return false
 }
 
+// PodIsPending checks if a scheduled pod is in Pending status
+func PodIsPending(pod *api.Pod) bool {
+	if pod.Status.Phase != api.PodPending {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == api.PodScheduled {
+			return condition.Status == api.ConditionTrue
+		}
+	}
+	return false
+}
+
 // GetPodInPhase finds the pod with the specific name in the specific phase (e.g., Running).
 // If pod not found, nil pod pointer will be returned without error.
 func GetPodInPhase(podClient v1.PodInterface, name string, phase api.PodPhase) (*api.Pod, error) {

--- a/pkg/discovery/worker/compliance/taint_toleration_processor.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor.go
@@ -167,9 +167,10 @@ func retrieveNodeAndPodDTOs(entityDTOs []*proto.EntityDTO) ([]*proto.EntityDTO, 
 	pods := []*proto.EntityDTO{}
 
 	for _, dto := range entityDTOs {
-		if *dto.EntityType == proto.EntityDTO_VIRTUAL_MACHINE {
+		if dto.GetEntityType() == proto.EntityDTO_VIRTUAL_MACHINE {
 			nodes = append(nodes, dto)
-		} else if *dto.EntityType == proto.EntityDTO_CONTAINER_POD {
+		} else if dto.GetEntityType() == proto.EntityDTO_CONTAINER_POD &&
+			dto.GetPowerState() == proto.EntityDTO_POWERED_ON {
 			pods = append(pods, dto)
 		}
 	}

--- a/pkg/discovery/worker/container_spec_metrics_collector.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector.go
@@ -83,7 +83,7 @@ func (collector *ContainerSpecMetricsCollector) collectContainerMetrics(containe
 		}
 		usedMetricValue, err := collector.getResourceMetricValue(containerMId, resourceType, metrics.Used, nodeCPUFrequency)
 		if err != nil {
-			glog.Errorf("Error getting resource %s value for container %s %s: %v", metrics.Used, containerMId, resourceType, err)
+			glog.Warningf("Cannot get resource %s value for container %s %s: %v", metrics.Used, containerMId, resourceType, err)
 			continue
 		}
 		usedValPoints, ok := usedMetricValue.([]metrics.Point)
@@ -94,7 +94,7 @@ func (collector *ContainerSpecMetricsCollector) collectContainerMetrics(containe
 		}
 		capacityMetricValue, err := collector.getResourceMetricValue(containerMId, resourceType, metrics.Capacity, nodeCPUFrequency)
 		if err != nil {
-			glog.Errorf("Error getting resource %s value for container %s %s", metrics.Capacity, containerMId, resourceType)
+			glog.Warningf("Cannot get resource %s value for container %s %s", metrics.Capacity, containerMId, resourceType)
 			continue
 		}
 		capVal, ok := capacityMetricValue.(float64)

--- a/pkg/discovery/worker/container_spec_metrics_collector.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector.go
@@ -36,7 +36,7 @@ func NewContainerSpecMetricsCollector(metricsSink *metrics.EntityMetricSink, pod
 
 // CollectContainerSpecMetrics collects list of ContainerSpecMetrics including resource capacity value and multiple
 // usage data points from sampling discoveries for container replicas which belong to the same ContainerSpec.
-func (collector *ContainerSpecMetricsCollector) CollectContainerSpecMetrics() ([]*repository.ContainerSpecMetrics, error) {
+func (collector *ContainerSpecMetricsCollector) CollectContainerSpecMetrics() []*repository.ContainerSpecMetrics {
 	var containerSpecMetricsList []*repository.ContainerSpecMetrics
 	for _, pod := range collector.podList {
 		// Create ContainerSpecMetrics only if Pod is deployed by a K8s controller
@@ -69,7 +69,7 @@ func (collector *ContainerSpecMetricsCollector) CollectContainerSpecMetrics() ([
 			}
 		}
 	}
-	return containerSpecMetricsList, nil
+	return containerSpecMetricsList
 }
 
 // collectContainerMetrics collects container metrics from metricsSink and stores them in the given ContainerSpecMetrics

--- a/pkg/discovery/worker/container_spec_metrics_collector_test.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector_test.go
@@ -187,7 +187,7 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithoutReques
 	metricsSink.UpdateMetricEntry(containerFooMemUsedMetric2)
 
 	containerSpecMetricsCollector := NewContainerSpecMetricsCollector(metricsSink, pods)
-	containerSpecMetricsList, _ := containerSpecMetricsCollector.CollectContainerSpecMetrics()
+	containerSpecMetricsList := containerSpecMetricsCollector.CollectContainerSpecMetrics()
 
 	expectedContainerSpecMetricsFoo := &repository.ContainerSpecMetrics{
 		Namespace:         namespace,
@@ -235,7 +235,7 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithRequestMe
 	metricsSink.UpdateMetricEntry(containerBarMemRequestUsedMetric4)
 
 	containerSpecMetricsCollector := NewContainerSpecMetricsCollector(metricsSink, pods)
-	containerSpecMetricsList, _ := containerSpecMetricsCollector.CollectContainerSpecMetrics()
+	containerSpecMetricsList := containerSpecMetricsCollector.CollectContainerSpecMetrics()
 
 	expectedContainerSpecMetricsBar := &repository.ContainerSpecMetrics{
 		Namespace:         namespace,

--- a/pkg/discovery/worker/controller_metrics_collector.go
+++ b/pkg/discovery/worker/controller_metrics_collector.go
@@ -30,11 +30,7 @@ func NewControllerMetricsCollector(discoveryWorker *k8sDiscoveryWorker, currTask
 
 // Collect allocation resource metrics for K8s controllers where usage values are aggregated from pods and capacity values
 // are from namespace quota capacity.
-func (collector *ControllerMetricsCollector) CollectControllerMetrics() ([]*repository.KubeController, error) {
-	if collector.cluster == nil {
-		return nil, fmt.Errorf("error collecting K8s controller metrics, because cluster summary object is null for discovery worker %s",
-			collector.workerId)
-	}
+func (collector *ControllerMetricsCollector) CollectControllerMetrics() []*repository.KubeController {
 	kubeNamespaceMap := collector.cluster.NamespaceMap
 	// Map from controller UID to the corresponding kubeController
 	kubeControllersMap := make(map[string]*repository.KubeController)
@@ -85,7 +81,7 @@ func (collector *ControllerMetricsCollector) CollectControllerMetrics() ([]*repo
 		// Update quota resources usage for the controller aggregated from pods quota usage
 		collector.updateQuotaResourcesUsed(kubeController, pod)
 	}
-	return kubeControllerList, nil
+	return kubeControllerList
 }
 
 // Get KubeController info from the given pod from metrics sink, including controller type, name and UID.

--- a/pkg/discovery/worker/controller_metrics_collector_test.go
+++ b/pkg/discovery/worker/controller_metrics_collector_test.go
@@ -117,7 +117,7 @@ func TestCollectControllerMetrics(t *testing.T) {
 
 	// Test CollectControllerMetrics
 	controllerMetricsCollector := NewControllerMetricsCollector(discoveryWorker, currTask)
-	kubeControllers, _ := controllerMetricsCollector.CollectControllerMetrics()
+	kubeControllers := controllerMetricsCollector.CollectControllerMetrics()
 
 	// 2 KubeControllers are created
 	assert.Equal(t, 2, len(kubeControllers))

--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -127,10 +127,15 @@ func (d *Dispatcher) RegisterWorker(worker *k8sDiscoveryWorker) {
 func (d *Dispatcher) Dispatch(nodes []*api.Node, cluster *repository.ClusterSummary) int {
 	go func() {
 		for _, node := range nodes {
-			currPods := d.config.clusterInfoScraper.GetRunningAndReadyPodsOnNode(node)
+			runningPods := d.config.clusterInfoScraper.GetRunningPodsOnNode(node)
 			// Save the node to pods map in the cluster summary
-			cluster.SetRunningPodsOnNode(node, currPods)
-			currTask := task.NewTask().WithNode(node).WithPods(currPods).WithCluster(cluster)
+			cluster.SetRunningPodsOnNode(node, runningPods)
+			pendingPods := d.config.clusterInfoScraper.GetPendingPodsOnNode(node)
+			currTask := task.NewTask().
+				WithNode(node).
+				WithRunningPods(runningPods).
+				WithPendingPods(pendingPods).
+				WithCluster(cluster)
 			glog.V(2).Infof("Dispatching task %v", currTask)
 			d.assignTask(currTask)
 		}

--- a/pkg/discovery/worker/group_metrics_collector.go
+++ b/pkg/discovery/worker/group_metrics_collector.go
@@ -26,7 +26,7 @@ func NewGroupMetricsCollector(discoveryWorker *k8sDiscoveryWorker, currTask *tas
 	return metricsCollector
 }
 
-func (collector *GroupMetricsCollector) CollectGroupMetrics() ([]*repository.EntityGroup, error) {
+func (collector *GroupMetricsCollector) CollectGroupMetrics() []*repository.EntityGroup {
 	var entityGroupList []*repository.EntityGroup
 
 	entityGroups := make(map[string]*repository.EntityGroup)
@@ -84,7 +84,7 @@ func (collector *GroupMetricsCollector) CollectGroupMetrics() ([]*repository.Ent
 		}
 	}
 
-	return entityGroupList, nil
+	return entityGroupList
 }
 
 func (collector *GroupMetricsCollector) getGroupName(etype metrics.DiscoveredEntityType, entityKey string) (string, string, error) {

--- a/pkg/discovery/worker/k8s_discovery_worker_test.go
+++ b/pkg/discovery/worker/k8s_discovery_worker_test.go
@@ -30,7 +30,7 @@ func TestBuildDTOsWithMissingMetrics(t *testing.T) {
 
 	currTask := task.NewTask().WithNodes([]*api.Node{node}).WithPods([]*api.Pod{pod})
 
-	_, _, err = worker.buildDTOs(currTask)
+	_, _ = worker.buildEntityDTOs(currTask)
 	if err != nil {
 		t.Errorf("Error while building DTOs: %v", err)
 	}

--- a/pkg/discovery/worker/metrics_collector.go
+++ b/pkg/discovery/worker/metrics_collector.go
@@ -1,8 +1,6 @@
 package worker
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
@@ -98,9 +96,10 @@ func (podCollectionMap PodMetricsByNodeAndNamespace) addPodMetric(podName, nodeN
 // Create Pod metrics by selecting the pod compute resource usages from the metrics sink.
 // The PodMetrics are organized in a map by node and namespace.
 // The discovery worker will add the PodMetrics to the metrics sink.
-func (collector *MetricsCollector) CollectPodMetrics() (PodMetricsByNodeAndNamespace, error) {
+func (collector *MetricsCollector) CollectPodMetrics() PodMetricsByNodeAndNamespace {
 	if collector.Cluster == nil {
-		return nil, fmt.Errorf("cluster summary object is null for discovery worker %s", collector.workerId)
+		glog.Errorf("Cluster summary object is null for discovery worker %s", collector.workerId)
+		return nil
 	}
 	podCollectionMap := make(PodMetricsByNodeAndNamespace)
 	// Iterate over all pods
@@ -127,7 +126,7 @@ func (collector *MetricsCollector) CollectPodMetrics() (PodMetricsByNodeAndNames
 		}
 		podCollectionMap.addPodMetric(pod.Name, nodeName, kubeNamespace.Name, podMetrics)
 	}
-	return podCollectionMap, nil
+	return podCollectionMap
 }
 
 // Return the capacity for the resource quota in a namespace

--- a/pkg/discovery/worker/metrics_collector_test.go
+++ b/pkg/discovery/worker/metrics_collector_test.go
@@ -252,8 +252,7 @@ func TestPodMetricsCollectionNullCluster(t *testing.T) {
 		PodList:     nodeToPodsMap[node1],
 	}
 
-	podCollection, err := collector.CollectPodMetrics()
-	assert.NotNil(t, err)
+	podCollection := collector.CollectPodMetrics()
 	assert.Nil(t, podCollection)
 }
 
@@ -277,7 +276,7 @@ func TestPodMetricsCollectionUnknownNamespace(t *testing.T) {
 		NodeList:    []*v1.Node{n1},
 	}
 
-	podCollection, _ := collector.CollectPodMetrics()
+	podCollection := collector.CollectPodMetrics()
 	assert.Equal(t, 0, len(podCollection))
 }
 
@@ -320,8 +319,7 @@ func TestPodMetricsCollectionSingleNode(t *testing.T) {
 		NodeList:    []*v1.Node{n1},
 	}
 
-	podCollection, err := collector.CollectPodMetrics()
-	assert.Nil(t, err)
+	podCollection := collector.CollectPodMetrics()
 	assert.NotNil(t, podCollection)
 	_, exists := podCollection[node1]
 	assert.True(t, exists)


### PR DESCRIPTION
## Problem

Currently we do not discover pods that are scheduled on a node, but not in ready state. This produces an incorrect state of the cluster:

* Wrong number of pods on a node
* Incorrect resource request usage on a node

The latter causes a more serious problem when market generates wrong Pod move and provision actions.

## Solution

We will discover the pods scheduled on a node but not in ready state. We will set the state of the pod to be:

* Power state: `Unknown`
* Controllable: `false`
* Suspendable: `false`
* Provisonable: `false`
* Monitored: `false`

The resource commodities discovered are `VCPURequest`, and `VMemRequest` only (i.e., no `VCPU` or `VMem` commodities). The quota commodities and access commodities (that lock the pods to node and cluster) are still discovered the same as ready pods. No volume and related commodities are discovered for these pods.

## Implementation
Most of the real changes are in `k8s_discovery_worker.go` and `pod_entity_dto_builder.go`.
* Refactor code to not returning `error` when discovering entities in `k8sDiscoveryWorker`. We already allow discovery to continue with non-fatal errors.
* In `podEntityDTOBuilder`, define resource types to discover for pending pods and running pods, and process pending and running pods separately. Properly set the state/flag for pending pods.
* Update unit tests accordingly.

## Testing
* Check the number of non-ready pods when scoping to a cluster:

![image](https://user-images.githubusercontent.com/10012486/95108005-aa1b9800-0708-11eb-8a23-4af330e11aee.png)

* View the `unknown` pods from the list. We cannot sort pods by state yet:

![image](https://user-images.githubusercontent.com/10012486/95108131-dc2cfa00-0708-11eb-8238-ff7854e98161.png)

* The following is a pod in `Init` status with non-zero resource request:

```
NAME                         READY   STATUS     RESTARTS   AGE
redis-0                      0/2     Init:0/1   0          32d
```
![image](https://user-images.githubusercontent.com/10012486/95105721-91f64980-0705-11eb-921e-d83b055c3189.png)

* The following is a pod in `` status with **no** resource request:

```
NAME                            READY   STATUS             RESTARTS   AGE
cert-manager-7c4fdf69b7-bc67h   0/1     ImagePullBackOff   0          59d
```
![image](https://user-images.githubusercontent.com/10012486/95106144-21036180-0706-11eb-9588-905310077919.png)
