### PR TITLE
Support executing CPU resize actions directly on values in millicores from ActionItem instead of converting from MHz.

### DIFF
--- a/pkg/action/executor/resize_container_test.go
+++ b/pkg/action/executor/resize_container_test.go
@@ -70,7 +70,7 @@ func TestSetZeroRequestCPU(t *testing.T) {
 
 	rtype := k8sapi.ResourceCPU
 	spec := NewContainerResizeSpec(idx)
-	amount, err := genCPUQuantity(1200.0, 2400.0)
+	amount, err := genCPUQuantity(1200.0)
 	if err != nil {
 		t.Errorf("Failed to generate memory Quantity: %v", err)
 		return
@@ -132,7 +132,7 @@ func TestSetZeroRequestCPU2(t *testing.T) {
 
 	//1. specify memory request
 	req := pod.Spec.Containers[idx].Resources.Requests
-	amount1, err := genCPUQuantity(100.0, 2200.0)
+	amount1, err := genCPUQuantity(100.0)
 	if err != nil {
 		t.Errorf("Failed to generate CPU quantity: %v", err)
 		return
@@ -141,7 +141,7 @@ func TestSetZeroRequestCPU2(t *testing.T) {
 
 	//2. set the new Memory capacity
 	spec := NewContainerResizeSpec(idx)
-	amount, err := genCPUQuantity(1200.0, 2200.0)
+	amount, err := genCPUQuantity(1200.0)
 	if err != nil {
 		t.Errorf("Failed to generate memory Quantity: %v", err)
 		return
@@ -169,7 +169,7 @@ func TestSetZeroRequestCPUMemory(t *testing.T) {
 
 	//1. specify memory request
 	req := pod.Spec.Containers[idx].Resources.Requests
-	amount1, err := genCPUQuantity(100.0, 2200.0)
+	amount1, err := genCPUQuantity(100.0)
 	if err != nil {
 		t.Errorf("Failed to generate memory Quantity: %v", err)
 		return
@@ -220,7 +220,7 @@ func TestSetZeroRequestCPUMemory2(t *testing.T) {
 	spec.NewCapacity[rtypeMem] = amount
 
 	//2. set the new CPU capacity
-	amount2, err := genCPUQuantity(1000.0, 2200.0)
+	amount2, err := genCPUQuantity(1000.0)
 	if err != nil {
 		t.Errorf("Failed to generate cpu Quantity: %v", err)
 		return

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -2,8 +2,6 @@ package executor
 
 import (
 	"fmt"
-	"math"
-
 	"github.com/golang/glog"
 
 	"github.com/turbonomic/kubeturbo/pkg/action/util"
@@ -138,13 +136,9 @@ func updateResourceAmount(podSpec *k8sapi.PodSpec, specs []*containerResizeSpec,
 }
 
 // Generate a resource.Quantity for CPU.
-// it will convert CPU unit from MHz to CPU.core time in milliSeconds
-// @newValue is from OpsMgr, in MHz
-// @nodeCpuFrequency is from kubeletClient, in MHz
-func genCPUQuantity(newValue float64, nodeCpuFrequency float64) (resource.Quantity, error) {
-	tmp := newValue * 1000 // to milliSeconds
-	tmp = tmp / nodeCpuFrequency
-	cpuTime := int(math.Ceil(tmp))
+// @newValue is from Turbo platform, in millicores
+func genCPUQuantity(newValue float64) (resource.Quantity, error) {
+	cpuTime := int(newValue)
 	if cpuTime < 1 {
 		cpuTime = 1
 	}

--- a/pkg/action/executor/resize_container_util_test.go
+++ b/pkg/action/executor/resize_container_util_test.go
@@ -10,12 +10,11 @@ import (
 )
 
 func TestGenCPUQuantity(t *testing.T) {
-	nodeCPUfreq := float64(2600) //MHz
-	reqArray := []int{2600, 1300, 0, 5200}
-	expectArray := []int{1000, 500, 1, 2000}
+	reqArray := []int{2600, 1300}
+	expectArray := []int{2600, 1300}
 
 	for i, req := range reqArray {
-		q, err := genCPUQuantity(float64(req), nodeCPUfreq)
+		q, err := genCPUQuantity(float64(req))
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
JIRA: https://vmturbo.atlassian.net/browse/OM-63851

**Background and Intent**:
1. Previously VCPU/VCPURequest resize actions sent from Turbo server have values in MHz. We have to convert the capacity values from MHz to millicores based on corresponding node CPU frequency in `resize_container.go`.
2. With the improvement in the Turbo server side to translate container CPU resize actions from using MHz to millicores, the values in ActionItem sent from Turbo server are in millicores now. The intent is to remove the logic of the conversion from MHz to millicores when executing CPU resize actions in Kubeturbo.

**Implementation**:
Instead of converting values based on node CPU frequency, directly set CPU quantity as the given new capacity from actionItem.

**Note**:
We are not going to support backward compatibility. Values will not be correct during action execution if a user use old Turbo platform + new Kubeturbo image or vice versa. But we'll make sure customers will upgrade both Turbo platform and Kubeturbo same time to 8.0.3.

**Testing Done**:
Executed following actions on WorkloadController:
![Screen Shot 2020-11-11 at 11 11 18](https://user-images.githubusercontent.com/23689754/98836999-67886200-2410-11eb-9655-df6314cdac12.png)
Action was executed successfully with following log messages in Kubeturbo:
```
I1111 11:11:27.336447   20861 action_handler.go:339] Received an action RIGHT_SIZE for entity WORKLOAD_CONTROLLER [action-merge-test]
I1111 11:11:27.385831   20861 workload_controller_resizer.go:257] Begin to resize workload controller action-merge-test/action-merge-test.
I1111 11:11:27.400389   20861 resize_container_util.go:66] Try to update container cpu-mem-load resource limit from map[cpu:{i:{value:200 scale:-3} d:{Dec:<nil>} s:200m Format:DecimalSI} memory:{i:{value:209715200 scale:0} d:{Dec:<nil>} s: Format:BinarySI}] to map[cpu:{{218 -3} {<nil>} 218m DecimalSI} memory:{{209715200 0} {<nil>}  BinarySI}]
I1111 11:11:27.400425   20861 resize_container_util.go:66] Try to update container cpu-mem-load-test-sidecar resource limit from map[memory:{i:{value:209715200 scale:0} d:{Dec:<nil>} s: Format:BinarySI}] to map[memory:{{268435456 0} {<nil>}  BinarySI}]
I1111 11:11:27.416823   20861 k8s_controller_updater.go:131] Successfully updated Deployment of pod action-merge-test/action-merge-test-5557f7cc57-4nfm7
```
By checking the deployment, spec `cpu-mem-load` was updated to the correct CPU limit (218m):
```
$ kubectl -n action-merge-test get deployment action-merge-test -o yaml

    spec:
      containers:
      - env:
        - name: RUN_TYPE
          value: cpu
        - name: CPU_PERCENT
          value: "85"
        image: beekman9527/cpumemload:latest
        imagePullPolicy: IfNotPresent
        name: cpu-mem-load
        resources:
          limits:
            cpu: 218m
            memory: 200Mi
          requests:
            cpu: 100m
            memory: 130Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      - env:
        - name: RUN_TYPE
          value: memory
        - name: MEMORY_NUM
          value: "190"
        image: beekman9527/cpumemload:latest
        imagePullPolicy: IfNotPresent
        name: cpu-mem-load-test-sidecar
        resources:
          limits:
            memory: 256Mi
          requests:
            memory: 130Mi
```