### PR TITLE
Update the request used values from aggregated quota used values for a namespace

### DIFF
--- a/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
@@ -2,13 +2,14 @@ package dtofactory
 
 import (
 	"fmt"
+	"math"
+
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-	"math"
 )
 
 type namespaceEntityDTOBuilder struct {


### PR DESCRIPTION
…

Fixes https://vmturbo.atlassian.net/browse/OM-64126.
This is needed because #487 does not separately aggregate the `cpurequest` and `memoryrequest` values for a namespaces.

cc @enlinxu @chlam4 

verified working
![image](https://user-images.githubusercontent.com/10027921/99078674-e5b45680-2612-11eb-8d07-431a0a2be028.png)
