### PR TITLE
Add legacy support of cpu and memory as keys in quota spec

### DIFF
--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -53,7 +53,13 @@ var (
 	}
 
 	// Mapping of Kubernetes API Server resource names to the allocation resource types
+	// A resource quota definition, although undocumented, honours both "cpu" and "requests.cpu"
+	// as keys for cpu request quota and likewise for memory.
+	// This has more to do with legacy support, where when the resourcequota proposal was introduced
+	// had support only for "cpu" and "memory" corresponding to limiting only requests.
 	KubeQuotaResourceTypes = map[v1.ResourceName]ResourceType{
+		v1.ResourceCPU:            CPURequestQuota,
+		v1.ResourceMemory:         MemoryRequestQuota,
 		v1.ResourceLimitsCPU:      CPULimitQuota,
 		v1.ResourceLimitsMemory:   MemoryLimitQuota,
 		v1.ResourceRequestsCPU:    CPURequestQuota,
@@ -104,9 +110,9 @@ func init() {
 	}
 	// Compute QuotaResources from the KubeQuotaResourceTypes map
 	for name, resource := range KubeQuotaResourceTypes {
-		QuotaResources = append(QuotaResources, resource)
-		if name == v1.ResourceLimitsCPU || name == v1.ResourceRequestsCPU {
-			cpuResources = append(cpuResources, resource)
+		QuotaResources = appendUnique(QuotaResources, resource)
+		if name == v1.ResourceCPU || name == v1.ResourceLimitsCPU || name == v1.ResourceRequestsCPU {
+			cpuResources = appendUnique(cpuResources, resource)
 		}
 	}
 	// Compute CPUResources
@@ -119,6 +125,17 @@ func init() {
 	for k, v := range QuotaToComputeMap {
 		ComputeToQuotaMap[v] = k
 	}
+}
+
+func appendUnique(resourceTypes []ResourceType, resourceType ResourceType) []ResourceType {
+	for _, rt := range resourceTypes {
+		if rt == resourceType {
+			// This type is already in the slice, don't add
+			return resourceTypes
+		}
+	}
+
+	return append(resourceTypes, resourceType)
 }
 
 // Returns true if the given resource type argument belongs to the list of allocation resources

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -388,6 +388,8 @@ func (kubeNamespace *KubeNamespace) ReconcileQuotas(quotas []*v1.ResourceQuota) 
 		resourceHardList := resourceStatus.Hard
 
 		for resource, _ := range resourceHardList {
+			// This will return resourceType as "limits.cpu" for resource as both "cpu" and "limits.cpu"
+			// Likewise for memory.
 			resourceType, isAllocationType := metrics.KubeQuotaResourceTypes[resource]
 			if !isAllocationType { // skip if it is not a allocation type resource
 				continue


### PR DESCRIPTION
This fixes https://vmturbo.atlassian.net/browse/OM-63295

Verified the fix using scenario listed at https://github.com/turbonomic/Turbo-ScenarioAsCode/tree/master/namespaceQuota

Using [scenario4](https://github.com/turbonomic/Turbo-ScenarioAsCode/tree/master/namespaceQuota/namespaceQuota4CPU)
and creating a quota resource with below spec:
```apiVersion: v1
kind: ResourceQuota
metadata:
  name: nsquota-test-cpu-multi-deployments
  namespace: nsquota-test-cpu-multi-deployments
spec:
  hard:
    cpu: "30m"
    memory: 100Mi
    limits.cpu: "30m"
    limits.memory: 150Mi
```
request capacities for namespace (which correspond to request.cpu and request.memory) are properly discovered:
![image](https://user-images.githubusercontent.com/10027921/96081110-5842f100-0f04-11eb-9318-23651ae259ad.png)
