### PR TITLE
Discover namespace labels and annotations and tag properties

### DIFF
--- a/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
@@ -2,6 +2,7 @@ package dtofactory
 
 import (
 	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
@@ -47,7 +48,9 @@ func (builder *namespaceEntityDTOBuilder) BuildEntityDTOs() ([]*proto.EntityDTO,
 		entityDTOBuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
 
 		// build entityDTO.
-		entityDto, err := entityDTOBuilder.Create()
+		entityDto, err := entityDTOBuilder.WithProperties(property.
+			BuildNamespaceProperties(namespace.TagProperties)).
+			Create()
 		if err != nil {
 			glog.Errorf("Failed to build Namespace entityDTO: %s", err)
 			continue

--- a/pkg/discovery/dtofactory/property/namespace_properties.go
+++ b/pkg/discovery/dtofactory/property/namespace_properties.go
@@ -1,0 +1,26 @@
+package property
+
+import (
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+// Build entity properties of a namespace.
+func BuildNamespaceProperties(tagMaps []map[string]string) []*proto.EntityDTO_EntityProperty {
+	var properties []*proto.EntityDTO_EntityProperty
+	tagsPropertyNamespace := VCTagsPropertyNamespace
+
+	for _, tagMap := range tagMaps {
+		for key, val := range tagMap {
+			tagNamePropertyName := key
+			tagNamePropertyValue := val
+			tagProperty := &proto.EntityDTO_EntityProperty{
+				Namespace: &tagsPropertyNamespace,
+				Name:      &tagNamePropertyName,
+				Value:     &tagNamePropertyValue,
+			}
+			properties = append(properties, tagProperty)
+		}
+	}
+
+	return properties
+}

--- a/pkg/discovery/processor/namespace_processor.go
+++ b/pkg/discovery/processor/namespace_processor.go
@@ -43,6 +43,7 @@ func (p *NamespaceProcessor) ProcessNamespaces() {
 		// Create default namespace object
 		kubeNamespaceUID := string(item.UID)
 		kubeNamespace := repository.CreateDefaultKubeNamespace(clusterName, item.Name, kubeNamespaceUID)
+		kubeNamespace.TagProperties = append(kubeNamespace.TagProperties, item.GetLabels(), item.GetAnnotations())
 
 		// update the default quota limits using the defined resource quota objects
 		quotaList, hasQuota := quotaMap[item.Name]
@@ -50,6 +51,7 @@ func (p *NamespaceProcessor) ProcessNamespaces() {
 			kubeNamespace.QuotaList = quotaList
 			kubeNamespace.ReconcileQuotas(quotaList)
 		}
+
 		namespaces[item.Name] = kubeNamespace
 		glog.V(4).Infof("Created namespace entity: %s.", kubeNamespace.String())
 

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -327,6 +327,9 @@ type KubeNamespace struct {
 	QuotaList               []*v1.ResourceQuota
 	AverageNodeCpuFrequency float64
 	QuotaDefined            map[metrics.ResourceType]bool
+
+	// Stores the labels and annotations on the given namespace
+	TagProperties []map[string]string
 }
 
 func (kubeNamespace *KubeNamespace) String() string {


### PR DESCRIPTION
Partially implements https://vmturbo.atlassian.net/browse/OM-63564.
The labels and annotations are reported as tag properties on a namespace; for example:

```      "entityProperties": [
        {
          "namespace": "VCTAGS",
          "name": "mine",
          "value": "testing"
        }
      ],
```
for the namespace label as below:

```
k get ns irf --show-labels
NAME   STATUS   AGE   LABELS
irf    Active   13d   mine=testing
```

The grouping filter however does not have tags for selection against the namespaces in the server, which might need additional work there for this functionality to be complete.