### PR TITLE
Adding aggregated-by relationship from container pod to workload controller to namespace to cluster to facilitate desired supply chain traversals

### DIFF
--- a/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
@@ -52,6 +52,8 @@ func (builder *namespaceEntityDTOBuilder) BuildEntityDTOs() ([]*proto.EntityDTO,
 		entityDTOBuilder.Provider(sdkbuilder.CreateProvider(proto.EntityDTO_CONTAINER_PLATFORM_CLUSTER, namespace.ClusterName)).BuysCommodities(commoditiesBought)
 		// Set movable false to avoid moving Namespace across Clusters
 		entityDTOBuilder.IsMovable(proto.EntityDTO_CONTAINER_PLATFORM_CLUSTER, false)
+		// also set up the aggregatedBy relationship with the cluster
+		entityDTOBuilder.AggregatedBy(namespace.ClusterName)
 
 		// Namespace entity cannot be provisioned or suspended by Turbonomic analysis
 		entityDTOBuilder.IsProvisionable(false)

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -190,6 +190,8 @@ func (builder *podEntityDTOBuilder) buildDTOs(pods []*api.Pod, resCommTypeSold,
 				entityDTOBuilder.BuysCommodities(commoditiesBoughtQuota)
 				// pods are not movable across namespaces
 				entityDTOBuilder.IsMovable(proto.EntityDTO_NAMESPACE, false)
+				// also set up the aggregatedBy relationship with the namespace
+				entityDTOBuilder.AggregatedBy(namespaceUID)
 			} else {
 				glog.Errorf("Failed to get namespaceUID from namespace %s for pod %s", pod.Namespace, pod.Name)
 			}

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -206,6 +206,8 @@ func (builder *podEntityDTOBuilder) buildDTOs(pods []*api.Pod, resCommTypeSold,
 			entityDTOBuilder.BuysCommodities(commoditiesBoughtQuota)
 			// pods are not movable across WorkloadController
 			entityDTOBuilder.IsMovable(proto.EntityDTO_WORKLOAD_CONTROLLER, false)
+			// also set up the aggregatedBy relationship with the controller
+			entityDTOBuilder.AggregatedBy(controllerUID)
 		}
 
 		mounts := builder.podToVolumesMap[displayName]

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
@@ -53,6 +53,8 @@ func (builder *workloadControllerDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, er
 			entityDTOBuilder.Provider(sdkbuilder.CreateProvider(proto.EntityDTO_NAMESPACE, namespaceUID)).BuysCommodities(commoditiesBought)
 			// Set movable false to avoid moving WorkloadController across namespaces
 			entityDTOBuilder.IsMovable(proto.EntityDTO_NAMESPACE, false)
+			// also set up the aggregatedBy relationship with the namespace
+			entityDTOBuilder.AggregatedBy(namespaceUID)
 		} else {
 			glog.Errorf("Failed to get namespaceUID from namespace %s for controller %s", kubeController.Namespace,
 				kubeController.GetFullName())

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
@@ -1,6 +1,7 @@
 package dtofactory
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
@@ -101,6 +102,21 @@ func TestBuildDTOs(t *testing.T) {
 			workloadControllerData2 := entityDTO.GetWorkloadControllerData()
 			assert.EqualValues(t, expectedWorkloadControllerData2, workloadControllerData2)
 		}
+
+		// Test AggregatedBy relationship
+		assert.True(t, len(entityDTO.ConnectedEntities) > 0,
+			fmt.Sprintf("WorkloadController %v should have at least one connected entity - the namespace",
+				entityDTO.DisplayName))
+		hasAggregatedBy := false
+		for _, connectedEntity := range entityDTO.ConnectedEntities {
+			if connectedEntity.GetConnectionType() == proto.ConnectedEntity_AGGREGATED_BY_CONNECTION {
+				hasAggregatedBy = true
+				assert.Equal(t, testNamespaceUID, connectedEntity.GetConnectedEntityId(),
+					fmt.Sprintf("WorkloadController %v must be aggregated by namespace %v but is aggregated by %v instead",
+						entityDTO.DisplayName, testNamespaceUID, connectedEntity.GetConnectedEntityId()))
+			}
+		}
+		assert.True(t, hasAggregatedBy, fmt.Sprintf("Namespace %v does not have an AggregatedBy connection", entityDTO.DisplayName))
 	}
 }
 


### PR DESCRIPTION
This PR is adding the AggregatedBy relationship to the followings to facilitate desired supply chain traversals without special rules (requiring corresponding turbo server side changes which will be in 8.0.4):
- From ContainerPod to WorkloadController
- From WorkloadController to Namespace
- From Namespace to ContainerCluster

With the server side changes, this will address the following two JIRAs:
- https://vmturbo.atlassian.net/browse/OM-64005
- https://vmturbo.atlassian.net/browse/OM-64087

The ContainerCluster supply chain will now look like this
<img width="329" alt="from-container-cluster" src="https://user-images.githubusercontent.com/6045065/99551575-03bee580-298a-11eb-8b28-1b1a8d08cef7.png">
The ContainerCluster will now be reached from a Container or a ContainerSpec or a Container Volume:
From a Container:
<img width="335" alt="from-container" src="https://user-images.githubusercontent.com/6045065/99551205-8f844200-2989-11eb-83ad-59a26f18a743.png">
From a ContainerSpec:
<img width="320" alt="from-container-spec" src="https://user-images.githubusercontent.com/6045065/99551223-96ab5000-2989-11eb-927c-7baff8136005.png">
From a container Volume:
<img width="330" alt="from-container-volume" src="https://user-images.githubusercontent.com/6045065/99551781-41bc0980-298a-11eb-8d1c-16e632eccbde.png">

