### PR TITLE
Enhance pod move to copy annotations from parent

### DIFF
--- a/pkg/action/executor/move_util.go
+++ b/pkg/action/executor/move_util.go
@@ -482,22 +482,15 @@ func createClonePod(client *kclient.Clientset, pod *api.Pod, parent *unstructure
 		return nil, fmt.Errorf("movePod: error converting unstructured pod spec to typed pod spec for %s %s: %v", kind, parentName, err)
 	}
 	// annotations
-	annotationsUnstructured, found, err := unstructured.NestedFieldCopy(parent.Object, "metadata", "annotations")
-	if err != nil || !found {
+	annotations := make(map[string]string)
+	annotationsUnstructured, found, err := unstructured.NestedFieldCopy(parent.Object, "spec", "template", "metadata", "annotations")
+	if err != nil {
 		return nil, fmt.Errorf("movePod: error retrieving annotations from %s %s: %v", kind, parentName, err)
 	}
-	annotations := make(map[string]string)
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(annotationsUnstructured.(map[string]interface{}), &annotations); err != nil {
-		return nil, fmt.Errorf("movePod: error converting unstructured annotations to typed annotations for %s %s: %v", kind, parentName, err)
-	}
-	// labels
-	labelsUnstructured, found, err := unstructured.NestedFieldCopy(parent.Object, "metadata", "labels")
-	if err != nil || !found {
-		return nil, fmt.Errorf("movePod: error retrieving labels from %s %s: %v", kind, parentName, err)
-	}
-	labels := make(map[string]string)
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(labelsUnstructured.(map[string]interface{}), &labels); err != nil {
-		return nil, fmt.Errorf("movePod: error converting unstructured labels to typed labels for %s %s: %v", kind, parentName, err)
+	if found {
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(annotationsUnstructured.(map[string]interface{}), &annotations); err != nil {
+			return nil, fmt.Errorf("movePod: error converting unstructured annotations to typed annotations for %s %s: %v", kind, parentName, err)
+		}
 	}
 
 	// Set podSpec retrieved from parent. This saves from landing into
@@ -506,7 +499,6 @@ func createClonePod(client *kclient.Clientset, pod *api.Pod, parent *unstructure
 	npod.Spec.NodeName = nodeName
 	npod.Name = genNewPodName(pod)
 	npod.Annotations = annotations
-	npod.Labels = labels
 	// this annotation can be used for future garbage collection if action is interrupted
 	util.AddAnnotation(npod, TurboActionAnnotationKey, TurboMoveAnnotationValue)
 

--- a/pkg/action/executor/move_util.go
+++ b/pkg/action/executor/move_util.go
@@ -469,8 +469,10 @@ func createClonePod(client *kclient.Clientset, pod *api.Pod, parent *unstructure
 	npod := &api.Pod{}
 	copyPodWithoutLabel(pod, npod, false)
 
+	// copy pod spec, annotations, and labels from the parent
 	kind := parent.GetKind()
 	parentName := parent.GetName()
+	// pod spec
 	podSpecUnstructured, found, err := unstructured.NestedFieldCopy(parent.Object, "spec", "template", "spec")
 	if err != nil || !found {
 		return nil, fmt.Errorf("movePod: error retrieving podSpec from %s %s: %v", kind, parentName, err)
@@ -479,12 +481,32 @@ func createClonePod(client *kclient.Clientset, pod *api.Pod, parent *unstructure
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(podSpecUnstructured.(map[string]interface{}), &podSpec); err != nil {
 		return nil, fmt.Errorf("movePod: error converting unstructured pod spec to typed pod spec for %s %s: %v", kind, parentName, err)
 	}
+	// annotations
+	annotationsUnstructured, found, err := unstructured.NestedFieldCopy(parent.Object, "metadata", "annotations")
+	if err != nil || !found {
+		return nil, fmt.Errorf("movePod: error retrieving annotations from %s %s: %v", kind, parentName, err)
+	}
+	annotations := make(map[string]string)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(annotationsUnstructured.(map[string]interface{}), &annotations); err != nil {
+		return nil, fmt.Errorf("movePod: error converting unstructured annotations to typed annotations for %s %s: %v", kind, parentName, err)
+	}
+	// labels
+	labelsUnstructured, found, err := unstructured.NestedFieldCopy(parent.Object, "metadata", "labels")
+	if err != nil || !found {
+		return nil, fmt.Errorf("movePod: error retrieving labels from %s %s: %v", kind, parentName, err)
+	}
+	labels := make(map[string]string)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(labelsUnstructured.(map[string]interface{}), &labels); err != nil {
+		return nil, fmt.Errorf("movePod: error converting unstructured labels to typed labels for %s %s: %v", kind, parentName, err)
+	}
 
 	// Set podSpec retrieved from parent. This saves from landing into
 	// problems of sidecar containers and injection systems.
 	npod.Spec = podSpec
 	npod.Spec.NodeName = nodeName
 	npod.Name = genNewPodName(pod)
+	npod.Annotations = annotations
+	npod.Labels = labels
 	// this annotation can be used for future garbage collection if action is interrupted
 	util.AddAnnotation(npod, TurboActionAnnotationKey, TurboMoveAnnotationValue)
 


### PR DESCRIPTION
Currently when executing pod move, Kubeturbo copies the spec from the parent while the annotations are still from the pod since they're part of the metadata and not in the spec.  We've observed that pod move would fail under the following scenario:
- The pod has a sidecar injected by some webhook such as the Hashicorp vault one which injection uses an annotation to signal a successful mutation and blocks any further mutation.  See https://www.vaultproject.io/docs/platform/k8s/injector/annotations#vault-hashicorp-com-agent-inject-status
- When creating a new pod, Kubeturbo copies the entire annotations from the pod including that “agent-inject-status” field.  As such, no proper mutation/injection is done.  In the case the pod relies on the sidecar to properly start up (like needing the sidecar to pull db credentials for example), the pod will crash and the pod move action will fail.

To support this use case, we will also copy annotations from the parent instead of from the pod.  The parent's annotations do not have the extra status field, making the sidecar injection successfully and allowing the pod move action to succeed.

Tested in the failure environment and observed the move action now will now be successful with this change.  Also tested in an OpenShift environment where pods have extra annotations not coming from the parent resource (but from some OpenShift admission controller), and verified that, during our execution of pod move with this change, the new pod will still have those extra annotations injected properly.