### PR TITLE
Fallback to the API Server node proxy path if kubelet call fails

### DIFF
--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -123,7 +123,7 @@ func (m *KubeletMonitor) scrapeKubelet(node *api.Node) {
 		return
 	}
 	// get summary information about the given node and the pods running on it.
-	summary, err := kc.GetSummary(ip)
+	summary, err := kc.GetSummary(ip, node.Name)
 	if err != nil {
 		glog.Errorf("Failed to get resource metrics summary from %s: %s", node.Name, err)
 		return

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -143,7 +143,7 @@ func (p *ClusterProcessor) connectToNodes() (bool, error) {
 // Checks the node connectivity be querying the kubelet summary endpoint
 func checkNode(node *v1.Node, kc kubeclient.KubeHttpClientInterface) error {
 	ip := repository.ParseNodeIP(node, v1.NodeInternalIP)
-	_, err := kc.GetSummary(ip)
+	_, err := kc.GetSummary(ip, node.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -217,7 +217,7 @@ func TestConnectCluster(t *testing.T) {
 	}
 
 	ns := &MockNodeScrapper{
-		mockGetSummary: func(host string) (*stats.Summary, error) {
+		mockGetSummary: func(ip, nodeName string) (*stats.Summary, error) {
 			summary := stats.Summary{}
 			return &summary, nil
 		},
@@ -244,8 +244,8 @@ func TestConnectClusterUnreachableNodes(t *testing.T) {
 	}
 
 	ns := &MockNodeScrapper{
-		mockGetSummary: func(host string) (*stats.Summary, error) {
-			return nil, fmt.Errorf("%s node is unreachable", host)
+		mockGetSummary: func(ip, nodeName string) (*stats.Summary, error) {
+			return nil, fmt.Errorf("%s node is unreachable", ip)
 		},
 	}
 
@@ -270,7 +270,7 @@ func TestConnectClusterReachableAndUnreachableNodes(t *testing.T) {
 	}
 
 	ns := &MockNodeScrapper{
-		mockGetSummary: func(host string) (*stats.Summary, error) {
+		mockGetSummary: func(ip, nodeName string) (*stats.Summary, error) {
 			summary := stats.Summary{}
 			return &summary, nil
 		},
@@ -370,29 +370,29 @@ func (s *MockClusterScrapper) GetAllPVCs() ([]*v1.PersistentVolumeClaim, error) 
 // Implements the KubeHttpClientInterface
 // Method implementation will check to see if the test has provided the mockXXX method function
 type MockNodeScrapper struct {
-	mockExecuteRequestAndGetValue func(host string, endpoint string, value interface{}) error
-	mockGetSummary                func(host string) (*stats.Summary, error)
-	mockGetMachineInfo            func(host string) (*cadvisorapi.MachineInfo, error)
+	mockExecuteRequestAndGetValue func(ip, nodeName, path string, value interface{}) error
+	mockGetSummary                func(ip, nodeName string) (*stats.Summary, error)
+	mockGetMachineInfo            func(ip, nodeName string) (*cadvisorapi.MachineInfo, error)
 	mockGetNodeCpuFrequency       func(node *v1.Node) (float64, error)
 }
 
-func (s *MockNodeScrapper) ExecuteRequestAndGetValue(host string, endpoint string, value interface{}) error {
+func (s *MockNodeScrapper) ExecuteRequestAndGetValue(ip, nodeName, path string, value interface{}) error {
 	if s.mockExecuteRequestAndGetValue != nil {
-		return s.mockExecuteRequestAndGetValue(host, endpoint, value)
+		return s.mockExecuteRequestAndGetValue(ip, "", path, value)
 	}
 	return fmt.Errorf("ExecuteRequestAndGetValue Not implemented")
 }
 
-func (s *MockNodeScrapper) GetSummary(host string) (*stats.Summary, error) {
+func (s *MockNodeScrapper) GetSummary(ip, nodeName string) (*stats.Summary, error) {
 	if s.mockGetSummary != nil {
-		return s.mockGetSummary(host)
+		return s.mockGetSummary(ip, nodeName)
 	}
 	return nil, fmt.Errorf("GetSummary Not implemented")
 }
 
-func (s *MockNodeScrapper) GetMachineInfo(host string) (*cadvisorapi.MachineInfo, error) {
+func (s *MockNodeScrapper) GetMachineInfo(ip, nodeName string) (*cadvisorapi.MachineInfo, error) {
 	if s.mockGetMachineInfo != nil {
-		return s.mockGetMachineInfo(host)
+		return s.mockGetMachineInfo(ip, nodeName)
 	}
 	return nil, fmt.Errorf("GetMachineInfo Not implemented")
 }

--- a/pkg/kubeclient/kubelet_client_test.go
+++ b/pkg/kubeclient/kubelet_client_test.go
@@ -68,13 +68,13 @@ func TestKubeletClientCacheNil(t *testing.T) {
 	kubeConf := &rest.Config{}
 	conf := NewKubeletConfig(kubeConf)
 
-	kc, _ := conf.Create(nil, "busybox")
+	kc, _ := conf.Create(nil, "busybox", false)
 	entry := &CacheEntry{}
 	kc.cache["host_1"] = entry
 	assert.False(t, kc.HasCacheBeenUsed("host_1"))
-	_, err := kc.GetSummary("host_1")
+	_, err := kc.GetSummary("host_1", "")
 	assert.NotNil(t, err)
 
-	_, err2 := kc.GetMachineInfo("host_1")
+	_, err2 := kc.GetMachineInfo("host_1", "")
 	assert.NotNil(t, err2)
 }


### PR DESCRIPTION
This implements falling back on to the nodes proxy endpoint via API server if the kubelet call to the node IP fails.
Each of this fallback will log a message at loglevel 2.
Too many of these messages would mean a global problem in the environment, in which case the flag to use the proxy endpoint always can be turned on.