### PR TITLE
Refactor and cache controllers

### DIFF
--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -7,14 +7,16 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/turbonomic/kubeturbo/pkg/cluster"
-	util2 "github.com/turbonomic/kubeturbo/pkg/discovery/util"
-	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
-	"github.com/turbonomic/kubeturbo/pkg/util"
+
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kclient "k8s.io/client-go/kubernetes"
+
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	discoveryutil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
+	"github.com/turbonomic/kubeturbo/pkg/util"
 )
 
 // k8sControllerUpdater defines a specific k8s controller resource
@@ -38,11 +40,11 @@ type controllerSpec struct {
 // newK8sControllerUpdaterViaPod returns a k8sControllerUpdater based on the parent kind of a pod
 func newK8sControllerUpdaterViaPod(clusterScraper *cluster.ClusterScraper, pod *api.Pod, ormClient *resourcemapping.ORMClient) (*k8sControllerUpdater, error) {
 	// Find parent kind of the pod
-	ownerInfo, _, _, err := clusterScraper.GetPodControllerInfo(pod, false)
+	ownerInfo, _, _, err := clusterScraper.GetPodControllerInfo(pod, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get parent info of pod %s/%s: %v", pod.Namespace, pod.Name, err)
 	}
-	if util2.IsOwnerInfoEmpty(ownerInfo) {
+	if discoveryutil.IsOwnerInfoEmpty(ownerInfo) {
 		return nil, fmt.Errorf("pod %s/%s does not have controller", pod.Namespace, pod.Name)
 	}
 	return newK8sControllerUpdater(clusterScraper, ormClient, ownerInfo.Kind, ownerInfo.Name, pod.Name, pod.Namespace)

--- a/pkg/action/executor/machine_scaler_capi.go
+++ b/pkg/action/executor/machine_scaler_capi.go
@@ -392,8 +392,8 @@ func newController(namespace string, nodeName string, diff int32, actionType Act
 		err = fmt.Errorf("cannot identify machine: %v", err)
 		return nil, nil, err
 	}
-	ownerInfo := discoveryutil.GetOwnerInfo(machine.OwnerReferences)
-	if discoveryutil.IsOwnerInfoEmpty(ownerInfo) {
+	ownerInfo, ownerSet := discoveryutil.GetOwnerInfo(machine.OwnerReferences)
+	if !ownerSet {
 		return nil, nil, fmt.Errorf("ownerRef missing from machine %s which manages %s", machine.Name, nodeName)
 	}
 	// TODO: Watch cluster-api evolution and check implementers other then openshift

--- a/pkg/action/executor/machine_scaler_capi.go
+++ b/pkg/action/executor/machine_scaler_capi.go
@@ -392,23 +392,18 @@ func newController(namespace string, nodeName string, diff int32, actionType Act
 		err = fmt.Errorf("cannot identify machine: %v", err)
 		return nil, nil, err
 	}
-
-	ownerKind, ownerName := "", ""
-	if machine.OwnerReferences != nil && len(machine.OwnerReferences) > 0 {
-		ownerKind, ownerName, _ = discoveryutil.ParseOwnerReferences(machine.OwnerReferences)
-		if !(len(ownerKind) > 0 && len(ownerName) > 0) {
-			return nil, nil, fmt.Errorf("OwnerRef missing from machine %s which manages %s.", machine.Name, nodeName)
-		}
-
+	ownerInfo := discoveryutil.GetOwnerInfo(machine.OwnerReferences)
+	if discoveryutil.IsOwnerInfoEmpty(ownerInfo) {
+		return nil, nil, fmt.Errorf("ownerRef missing from machine %s which manages %s", machine.Name, nodeName)
 	}
-
 	// TODO: Watch cluster-api evolution and check implementers other then openshift
 	// for a more generic implementation.
 	// In openshift we assume that machines are managed by machinesets.
-	if ownerKind != "MachineSet" {
-		return nil, nil, fmt.Errorf("Invalid owner kind [%s] for machine %s which manages %s.", ownerKind, machine.Name, nodeName)
+	if ownerInfo.Kind != "MachineSet" {
+		return nil, nil, fmt.Errorf("invalid owner kind [%s] for machine %s which manages %s",
+			ownerInfo.Kind, machine.Name, nodeName)
 	}
-	machineSet, err := client.machineSet.Get(context.TODO(), ownerName, metav1.GetOptions{})
+	machineSet, err := client.machineSet.Get(context.TODO(), ownerInfo.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -420,5 +415,5 @@ func newController(namespace string, nodeName string, diff int32, actionType Act
 
 	request := &actionRequest{client, nodeName, diff, actionType}
 	return &machineSetController{request, machineSet, machine, machineList},
-		&ownerName, nil
+		&ownerInfo.Name, nil
 }

--- a/pkg/action/executor/move_util.go
+++ b/pkg/action/executor/move_util.go
@@ -445,7 +445,7 @@ func isPodUsingVolume(pod *api.Pod) bool {
 func getPodOwnersInfo(clusterScraper *cluster.ClusterScraper, pod *api.Pod,
 	parentKind string) (*unstructured.Unstructured, *unstructured.Unstructured,
 	dynamic.ResourceInterface, dynamic.ResourceInterface, string, error) {
-	gpOwnerInfo, parent, nsParentClient, err := clusterScraper.GetPodControllerInfo(pod, true)
+	gpOwnerInfo, parent, nsParentClient, err := clusterScraper.GetPodControllerInfo(pod, false)
 	if err != nil {
 		return nil, nil, nil, nil, "", fmt.Errorf("error getting pods final owner: %v", err)
 	}

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -165,21 +165,21 @@ func (r *ReScheduler) reSchedule(pod *api.Pod, node *api.Node) (*api.Pod, error)
 	fullName := util.BuildIdentifier(pod.Namespace, pod.Name)
 	// if the pod is already on the target node, then simply return success.
 	if pod.Spec.NodeName == nodeName {
-		return nil, fmt.Errorf("Pod [%v] is already on host [%v]", fullName, nodeName)
+		return nil, fmt.Errorf("pod [%v] is already on host [%v]", fullName, nodeName)
 	}
 
-	parentKind, parentName, _, err := podutil.GetPodParentInfo(pod)
+	ownerInfo, err := podutil.GetPodParentInfo(pod)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot get parent info of pod [%v]: %v", fullName, err)
+		return nil, fmt.Errorf("cannot get parent info of pod [%v]: %v", fullName, err)
 	}
 
-	if !util.SupportedParent(parentKind, false) {
-		return nil, fmt.Errorf("The object kind [%v] of [%s] is not supported", parentKind, parentName)
+	if !util.SupportedParent(ownerInfo, false) {
+		return nil, fmt.Errorf("the object kind [%v] of [%s] is not supported", ownerInfo.Kind, ownerInfo.Name)
 	}
 
 	//2. move
-	return movePod(r.clusterScraper, pod, nodeName, parentKind, parentName,
-		defaultRetryMore, r.failVolumePodMoves, r.updateQuotaToAllowMoves, r.lockMap)
+	return movePod(r.clusterScraper, pod, nodeName, ownerInfo.Kind,
+		ownerInfo.Name, defaultRetryMore, r.failVolumePodMoves, r.updateQuotaToAllowMoves, r.lockMap)
 }
 
 func getVMIps(entity *proto.EntityDTO) []string {

--- a/pkg/action/util/util.go
+++ b/pkg/action/util/util.go
@@ -3,20 +3,18 @@ package util
 import (
 	"context"
 	"fmt"
-	util2 "github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"strings"
 
-	"github.com/turbonomic/kubeturbo/pkg/util"
+	"github.com/golang/glog"
+
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
-
+	discoveryutil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/turbonomic/kubeturbo/pkg/util"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-
-	"strings"
-
-	"github.com/golang/glog"
 )
 
 const (
@@ -107,8 +105,8 @@ func BuildIdentifier(namespace, name string) string {
 // check whether parentKind is supported for MovePod/ResizeContainer actions
 // currently, these actions can only works on barePod, ReplicaSet, and ReplicationController
 //   Note: pod's parent cannot be Deployment. Deployment will create/control ReplicaSet, and ReplicaSet will create/control Pods.
-func SupportedParent(ownerInfo util2.OwnerInfo, isResize bool) bool {
-	if util2.IsOwnerInfoEmpty(ownerInfo) {
+func SupportedParent(ownerInfo discoveryutil.OwnerInfo, isResize bool) bool {
+	if discoveryutil.IsOwnerInfoEmpty(ownerInfo) {
 		return true
 	}
 	if isResize && strings.EqualFold(ownerInfo.Kind, util.KindDaemonSet) {

--- a/pkg/action/util/util.go
+++ b/pkg/action/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+	util2 "github.com/turbonomic/kubeturbo/pkg/discovery/util"
 
 	"github.com/turbonomic/kubeturbo/pkg/util"
 	api "k8s.io/api/core/v1"
@@ -106,23 +107,19 @@ func BuildIdentifier(namespace, name string) string {
 // check whether parentKind is supported for MovePod/ResizeContainer actions
 // currently, these actions can only works on barePod, ReplicaSet, and ReplicationController
 //   Note: pod's parent cannot be Deployment. Deployment will create/control ReplicaSet, and ReplicaSet will create/control Pods.
-func SupportedParent(parentKind string, isResize bool) bool {
-	if parentKind == "" {
+func SupportedParent(ownerInfo util2.OwnerInfo, isResize bool) bool {
+	if util2.IsOwnerInfoEmpty(ownerInfo) {
 		return true
 	}
-
-	if isResize && strings.EqualFold(parentKind, util.KindDaemonSet) {
+	if isResize && strings.EqualFold(ownerInfo.Kind, util.KindDaemonSet) {
 		return true
 	}
-
-	if strings.EqualFold(parentKind, util.KindReplicaSet) {
+	if strings.EqualFold(ownerInfo.Kind, util.KindReplicaSet) {
 		return true
 	}
-
-	if strings.EqualFold(parentKind, util.KindReplicationController) {
+	if strings.EqualFold(ownerInfo.Kind, util.KindReplicationController) {
 		return true
 	}
-
 	return false
 }
 

--- a/pkg/discovery/dtofactory/cluster_dto_builder.go
+++ b/pkg/discovery/dtofactory/cluster_dto_builder.go
@@ -39,7 +39,7 @@ func GetClusterKey(clusterId string) string {
 
 func (builder *clusterDTOBuilder) BuildGroup() []*proto.GroupDTO {
 	var members []string
-	for _, node := range builder.cluster.NodeList {
+	for _, node := range builder.cluster.Nodes {
 		members = append(members, string(node.UID))
 	}
 	var clusterGroupDTOs []*proto.GroupDTO

--- a/pkg/discovery/dtofactory/container_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_dto_builder_test.go
@@ -1,7 +1,6 @@
 package dtofactory
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,16 +98,6 @@ func TestPodFlags(t *testing.T) {
 			t.Errorf("Pod %d Controllable: expected %v, got %v", i,
 				expectedResult[i].Controllable, controllable)
 		}
-	}
-}
-
-func dumpPodFlags(pods []*api.Pod) {
-	// This code dumps the attributes of the saved topology
-	for i, pod := range pods {
-		parentKind, _, _, _ := util.GetPodParentInfo(pod)
-		fmt.Printf("Pod %d: controllable = %v, parentKind = %s\n", i,
-			util.Controllable(pod),
-			parentKind)
 	}
 }
 

--- a/pkg/discovery/dtofactory/master_nodes_group_dto_builder.go
+++ b/pkg/discovery/dtofactory/master_nodes_group_dto_builder.go
@@ -25,7 +25,7 @@ func NewMasterNodesGroupDTOBuilder(cluster *repository.ClusterSummary,
 func (builder *masterNodesGroupDTOBuilder) Build() *proto.GroupDTO {
 	var masterNodes []string
 
-	nodes := builder.cluster.NodeList
+	nodes := builder.cluster.Nodes
 	for _, node := range nodes {
 		if util.NodeIsMaster(node) {
 			nodeID := string(node.UID)

--- a/pkg/discovery/dtofactory/node_roles_group_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_roles_group_dto_builder.go
@@ -80,7 +80,7 @@ type nodeRole struct {
 // This needs to be done for every discovery as node roles can change
 func (builder *NodeRolesGroupDTOBuilder) getNodeGroups() map[nodeRole][]string {
 	nodeGroups := map[nodeRole][]string{}
-	for _, node := range builder.cluster.NodeList {
+	for _, node := range builder.cluster.Nodes {
 		allRoles := util.DetectNodeRoles(node)
 		for _, role := range allRoles.List() {
 			nodeRole := nodeRole{

--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -208,7 +208,7 @@ func (m *ClusterMonitor) genNodePodsMetrics(node *api.Node, cpuCapacity, memCapa
 	for _, pod := range podList {
 		key := util.PodKeyFunc(pod)
 		// Pod owners
-		ownerInfo, _, _, err := m.clusterClient.GetPodControllerInfo(pod, false)
+		ownerInfo, _, _, err := m.clusterClient.GetPodControllerInfo(pod, true)
 		if err == nil && !util.IsOwnerInfoEmpty(ownerInfo) {
 			m.podOwners[key] = ownerInfo
 		}

--- a/pkg/discovery/processor/controller_processor.go
+++ b/pkg/discovery/processor/controller_processor.go
@@ -48,6 +48,16 @@ var (
 			Version:  util.K8sAPIDaemonsetGV.Version,
 			Resource: util.DaemonSetResName,
 		},
+		{
+			Group:    util.K8sAPIJobGV.Group,
+			Version:  util.K8sAPIJobGV.Version,
+			Resource: util.JobResName,
+		},
+		{
+			Group:    util.K8sAPICronJobGV.Group,
+			Version:  util.K8sAPICronJobGV.Version,
+			Resource: util.CronJobResName,
+		},
 	}
 )
 

--- a/pkg/discovery/processor/controller_processor.go
+++ b/pkg/discovery/processor/controller_processor.go
@@ -1,0 +1,112 @@
+package processor
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/util"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"strings"
+)
+
+// Query and cache predefined controllers
+var (
+	supportedControllers = []schema.GroupVersionResource{
+		{
+			Group:    util.K8sAPIReplicationControllerGV.Group,
+			Version:  util.K8sAPIReplicationControllerGV.Version,
+			Resource: util.ReplicationControllerResName,
+		},
+		{
+			Group:    util.K8sAPIReplicasetGV.Group,
+			Version:  util.K8sAPIReplicasetGV.Version,
+			Resource: util.ReplicaSetResName,
+		},
+		{
+			Group:    util.K8sAPIDeploymentGV.Group,
+			Version:  util.K8sAPIDeploymentGV.Version,
+			Resource: util.DeploymentResName,
+		},
+		{
+			Group:    util.OpenShiftAPIDeploymentConfigGV.Group,
+			Version:  util.OpenShiftAPIDeploymentConfigGV.Version,
+			Resource: util.DeploymentConfigResName,
+		},
+		{
+			Group:    util.K8sAPIStatefulsetGV.Group,
+			Version:  util.K8sAPIStatefulsetGV.Version,
+			Resource: util.StatefulSetResName,
+		},
+		{
+			Group:    util.K8sAPIDaemonsetGV.Group,
+			Version:  util.K8sAPIDaemonsetGV.Version,
+			Resource: util.DaemonSetResName,
+		},
+	}
+)
+
+type ControllerProcessor struct {
+	ClusterInfoScraper cluster.ClusterScraperInterface
+	KubeCluster        *repository.KubeCluster
+}
+
+func NewControllerProcessor(clusterInfoScraper cluster.ClusterScraperInterface,
+	kubeCluster *repository.KubeCluster) *ControllerProcessor {
+	return &ControllerProcessor{
+		ClusterInfoScraper: clusterInfoScraper,
+		KubeCluster:        kubeCluster,
+	}
+}
+
+func (cp *ControllerProcessor) ProcessControllers() {
+	cp.cacheAllControllers()
+}
+
+func (cp *ControllerProcessor) cacheAllControllers() {
+	scs := spew.ConfigState{
+		DisablePointerAddresses: true,
+		DisableCapacities:       true,
+		Indent:                  "  ",
+		SortKeys:                true,
+	}
+	controllerMap := make(map[string]*repository.K8sController)
+	for _, controller := range supportedControllers {
+		list, err := cp.ClusterInfoScraper.GetResources(controller)
+		if err != nil {
+			if apierrors.IsNotFound(err) && strings.Contains(err.Error(), "the server could not find the requested resource") {
+				glog.V(3).Infof("Resource %v not found ", controller.Resource)
+			} else {
+				glog.Errorf("Failed to list workload controller for %v", controller.Resource)
+			}
+			continue
+		}
+		for _, item := range list.Items {
+			uid := string(item.GetUID())
+			kind := item.GetKind()
+			name := item.GetName()
+			namespace := item.GetNamespace()
+			// insert into the map
+			k8sController := repository.
+				NewK8sController(kind, name, namespace, uid).
+				WithLabels(item.GetLabels()).
+				WithAnnotations(item.GetAnnotations()).
+				WithOwnerReferences(item.GetOwnerReferences())
+			replicas, found, err := unstructured.NestedInt64(item.Object, "spec", "replicas")
+			if err != nil {
+				glog.Warningf("The spec.replicas of %s %s/%s is not an integer.", kind, namespace, name)
+			} else if found {
+				k8sController.WithReplicas(replicas)
+			} else if kind == util.DaemonSetResName {
+				// For daemonset controller, set the replicas as the number of nodes in the cluster
+				k8sController.WithReplicas(int64(len(cp.KubeCluster.Nodes)))
+			}
+			controllerMap[uid] = k8sController
+			glog.V(3).Infof("Discovered %s %s/%s %s.", kind, namespace, name, uid)
+			glog.V(4).Infof("%+v", scs.Sdump(k8sController))
+		}
+	}
+	cp.KubeCluster.ControllerMap = controllerMap
+}

--- a/pkg/discovery/processor/controller_processor.go
+++ b/pkg/discovery/processor/controller_processor.go
@@ -1,15 +1,18 @@
 package processor
 
 import (
-	"github.com/davecgh/go-spew/spew"
+	"strings"
+
 	"github.com/golang/glog"
-	"github.com/turbonomic/kubeturbo/pkg/cluster"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
-	"github.com/turbonomic/kubeturbo/pkg/util"
+
+	"github.com/davecgh/go-spew/spew"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"strings"
+
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/util"
 )
 
 // Query and cache predefined controllers
@@ -99,7 +102,8 @@ func (cp *ControllerProcessor) cacheAllControllers() {
 				glog.Warningf("The spec.replicas of %s %s/%s is not an integer.", kind, namespace, name)
 			} else if found {
 				k8sController.WithReplicas(replicas)
-			} else if kind == util.DaemonSetResName {
+			}
+			if kind == util.KindDaemonSet {
 				// For daemonset controller, set the replicas as the number of nodes in the cluster
 				k8sController.WithReplicas(int64(len(cp.KubeCluster.Nodes)))
 			}

--- a/pkg/discovery/processor/namespace_processor.go
+++ b/pkg/discovery/processor/namespace_processor.go
@@ -56,5 +56,5 @@ func (p *NamespaceProcessor) ProcessNamespaces() {
 		glog.V(4).Infof("Created namespace entity: %s.", kubeNamespace.String())
 
 	}
-	p.KubeCluster.Namespaces = namespaces
+	p.KubeCluster.NamespaceMap = namespaces
 }

--- a/pkg/discovery/processor/namespace_processor_test.go
+++ b/pkg/discovery/processor/namespace_processor_test.go
@@ -82,7 +82,7 @@ func TestProcessNamespaces(t *testing.T) {
 	}
 
 	namespaceProcessor.ProcessNamespaces()
-	nsMap := ks.Namespaces
+	nsMap := ks.NamespaceMap
 	assert.Equal(t, len(nsMap), len(mockNamepaces))
 	mockedNamespaces := map[string]struct{}{
 		"test-ns1": {},

--- a/pkg/discovery/processor/volume_processor.go
+++ b/pkg/discovery/processor/volume_processor.go
@@ -37,12 +37,6 @@ func (p *VolumeProcessor) ProcessVolumes() {
 	}
 	glog.V(2).Infof("There are %d volume claims.", len(pvcList))
 
-	allPods, err := p.ClusterInfoScraper.GetAllPods()
-	if err != nil {
-		glog.Errorf("Failed to get all pods for cluster %s: %v.", clusterName, err)
-		return
-	}
-
 	// A map which lists the volume to pvc bindings (1 to 1)
 	// There can be volumes which are not bound via claims
 	// and pods use them directly.
@@ -71,7 +65,7 @@ func (p *VolumeProcessor) ProcessVolumes() {
 			// Unused volume.
 			volumeToPodsMap[pv] = nil
 		}
-		for _, pod := range allPods {
+		for _, pod := range p.KubeCluster.Pods {
 			for _, vol := range pod.Spec.Volumes {
 				claim := vol.VolumeSource.PersistentVolumeClaim
 				if claim != nil {

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"bytes"
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 
 	"github.com/golang/glog"
@@ -17,10 +18,10 @@ import (
 // New discovery will bring in changes to the nodes and namespaces
 // Aggregate structure for nodes, namespaces and quotas
 type KubeCluster struct {
-	Name             string
-	Nodes            map[string]*KubeNode
-	Namespaces       map[string]*KubeNamespace
-	ClusterResources map[metrics.ResourceType]*KubeDiscoveredResource
+	Name         string
+	Nodes        []*v1.Node
+	Pods         []*v1.Pod
+	NamespaceMap map[string]*KubeNamespace
 	// Map of Service to Pod cluster Ids
 	Services map[*v1.Service][]string
 	// Map of Persistent Volumes to namespace qualified pod names with their
@@ -33,76 +34,144 @@ type KubeCluster struct {
 
 	K8sAppToComponentMap map[K8sApp][]K8sAppComponent
 	ComponentToAppMap    map[K8sAppComponent][]K8sApp
-}
-
-type K8sApp struct {
-	Uid       string
-	Namespace string
-	Name      string
-}
-
-type K8sAppComponent struct {
-	EntityType proto.EntityDTO_EntityType
-	Uid        string
-	Namespace  string
-	Name       string
-}
-
-type PodVolume struct {
-	// Namespace qualified pod name.
-	QualifiedPodName string
-	// Name used by the pod to mount the volume.
-	MountName string
-}
-
-type MountedVolume struct {
-	UsedVolume *v1.PersistentVolume
-	MountName  string
-}
-
-// Volume metrics reported for a given pod
-type PodVolumeMetrics struct {
-	Volume   *v1.PersistentVolume
-	Capacity float64
-	Used     float64
-	PodVolume
+	ControllerMap        map[string]*K8sController
 }
 
 func NewKubeCluster(clusterName string, nodes []*v1.Node) *KubeCluster {
-	kubeCluster := &KubeCluster{
-		Name:             clusterName,
-		Nodes:            make(map[string]*KubeNode),
-		Namespaces:       make(map[string]*KubeNamespace),
-		ClusterResources: make(map[metrics.ResourceType]*KubeDiscoveredResource),
+	return &KubeCluster{
+		Name:         clusterName,
+		Nodes:        nodes,
+		Pods:         []*v1.Pod{},
+		NamespaceMap: make(map[string]*KubeNamespace),
 	}
-	kubeCluster.addNodes(nodes)
-	if glog.V(3) {
-		kubeCluster.logClusterNodes()
-	}
-	kubeCluster.computeClusterResources()
-	return kubeCluster
 }
 
-func (kc *KubeCluster) addNodes(nodes []*v1.Node) *KubeCluster {
-	for _, node := range nodes {
-		// Create kubeNode with Allocatable resource as the
-		// resource capacity
-		kc.Nodes[node.Name] = NewKubeNode(node, kc.Name)
-	}
+func (kc *KubeCluster) WithPods(pods []*v1.Pod) *KubeCluster {
+	kc.Pods = pods
 	return kc
 }
 
-func (kc *KubeCluster) logClusterNodes() {
-	for _, nodeEntity := range kc.Nodes {
-		glog.Infof("Created node entity : %s", nodeEntity.String())
+// Summary object to get the nodes, quotas and namespaces in the cluster
+type ClusterSummary struct {
+	*KubeCluster
+	// Computed
+	NodeMap                  map[string]*KubeNode
+	NodeNameUIDMap           map[string]string
+	NamespaceUIDMap          map[string]string
+	PodClusterIDToServiceMap map[string]*v1.Service
+	NodeToRunningPods        map[string][]*v1.Pod
+	NodeToPendingPods        map[string][]*v1.Pod
+	ClusterResources         map[metrics.ResourceType]*KubeDiscoveredResource
+	AverageNodeCpuFrequency  float64
+}
+
+func CreateClusterSummary(kubeCluster *KubeCluster) *ClusterSummary {
+	clusterSummary := &ClusterSummary{
+		KubeCluster:              kubeCluster,
+		NodeMap:                  make(map[string]*KubeNode),
+		NodeNameUIDMap:           make(map[string]string),
+		NamespaceUIDMap:          make(map[string]string),
+		PodClusterIDToServiceMap: make(map[string]*v1.Service),
+		NodeToRunningPods:        make(map[string][]*v1.Pod),
+		NodeToPendingPods:        make(map[string][]*v1.Pod),
+		ClusterResources:         make(map[metrics.ResourceType]*KubeDiscoveredResource),
+	}
+	clusterSummary.computeNodeMap()
+	clusterSummary.computePodMap()
+	clusterSummary.computeQuotaMap()
+	clusterSummary.computePodToServiceMap()
+	clusterSummary.computeClusterResources()
+	return clusterSummary
+}
+
+func (summary *ClusterSummary) GetKubeNamespace(namespace string) *KubeNamespace {
+	kubeNamespace, exists := summary.NamespaceMap[namespace]
+	if !exists {
+		glog.Errorf("Cannot find KubeNamespace entity for namespace %s", namespace)
+		return nil
+	}
+	return kubeNamespace
+}
+
+func (summary *ClusterSummary) GetReadyPods() (readyPods []*v1.Pod) {
+	for _, pod := range summary.Pods {
+		if util.PodIsReady(pod) {
+			readyPods = append(readyPods, pod)
+		}
+	}
+	return
+}
+
+func (summary *ClusterSummary) GetRunningPodsOnNode(node *v1.Node) []*v1.Pod {
+	runningPods, exists := summary.NodeToRunningPods[node.Name]
+	if !exists {
+		glog.V(3).Infof("No running pods found on node %v.", node.Name)
+		return nil
+	}
+	return runningPods
+
+}
+
+func (summary *ClusterSummary) GetPendingPodsOnNode(node *v1.Node) []*v1.Pod {
+	pendingPods, exists := summary.NodeToPendingPods[node.Name]
+	if !exists {
+		glog.V(3).Infof("No pending pods found on node %v.", node.Name)
+		return nil
+	}
+	return pendingPods
+
+}
+
+func (summary *ClusterSummary) computePodMap() {
+	for _, pod := range summary.Pods {
+		nodeName := pod.Spec.NodeName
+		if nodeName == "" {
+			glog.V(3).Infof("Skip pod %v/%v without assigned node.",
+				pod.Namespace, pod.Name)
+			continue
+		}
+		switch pod.Status.Phase {
+		case v1.PodPending:
+			summary.NodeToPendingPods[nodeName] =
+				append(summary.NodeToPendingPods[nodeName], pod)
+		case v1.PodRunning:
+			summary.NodeToRunningPods[nodeName] =
+				append(summary.NodeToRunningPods[nodeName], pod)
+		default:
+			glog.V(3).Infof("Skip pod %v/%v with status %v.",
+				pod.Namespace, pod.Name, pod.Status.Phase)
+		}
+	}
+}
+
+func (summary *ClusterSummary) computeNodeMap() {
+	for _, node := range summary.Nodes {
+		summary.NodeMap[node.Name] = NewKubeNode(node, summary.Name)
+		summary.NodeNameUIDMap[node.Name] = string(node.UID)
+	}
+	return
+}
+
+func (summary *ClusterSummary) computeQuotaMap() {
+	for namespaceName, namespace := range summary.NamespaceMap {
+		summary.NamespaceUIDMap[namespaceName] = namespace.UID
+	}
+	return
+}
+
+func (summary *ClusterSummary) computePodToServiceMap() {
+	for svc, podList := range summary.Services {
+		for _, podClusterID := range podList {
+			summary.PodClusterIDToServiceMap[podClusterID] = svc
+		}
 	}
 }
 
 // Sum the compute resource capacities from all the nodes to create the cluster resource capacities
-func (kc *KubeCluster) computeClusterResources() {
+func (summary *ClusterSummary) computeClusterResources() {
 	// sum the capacities/used of the node resources
 	computeResources := make(map[metrics.ResourceType]float64)
-	for _, node := range kc.Nodes {
+	for _, node := range summary.NodeMap {
 		nodeActive := util.NodeIsReady(node.Node) && util.NodeIsSchedulable(node.Node)
 		if nodeActive {
 			// Iterate over all ready and schedulable compute resource types
@@ -134,91 +203,7 @@ func (kc *KubeCluster) computeClusterResources() {
 				Type:     rt,
 				Capacity: capacity,
 			}
-			kc.ClusterResources[rt] = r
-		}
-	}
-}
-
-func (kc *KubeCluster) GetKubeNamespace(namespace string) *KubeNamespace {
-	kubeNamespace, exists := kc.Namespaces[namespace]
-	if !exists {
-		glog.Errorf("Cannot find KubeNamespace entity for namespace %s", namespace)
-		return nil
-	}
-	return kubeNamespace
-}
-
-// Summary object to get the nodes, quotas and namespaces in the cluster
-type ClusterSummary struct {
-	*KubeCluster
-	// Computed
-	NodeMap                  map[string]*v1.Node
-	NodeList                 []*v1.Node
-	NamespaceMap             map[string]*KubeNamespace
-	NodeNameUIDMap           map[string]string
-	NamespaceUIDMap          map[string]string
-	PodClusterIDToServiceMap map[string]*v1.Service
-	NodeNameToPodMap         map[string][]*v1.Pod
-	AverageNodeCpuFrequency  float64
-}
-
-func CreateClusterSummary(kubeCluster *KubeCluster) *ClusterSummary {
-	clusterSummary := &ClusterSummary{
-		KubeCluster:              kubeCluster,
-		NodeMap:                  make(map[string]*v1.Node),
-		NodeList:                 []*v1.Node{},
-		NamespaceMap:             make(map[string]*KubeNamespace),
-		NodeNameUIDMap:           make(map[string]string),
-		NamespaceUIDMap:          make(map[string]string),
-		PodClusterIDToServiceMap: make(map[string]*v1.Service),
-		NodeNameToPodMap:         make(map[string][]*v1.Pod),
-	}
-
-	clusterSummary.computeNodeMap()
-	clusterSummary.computeQuotaMap()
-	clusterSummary.computePodToServiceMap()
-
-	return clusterSummary
-}
-
-func (summary *ClusterSummary) SetRunningPodsOnNode(node *v1.Node, pods []*v1.Pod) {
-
-	if node == nil {
-		glog.Errorf("Null node while setting pods for node")
-		return
-	}
-
-	glog.Infof("Found %d pods for node %s", len(pods), node.Name)
-	summary.NodeNameToPodMap[node.Name] = pods
-}
-
-func (summary *ClusterSummary) computeNodeMap() {
-	summary.NodeMap = make(map[string]*v1.Node)
-	summary.NodeNameUIDMap = make(map[string]string)
-	for nodeName, node := range summary.Nodes {
-		summary.NodeMap[nodeName] = node.Node
-		summary.NodeNameUIDMap[nodeName] = string(node.Node.UID)
-		summary.NodeList = append(summary.NodeList, node.Node)
-	}
-	return
-}
-
-func (getter *ClusterSummary) computeQuotaMap() {
-	getter.NamespaceMap = make(map[string]*KubeNamespace)
-	getter.NamespaceUIDMap = make(map[string]string)
-	for namespaceName, namespace := range getter.Namespaces {
-		getter.NamespaceMap[namespaceName] = namespace
-		getter.NamespaceUIDMap[namespace.Name] = namespace.UID
-	}
-	return
-}
-
-func (summary *ClusterSummary) computePodToServiceMap() {
-	summary.PodClusterIDToServiceMap = make(map[string]*v1.Service)
-
-	for svc, podList := range summary.Services {
-		for _, podClusterID := range podList {
-			summary.PodClusterIDToServiceMap[podClusterID] = svc
+			summary.ClusterResources[rt] = r
 		}
 	}
 }
@@ -307,6 +292,84 @@ func parseResourceValue(computeResourceType metrics.ResourceType, resourceList v
 		return memoryCapacityKiloBytes
 	}
 	return DEFAULT_METRIC_VALUE
+}
+
+type K8sApp struct {
+	Uid       string
+	Namespace string
+	Name      string
+}
+
+type K8sAppComponent struct {
+	EntityType proto.EntityDTO_EntityType
+	Uid        string
+	Namespace  string
+	Name       string
+}
+
+type PodVolume struct {
+	// Namespace qualified pod name.
+	QualifiedPodName string
+	// Name used by the pod to mount the volume.
+	MountName string
+}
+
+type MountedVolume struct {
+	UsedVolume *v1.PersistentVolume
+	MountName  string
+}
+
+// Volume metrics reported for a given pod
+type PodVolumeMetrics struct {
+	Volume   *v1.PersistentVolume
+	Capacity float64
+	Used     float64
+	PodVolume
+}
+
+// An immutable snapshot of a k8s workload controller. This is used by ControllerProcessor
+// to temporarily cache the critical information of a k8s controller for efficient lookup.
+// This is different than the KubeController object which can be incrementally updated or
+// aggregated during discovery to fill in list of pods, resource usage, etc.
+type K8sController struct {
+	Kind            string
+	Name            string
+	Namespace       string
+	UID             string
+	Labels          map[string]string
+	Annotations     map[string]string
+	OwnerReferences []metav1.OwnerReference
+	// May not exist in all controllers. For Daemonset, defaults to number of nodes in the cluster.
+	Replicas *int64
+}
+
+func NewK8sController(kind, name, namespace, uid string) *K8sController {
+	return &K8sController{
+		Kind:      kind,
+		Name:      name,
+		Namespace: namespace,
+		UID:       uid,
+	}
+}
+
+func (kc *K8sController) WithLabels(labels map[string]string) *K8sController {
+	kc.Labels = labels
+	return kc
+}
+
+func (kc *K8sController) WithAnnotations(annotations map[string]string) *K8sController {
+	kc.Annotations = annotations
+	return kc
+}
+
+func (kc *K8sController) WithOwnerReferences(owners []metav1.OwnerReference) *K8sController {
+	kc.OwnerReferences = owners
+	return kc
+}
+
+func (kc *K8sController) WithReplicas(replicas int64) *K8sController {
+	kc.Replicas = &replicas
+	return kc
 }
 
 // K8s controller in the cluster
@@ -467,26 +530,4 @@ func parseAllocationResourceValue(resource v1.ResourceName, allocationResourceTy
 		return memoryKiloBytes
 	}
 	return DEFAULT_METRIC_VALUE
-}
-
-// =================================================================================================
-// The volumes in the cluster
-type KubeVolume struct {
-	*KubeEntity
-	*v1.PersistentVolume
-	ClusterName string
-}
-
-// Create a KubeVolume entity representing a volume in the cluster
-func NewKubeVolume(pv *v1.PersistentVolume, clusterName string) *KubeVolume {
-	entity := NewKubeEntity(metrics.VolumeType, clusterName,
-		pv.ObjectMeta.Namespace, pv.ObjectMeta.Name,
-		string(pv.ObjectMeta.UID))
-
-	volumeEntity := &KubeVolume{
-		KubeEntity:       entity,
-		PersistentVolume: pv,
-	}
-
-	return volumeEntity
 }

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -3,14 +3,15 @@ package repository
 import (
 	"bytes"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 
 	"github.com/golang/glog"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
@@ -59,10 +60,15 @@ type ClusterSummary struct {
 	NodeNameUIDMap           map[string]string
 	NamespaceUIDMap          map[string]string
 	PodClusterIDToServiceMap map[string]*v1.Service
-	NodeToRunningPods        map[string][]*v1.Pod
-	NodeToPendingPods        map[string][]*v1.Pod
-	ClusterResources         map[metrics.ResourceType]*KubeDiscoveredResource
-	AverageNodeCpuFrequency  float64
+	// Map node to all Running pods on the node.
+	// Pod in Running phase may NOT necessarily be in a Ready condition
+	NodeToRunningPods map[string][]*v1.Pod
+	// Map node to all Pending pods on the node
+	// A scheduled pod can still be in Pending phase, for example, when
+	// it fails to pull image onto the host
+	NodeToPendingPods       map[string][]*v1.Pod
+	ClusterResources        map[metrics.ResourceType]*KubeDiscoveredResource
+	AverageNodeCpuFrequency float64
 }
 
 func CreateClusterSummary(kubeCluster *KubeCluster) *ClusterSummary {

--- a/pkg/discovery/util/application_util.go
+++ b/pkg/discovery/util/application_util.go
@@ -23,19 +23,18 @@ func GetAppType(pod *api.Pod) string {
 		}
 		return result
 	} else {
-		_, parentName, _, err := GetPodParentInfo(pod)
+		ownerInfo, err := GetPodParentInfo(pod)
 		if err != nil {
 			glog.Errorf("fail to getAppType: %v", err.Error())
 			return ""
 		}
-
-		if parentName == "" {
+		if IsOwnerInfoEmpty(ownerInfo) {
 			return pod.Name
 		}
 
 		//TODO: if parent.Kind==ReplicaSet:
 		//       try to find the Deployment if it has.
 		//      or extract the Deployment Name by string operations
-		return parentName
+		return ownerInfo.Name
 	}
 }

--- a/pkg/discovery/util/owner_util.go
+++ b/pkg/discovery/util/owner_util.go
@@ -21,7 +21,7 @@ func GetOwnerInfo(owners []metav1.OwnerReference) (OwnerInfo, bool) {
 	var ownerSet bool
 	for _, owner := range owners {
 		if owner.Controller == nil || !(*owner.Controller) {
-			glog.V(3).Info("Owner %+v is not a managing controller.", owner)
+			glog.V(3).Infof("Owner %+v is not a managing controller.", owner)
 			continue
 		}
 		if len(owner.Kind) > 0 && len(owner.Name) > 0 && len(owner.UID) > 0 {

--- a/pkg/discovery/util/owner_util.go
+++ b/pkg/discovery/util/owner_util.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Utilities to handle operations related to OwnerReference
+
+type OwnerInfo struct {
+	Kind string
+	Name string
+	Uid  string
+}
+
+// Get owner info by parsing the ownerReferences of an object
+func GetOwnerInfo(owners []metav1.OwnerReference) OwnerInfo {
+	for i := range owners {
+		owner := &owners[i]
+		if owner == nil || owner.Controller == nil {
+			glog.Warningf("Nil OwnerReference")
+			continue
+		}
+		if *(owner.Controller) && len(owner.Kind) > 0 && len(owner.Name) > 0 && len(owner.UID) > 0 {
+			return OwnerInfo{owner.Kind, owner.Name, string(owner.UID)}
+		}
+	}
+	return OwnerInfo{}
+}
+
+// Check if the input ownerInfo is empty
+func IsOwnerInfoEmpty(ownerInfo OwnerInfo) bool {
+	return ownerInfo.Kind == "" || ownerInfo.Name == "" || ownerInfo.Uid == ""
+}

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
-
 	"github.com/golang/glog"
 
 	api "k8s.io/api/core/v1"
@@ -18,6 +16,7 @@ import (
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	commonutil "github.com/turbonomic/kubeturbo/pkg/util"
 )
 
@@ -255,9 +254,8 @@ func ParsePodDisplayName(displayName string) (string, string, error) {
 // The result OwnerInfo can be empty, indicating that the pod does not have an owner.
 func GetPodParentInfo(pod *api.Pod) (OwnerInfo, error) {
 	//1. check ownerReferences:
-	ownerInfo := GetOwnerInfo(pod.OwnerReferences)
-	if !IsOwnerInfoEmpty(ownerInfo) {
-		// OwnerReference is not empty
+	ownerInfo, ownerSet := GetOwnerInfo(pod.OwnerReferences)
+	if ownerSet {
 		return ownerInfo, nil
 	}
 

--- a/pkg/discovery/worker/compliance/affinity_processor.go
+++ b/pkg/discovery/worker/compliance/affinity_processor.go
@@ -2,17 +2,18 @@ package compliance
 
 import (
 	"github.com/golang/glog"
+
+	api "k8s.io/api/core/v1"
+
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-	api "k8s.io/api/core/v1"
 )
 
 // Affinity processor parses each affinity rule defined in pod and creates commodityDTOs for nodes and pods.
 type AffinityProcessor struct {
 	*ComplianceProcessor
-	cluster     *repository.ClusterSummary
 	commManager *AffinityCommodityManager
 	nodes       []*api.Node
 	pods        []*api.Pod

--- a/pkg/discovery/worker/compliance/node_schedulability_manager.go
+++ b/pkg/discovery/worker/compliance/node_schedulability_manager.go
@@ -33,7 +33,7 @@ func NewNodeSchedulabilityManager(cluster *repository.ClusterSummary) *NodeSched
 func (manager *NodeSchedulabilityManager) buildNodeNameToPodUIDsMap() map[string][]string {
 	nodeNameToPodUIDsMap := make(map[string][]string)
 
-	nodeNameToPodMap := manager.cluster.NodeNameToPodMap
+	nodeNameToPodMap := manager.cluster.NodeToRunningPods
 	for nodeName, schedulable := range manager.schedulableStateMap {
 		// skip over pods on schedulable nodes
 		if schedulable {
@@ -55,7 +55,7 @@ func (manager *NodeSchedulabilityManager) checkNodes() {
 
 	manager.unSchedulableNodes = nil
 
-	for _, node := range manager.cluster.NodeList {
+	for _, node := range manager.cluster.Nodes {
 		// check for schedulable property
 		schedulable := util.NodeIsReady(node) && util.NodeIsSchedulable(node)
 		manager.schedulableStateMap[node.Name] = schedulable

--- a/pkg/discovery/worker/compliance/taint_toleration_processor.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor.go
@@ -45,10 +45,10 @@ func NewTaintTolerationProcessor(cluster *repository.ClusterSummary,
 
 	nodeNameToUID := cluster.NodeNameUIDMap
 
-	nodeToPodsMap := cluster.NodeNameToPodMap
+	nodeToPodsMap := cluster.NodeToRunningPods
 	for nodeName, podList := range nodeToPodsMap {
 		node := cluster.NodeMap[nodeName]
-		nodeMap[string(node.UID)] = node
+		nodeMap[node.UID] = node.Node
 
 		for _, pod := range podList {
 			podMap[string(pod.UID)] = pod

--- a/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
@@ -54,9 +54,9 @@ func TestProcess(t *testing.T) {
 	kubeCluster := repository.NewKubeCluster(clusterName, nodeAndPodGetter.nodes)
 
 	clusterSummary := repository.CreateClusterSummary(kubeCluster)
-	clusterSummary.SetRunningPodsOnNode(n1, []*api.Pod{pod1})
-	clusterSummary.SetRunningPodsOnNode(n2, []*api.Pod{pod2})
-	clusterSummary.SetRunningPodsOnNode(n3, []*api.Pod{pod3})
+	clusterSummary.NodeToRunningPods[n1.Name] = []*api.Pod{pod1}
+	clusterSummary.NodeToRunningPods[n2.Name] = []*api.Pod{pod2}
+	clusterSummary.NodeToRunningPods[n3.Name] = []*api.Pod{pod3}
 
 	nodesManager := NewNodeSchedulabilityManager(clusterSummary)
 	taintTolerationProcessor, err := NewTaintTolerationProcessor(clusterSummary, nodesManager)

--- a/pkg/discovery/worker/controller_metrics_collector_test.go
+++ b/pkg/discovery/worker/controller_metrics_collector_test.go
@@ -85,7 +85,7 @@ func TestCollectControllerMetrics(t *testing.T) {
 
 	kubeCluster := &repository.KubeCluster{
 		Name: "cluster",
-		Namespaces: map[string]*repository.KubeNamespace{
+		NamespaceMap: map[string]*repository.KubeNamespace{
 			namespace: kubeNamespace,
 		},
 	}

--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -127,10 +127,8 @@ func (d *Dispatcher) RegisterWorker(worker *k8sDiscoveryWorker) {
 func (d *Dispatcher) Dispatch(nodes []*api.Node, cluster *repository.ClusterSummary) int {
 	go func() {
 		for _, node := range nodes {
-			runningPods := d.config.clusterInfoScraper.GetRunningPodsOnNode(node)
-			// Save the node to pods map in the cluster summary
-			cluster.SetRunningPodsOnNode(node, runningPods)
-			pendingPods := d.config.clusterInfoScraper.GetPendingPodsOnNode(node)
+			runningPods := cluster.GetRunningPodsOnNode(node)
+			pendingPods := cluster.GetPendingPodsOnNode(node)
 			currTask := task.NewTask().
 				WithNode(node).
 				WithRunningPods(runningPods).

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -437,7 +437,7 @@ func (worker *k8sDiscoveryWorker) buildAppDTOs(
 	applicationEntityDTOBuilder := dtofactory.NewApplicationEntityDTOBuilder(worker.sink,
 		cluster.PodClusterIDToServiceMap)
 	for _, pod := range runningPods {
-		kubeNode := cluster.Nodes[pod.Spec.NodeName]
+		kubeNode := cluster.NodeMap[pod.Spec.NodeName]
 		kubePod := repository.NewKubePod(pod, kubeNode, cluster.Name)
 		// Pod service Id
 		service := cluster.PodClusterIDToServiceMap[kubePod.PodClusterId]

--- a/pkg/discovery/worker/metrics_collector.go
+++ b/pkg/discovery/worker/metrics_collector.go
@@ -275,7 +275,7 @@ func (collector *MetricsCollector) CollectNamespaceMetrics(podCollection PodMetr
 		namespaceMetrics := repository.CreateDefaultNamespaceMetrics(namespace)
 		// create quota sold used for each namespace handled by this metric collector
 		for _, node := range collector.NodeList {
-			kubeNode := collector.Cluster.Nodes[node.Name]
+			kubeNode := collector.Cluster.NodeMap[node.Name]
 			// list of pods on this namespace on this node
 			podMetricsList, exists := podCollection[node.Name][namespace]
 			if !exists {
@@ -321,7 +321,7 @@ func (collector *MetricsCollector) CollectNamespaceMetrics(podCollection PodMetr
 
 // Get the CPU processor frequency values for the nodes from the Metrics sink
 func (collector *MetricsCollector) collectNodeFrequencies() {
-	kubeNodes := collector.Cluster.Nodes
+	kubeNodes := collector.Cluster.NodeMap
 	for _, node := range collector.NodeList {
 		key := util.NodeKeyFunc(node)
 		cpuFrequencyUID := metrics.GenerateEntityStateMetricUID(metrics.NodeType, key, metrics.CpuFrequency)
@@ -343,7 +343,7 @@ func (collector *MetricsCollector) collectNodeFrequencies() {
 }
 
 func (collector *MetricsCollector) collectNodeFrequency(node *v1.Node) {
-	kubeNodes := collector.Cluster.Nodes
+	kubeNodes := collector.Cluster.NodeMap
 
 	key := util.NodeKeyFunc(node)
 	cpuFrequencyUID := metrics.GenerateEntityStateMetricUID(metrics.NodeType, key, metrics.CpuFrequency)

--- a/pkg/discovery/worker/metrics_collector_test.go
+++ b/pkg/discovery/worker/metrics_collector_test.go
@@ -128,22 +128,15 @@ var (
 		},
 	}
 
-	kubeNode1 = repository.NewKubeNode(n1, cluster1)
-
-	kubeNode2 = repository.NewKubeNode(n2, cluster1)
-
 	kubens1 = repository.CreateDefaultKubeNamespace(cluster1, ns1, "namespace-uuid1")
 	kubens2 = repository.CreateDefaultKubeNamespace(cluster1, ns2, "namespace-uuid2")
 	kubens3 = repository.CreateDefaultKubeNamespace(cluster1, ns3, "namespace-uuid3")
 	kubens4 = repository.CreateDefaultKubeNamespace(cluster1, ns4, "namespace-uuid4")
 
 	kubeCluster = &repository.KubeCluster{
-		Name: cluster1,
-		Nodes: map[string]*repository.KubeNode{
-			node1: kubeNode1,
-			node2: kubeNode2,
-		},
-		Namespaces: map[string]*repository.KubeNamespace{
+		Name:  cluster1,
+		Nodes: []*v1.Node{n1, n2},
+		NamespaceMap: map[string]*repository.KubeNamespace{
 			ns1: kubens1,
 			ns2: kubens2,
 			ns3: kubens3,

--- a/pkg/discovery/worker/namespace_discovery_worker.go
+++ b/pkg/discovery/worker/namespace_discovery_worker.go
@@ -50,7 +50,7 @@ func (worker *k8sNamespaceDiscoveryWorker) Do(namespaceMetricsList []*repository
 		existingMetric.AggregateUsed(namespaceMetrics.Used)
 	}
 
-	kubeNodes := worker.Cluster.Nodes
+	kubeNodes := worker.Cluster.NodeMap
 	var nodeUIDs []string
 	var totalNodeFrequency float64
 	activeNodeCount := 0

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -17,11 +17,13 @@ const (
 	K8sAppsGroupName        = "apps"
 	K8sApplicationGroupName = "app.k8s.io"
 	OpenShiftAppsGroupName  = "apps.openshift.io"
+	K8sBatchGroupName       = "batch"
 
 	ReplicationControllerResName = "replicationcontrollers"
 	ReplicaSetResName            = "replicasets"
 	DeploymentResName            = "deployments"
 	DeploymentConfigResName      = "deploymentconfigs"
+	CronJobResName               = "cronjobs"
 	JobResName                   = "jobs"
 	StatefulSetResName           = "statefulsets"
 	DaemonSetResName             = "daemonsets"
@@ -46,4 +48,8 @@ var (
 	K8sAPIStatefulsetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
 	// The API group under which daemonsets are exposed by the k8s cluster
 	K8sAPIDaemonsetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
+	// The API group under which Job are exposed by the k8s cluster
+	K8sAPIJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1"}
+	// The API group under which CronJob are exposed by the k8s cluster
+	K8sAPICronJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1beta1"}
 )

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -28,21 +28,22 @@ const (
 	ApplicationResName           = "applications"
 )
 
-// The API group version under which deployments and replicasets are exposed by the k8s cluster as of today
-var K8sAPIDeploymentReplicasetDefaultGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
-
-// The API group version under which deployments are exposed by the k8s cluster
-var K8sAPIDeploymentGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
-
-// The API group version under which replicasets are exposed by the k8s cluster
-var K8sAPIReplicasetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
-
-// The API group under which replicationcontrollers are exposed by the k8s server
-// We do not discover the latest GV for this as we know that it has matured under core/v1
-var K8sAPIReplicationControllerGV = schema.GroupVersion{Group: "", Version: "v1"}
-
-// The API group under which openshifts deploymentconfig resource is exposed by the server
-var OpenShiftAPIDeploymentConfigGV = schema.GroupVersion{Group: OpenShiftAppsGroupName, Version: "v1"}
-
-// The API group under which application crd resource is installed on the server
-var K8sApplicationGV = schema.GroupVersion{Group: K8sApplicationGroupName, Version: "v1beta1"}
+var (
+	// The API group version under which deployments and replicasets are exposed by the k8s cluster as of today
+	K8sAPIDeploymentReplicasetDefaultGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
+	// The API group version under which deployments are exposed by the k8s cluster
+	K8sAPIDeploymentGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
+	// The API group version under which replicasets are exposed by the k8s cluster
+	K8sAPIReplicasetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
+	// The API group under which replicationcontrollers are exposed by the k8s server
+	// We do not discover the latest GV for this as we know that it has matured under core/v1
+	K8sAPIReplicationControllerGV = schema.GroupVersion{Group: "", Version: "v1"}
+	// The API group under which openshifts deploymentconfig resource is exposed by the server
+	OpenShiftAPIDeploymentConfigGV = schema.GroupVersion{Group: OpenShiftAppsGroupName, Version: "v1"}
+	// The API group under which application crd resource is installed on the server
+	K8sApplicationGV = schema.GroupVersion{Group: K8sApplicationGroupName, Version: "v1beta1"}
+	// The API group under which statefulsets are exposed by the k8s cluster
+	K8sAPIStatefulsetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
+	// The API group under which daemonsets are exposed by the k8s cluster
+	K8sAPIDaemonsetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
+)


### PR DESCRIPTION
This PR refactors `kubeturbo`, and adds caching for workload controllers during main discovery.

Please make sure the [**diff**](https://github.com/turbonomic/kubeturbo/pull/530/files#diff-dca03bcfd72dda18a2ba06cea2b6080deb981d81f524c39fac2b9aded94b5768) for [`kube_cluster.go`](https://github.com/turbonomic/kubeturbo/blob/cb616a98401fe09964dd4f5fe89cfaee2e4fdeb2/pkg/discovery/repository/kube_cluster.go) is expanded.

## Refactor
The following refactoring are done for better performance and readability:
#### `KubeCluster`
* Cache all `Pods` in `KubeCluster`
* Compute `ClusterSummary.NodeToRunningPods` and `ClusterSummary.NodeToPendingPods` maps
* Change `KubeCluster.Nodes` from `map[string]*KubeNode` to `[]*v1.Node`, and change the computed `ClusterSummary.NodeMap` from `map[string]*v1.Node` to `map[string]*kubeNode`
* Remove redundant `ClusterSummary.NodeList`
* Remove redundant `ClusterSummary.NamespaceMap`
* Add `GetRunningPodsOnNode`, `GetRunningPodsOnNode` and `GetReadyPods` functions to provide access to cached pods without having to call the API to get pods again, such as in `Dispatcher`,  `VolumeProcessor`, `AffinityProcessor`, and `TaintTolerationProcessor`

#### `ClusterScraper`
* Remove the following unnecessary calls:
  * `GetRunningPodsOnNode` 
  * `GetPendingPodsOnNode`
  * `GetPendingPodsOnNode`
  * `findPodsOnNode`
* Add the `GetResources` interface and implementation to query controllers

#### `OwnerReference`
* Create `owner_util` to handle operations related to `OwnerReference`
* Replace all places of `{kind, name, uid}` with `OwnerInfo`
* Replace `ClusterMonitor.PodOwner` with `OwnerInfo` 
* Replace `kubeControllerInfo` with `OwnerInfo`
* Rename `GetPodGrandparentInfo` to `GetPodControllerInfo`

## Cache Controllers
* Implement `ControllerProcessor.ProcessControllers` to cache predefined types of controllers. Predefined types include `replicationController`, `replicaSet`, `deployment`, `deploymentConfig`, `statefulSet` and `daemonSet`. Cached information include `uid`, `kind`, `name`, `namespace`, `labels`, `annotations`, and `*replicas`. If no replicas is found, or if parsing replicas fails, `*replicas` is not set. For `daemonSet`, `*replicas` is set to the number of nodes in the cluster.
* Implement `ClusterScraper.UpdatePodControllerCache`. It is called at the beginning of a main discovery after all pods and controllers are discovered. This will speed up the query and caching of pod controllers later on when we build entity DTOs.