### PR TITLE
Use spec from the workload controller for merged actions

### DIFF
--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -110,8 +110,8 @@ func (c *k8sControllerUpdater) updateWithRetry(ctlrSpec *controllerSpec) error {
 //   update the current specification in place if the changes are valid
 // - Update the controller object with the server after a successful reconciliation
 func (c *k8sControllerUpdater) update(desired *controllerSpec) error {
-	glog.V(4).Infof("Begin to update %v of pod %s/%s",
-		c.controller, c.namespace, c.podName)
+	glog.V(4).Infof("Begin to update %v %s/%s",
+		c.controller, c.namespace, c.name)
 	current, err := c.controller.get(c.name)
 	if err != nil {
 		return err
@@ -121,15 +121,15 @@ func (c *k8sControllerUpdater) update(desired *controllerSpec) error {
 		return err
 	}
 	if !updated {
-		glog.V(2).Infof("%v of pod %s/%s has already been updated to the desired specification",
-			c.controller, c.namespace, c.podName)
+		glog.V(2).Infof("%v %s/%s has already been updated to the desired specification",
+			c.controller, c.namespace, c.name)
 		return nil
 	}
 	if err := c.controller.update(current); err != nil {
 		return err
 	}
-	glog.V(2).Infof("Successfully updated %v of pod %s/%s",
-		c.controller, c.namespace, c.podName)
+	glog.V(2).Infof("Successfully updated %v %s/%s",
+		c.controller, c.namespace, c.name)
 	return nil
 }
 
@@ -145,8 +145,8 @@ func (c *k8sControllerUpdater) reconcile(current *k8sControllerSpec, desired *co
 			return false, err
 		}
 		// Update the replicas of the controller
-		glog.V(2).Infof("Try to update replicas of %v from %d to %d",
-			c.controller, *current.replicas, num)
+		glog.V(2).Infof("Try to update replicas of %v %s/%s from %d to %d",
+			c.controller, c.namespace, c.name, *current.replicas, num)
 		*current.replicas = num
 		return true, nil
 	}
@@ -160,8 +160,8 @@ func (c *k8sControllerUpdater) reconcile(current *k8sControllerSpec, desired *co
 			indexes = indexes + strconv.Itoa(spec.Index) + ","
 		}
 	}
-	glog.V(4).Infof("Try to update resources for container indexes: %s in pod %v/%v's spec.",
-		indexes, c.namespace, c.podName)
+	glog.V(4).Infof("Try to update resources for container indexes: %s in pod template spec of %v %s/%s .",
+		indexes, c.controller, c.namespace, c.name)
 	updated, err := updateResourceAmount(current.podSpec, desired.resizeSpecs, current.controllerName)
 	if err != nil {
 		return false, err

--- a/pkg/action/executor/resize_container_test.go
+++ b/pkg/action/executor/resize_container_test.go
@@ -2,11 +2,12 @@ package executor
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	k8sapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func createPod() *k8sapi.Pod {
@@ -54,7 +55,7 @@ func TestSetZeroRequestMemory(t *testing.T) {
 	spec.NewCapacity[rtype] = amount
 
 	resizer := &ContainerResizer{}
-	resizer.setZeroRequest(pod, idx, spec)
+	resizer.setZeroRequest(pod.Name, &pod.Spec, idx, spec)
 
 	if v, exist := spec.NewRequest[rtype]; !exist {
 		t.Error("Failed to set zero request")
@@ -79,7 +80,7 @@ func TestSetZeroRequestCPU(t *testing.T) {
 	fmt.Printf("amount = %++v", amount)
 
 	resizer := &ContainerResizer{}
-	resizer.setZeroRequest(pod, idx, spec)
+	resizer.setZeroRequest(pod.Name, &pod.Spec, idx, spec)
 
 	if v, exist := spec.NewRequest[rtype]; !exist {
 		t.Error("Failed to set zero request")
@@ -115,7 +116,7 @@ func TestSetZeroRequestMemory2(t *testing.T) {
 	spec.NewCapacity[rtype] = amount
 
 	resizer := &ContainerResizer{}
-	resizer.setZeroRequest(pod, idx, spec)
+	resizer.setZeroRequest(pod.Name, &pod.Spec, idx, spec)
 
 	if _, exist := spec.NewRequest[rtype]; exist {
 		t.Errorf("Should not set %v to zero", rtype)
@@ -150,7 +151,7 @@ func TestSetZeroRequestCPU2(t *testing.T) {
 
 	//3. update it
 	resizer := &ContainerResizer{}
-	resizer.setZeroRequest(pod, idx, spec)
+	resizer.setZeroRequest(pod.Name, &pod.Spec, idx, spec)
 
 	//4. check result
 	if _, exist := spec.NewRequest[rtype]; exist {
@@ -187,7 +188,7 @@ func TestSetZeroRequestCPUMemory(t *testing.T) {
 
 	//3. update it
 	resizer := &ContainerResizer{}
-	resizer.setZeroRequest(pod, idx, spec)
+	resizer.setZeroRequest(pod.Name, &pod.Spec, idx, spec)
 
 	//4. check it
 	if v, exist := spec.NewRequest[rtypeMem]; !exist {
@@ -229,7 +230,7 @@ func TestSetZeroRequestCPUMemory2(t *testing.T) {
 
 	//3. update it
 	resizer := &ContainerResizer{}
-	resizer.setZeroRequest(pod, idx, spec)
+	resizer.setZeroRequest(pod.Name, &pod.Spec, idx, spec)
 
 	//4. check it
 	if len(spec.NewRequest) != 2 {
@@ -256,7 +257,7 @@ func TestBuildResourceListsWithLimits(t *testing.T) {
 	}
 	spec := NewContainerResizeSpec(0)
 	resizer := &ContainerResizer{}
-	resizer.buildResourceLists(createPod(), actionItem, spec)
+	resizer.buildResourceLists(createPod().Name, actionItem, spec)
 
 	assert.Equal(t, 0, len(spec.NewRequest))
 	newMemoryCapacity := spec.NewCapacity[k8sapi.ResourceMemory]
@@ -270,7 +271,7 @@ func TestBuildResourceListsWithRequests(t *testing.T) {
 	}
 	spec := NewContainerResizeSpec(0)
 	resizer := &ContainerResizer{}
-	resizer.buildResourceLists(createPod(), actionItem, spec)
+	resizer.buildResourceLists(createPod().Name, actionItem, spec)
 
 	assert.Equal(t, 0, len(spec.NewCapacity))
 	newMemoryRequests := spec.NewRequest[k8sapi.ResourceMemory]


### PR DESCRIPTION
As there is no need to have the nodes cpu frequency for merged actions after #496, we don't need to have the complicated logic of finding out a pod from the workload controller and land into issues like https://vmturbo.atlassian.net/browse/OM-64853.

~~Marking it as WIP as there are many different scenarios that need test after this change and I could not test them yet.~~