### PR TITLE
Set numCPUs in cores to VirtualMachineData when building node entity DTO.

### DIFF
--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -133,6 +133,7 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) []*proto
 			entityDTOBuilder = entityDTOBuilder.WithPowerState(proto.EntityDTO_POWERSTATE_UNKNOWN)
 		}
 
+		// Get CPU capacity in cores.
 		cpuMetricValue, err := builder.metricValue(metrics.NodeType, nodeKey, metrics.CPU, metrics.Capacity, nil)
 		if err != nil {
 			glog.Errorf("Failed to get number of CPU in cores for VM %s: %v", nodeKey, err)


### PR DESCRIPTION
This is Kubeturbo side change for this JIRA: https://vmturbo.atlassian.net/browse/OM-63243.

**Background**:
We are introducing new set of settings to ContainerSpec policy to allow users define resize max/min thresholds, which are already applied to VM policy. Specifically for VCPU/VCPURequest thresholds, the unit of the setting value is in millicores instead of MHz, which will be more user friendly for users who are familiar with CloudNative environment. This is equivalent to VM policy, where VCPU thresholds settings are in cores.

Meanwhile, the market analysis in Turbo platform side recommend VCPU/VCPURequest resize actions based on MHz. So we need to provide CPU speed to convert the user specified millicores into MHz to feed to analysis engine.

The way works for VM policy is to calculate CPU speed by `VCPU commodity capacity (in MHz) / numCPUs in cores`. Similarly to convert VCPU/VCPURequest thresholds in millicores to MHz, we need to get CPU speed from the underlying node (VM). 

In a stitching environment with kubeturbo and VC targets, or kubeturbo and cloud targets (AWS/Azure), number of CPUs are provided from the VM from underlying infrastructure. So for individual kubeturbo case, we need to send number of CPUs as well on the nodes.

**Implementation**:
Set numCPUs in cores to `NumCpus` of `EntityDTO_VirtualMachineData` for each discovered node. All the following steps to parse this piece of data to the final TopologyDTO data in Turbo platform will be automatically done by the existing mechanism.

**Testing Done**:
Tested with the changes. In the discovery response DTO data, "numCPUs" is correctly populated in `virtual_machine_data` for each VM discovered from Kubeturbo, for example:
```
entityDTO {
  entityType: VIRTUAL_MACHINE
  id: "fddcecd0-fb27-11e9-a641-0050568018c4"
  displayName: "pt-okd-master-3"
  ...
  virtual_machine_data {
    ipAddress: "10.10.170.180"
    ipAddress: "pt-okd-master-3"
    numCpus: 4
  }
}
```