### PR TITLE
A few enhancements to kubeturbo operator

### DIFF
--- a/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
+++ b/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
@@ -41,11 +41,13 @@ spec:
         metadata:
           type: object
         spec:
+          type: Object
           properties:
             replicaCount:
               description: Kubeturbo replicaCount
               type: integer
             image:
+              type: Object
               description: Kubeturbo image details for deployments outside of RH Operator Hub
               properties:
                 repository:
@@ -57,7 +59,11 @@ spec:
                 pullPolicy:
                   description: Define pull policy, Always is default
                   type: string
+                imagePullSecret:
+                  description: Define the secret used to authenticate to the container image registry
+                  type: string
             serverMeta:
+              type: Object
               description: Configuration for Turbo Server
               properties:
                 version:
@@ -67,6 +73,7 @@ spec:
                   description: URL for Turbo Server endpoint
                   type: string
             restAPIConfig:
+              type: Object
               description: Credentials to register probe with Turbo Server
               properties:
                 turbonomicCredentialsSecretName:
@@ -79,18 +86,21 @@ spec:
                   description: Turbo admin user password
                   type: string
             HANodeConfig:
+              type: Object
               description: Create HA placement policy for Node to Hypervisor by node role. Master is default
               properties:
                 nodeRoles:
                   description: Node role names
                   type: string, quote
             targetConfig:
+              type: Object
               description: Optional target configuration
               properties:
                 targetName:
                   description: Optional target name for registration
                   type: string
             args:
+              type: Object
               description: Kubeturbo command line arguments
               properties:
                 logginglevel:
@@ -109,9 +119,11 @@ spec:
                   description: Allow kubeturbo to execute actions in OCP
                   type: string
             resources:
+              type: Object
               description: Kubeturbo resource configuration
               properties:
                 limits:
+                  type: Object
                   description: Define limits
                   properties:
                     memory:
@@ -121,6 +133,7 @@ spec:
                       description: Define cpu limits in cores or millicores, include units
                       type: string
                 requests:
+                  type: Object
                   description: Define requests
                   properties:
                     memory:

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: turbo-user
+{{- if .Values.image.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.imagePullSecret }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
 {{- if .Values.image.related }}

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/serviceaccount.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: turbo-user
+  name: {{ .Values.serviceAccountName }}
 {{- if eq .Values.roleName "turbo-cluster-reader" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -91,7 +91,7 @@ kind: ClusterRoleBinding
 # For kubernetes 1.8 use rbac.authorization.k8s.io/v1beta1
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: turbo-all-binding
+  name: {{ .Values.roleBinding }}
 subjects:
   - kind: ServiceAccount
     name: turbo-user

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -19,6 +19,12 @@ annotations:
 # Specify custom turbo-cluster-reader or turbo-cluster-admin role instead of the default cluster-admin role
 roleName: "cluster-admin"
 
+# Specify the name of clusterrolebinding
+roleBinding: "turbo-all-binding"
+
+# Specify the name of the serviceaccount
+serviceAccountName: "turbo-user"
+
 # Turbo server version and address
 serverMeta:
   version: 8.0


### PR DESCRIPTION
This PR makes a few enhancements to the `kubeturbo` operator:

* Allow specifying `imagePullSecret`
* Allow customizing the name of `clusterrolebinding` and `serviceaccount`

Example:
```
spec:
  image:
    imagePullSecret: turboregistrykey
  restAPIConfig:
    opsManagerPassword: a
    opsManagerUserName: administrator
  roleBinding: turbo-all-binding-meng
  serverMeta:
    turboServer: https://10.10.170.117
    version: 8.0.4
  serviceAccountName: turbo-user-meng
  targetConfig:
    targetName: ccp1
```

* Fix schema violations

I see the following violations in the `kubeturbo` CRD status, caused by errors in the schema definitions in CRD:
```
  - lastTransitionTime: "2020-12-03T02:22:17Z"
    message: '[spec.validation.openAPIV3Schema.properties[spec].properties[HANodeConfig].type:
      Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.properties[spec].properties[args].type:
      Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.properties[spec].properties[image].type:
      Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.properties[spec].properties[resources].properties[limits].type:
      Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.properties[spec].properties[resources].properties[requests].type:
      Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.properties[spec].properties[resources].type:
      Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.properties[spec].properties[restAPIConfig].type:
      Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.properties[spec].properties[serverMeta].type:
      Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.properties[spec].properties[targetConfig].type:
      Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.properties[spec].type:
      Required value: must not be empty for specified object fields]'
    reason: Violations
    status: "True"
    type: NonStructuralSchema

```
