### PR TITLE
Skip pending pods when building containerspecs owned by controller

### DIFF
--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
@@ -137,6 +137,14 @@ func (builder *workloadControllerDTOBuilder) getCommoditiesBought(kubeController
 func (builder *workloadControllerDTOBuilder) getContainerSpecIds(kubeController *repository.KubeController) []string {
 	containerNameSet := make(map[string]struct{})
 	for _, pod := range kubeController.Pods {
+		// Pods scheduled on a node, but still in Pending phase do not have containers started, exclude them
+		// when getting container specs
+		if discoveryUtil.PodIsPending(pod) {
+			glog.V(3).Infof("Skipping pod %v when building containerSpecs owned by controller %v."+
+				" There is no container started in the pod.", discoveryUtil.GetPodClusterID(pod),
+				kubeController.GetFullName())
+			continue
+		}
 		for _, container := range pod.Spec.Containers {
 			containerNameSet[container.Name] = struct{}{}
 		}


### PR DESCRIPTION
This fixes https://vmturbo.atlassian.net/browse/OM-64209. 

The root cause of this problem is that a container pod is scheduled on a node, but still in Pending phase, i.e., image pull failed, so there is no container started in the pod, and there is no corresponding containerSpec entity either created either. However, in `kubeturbo`, we still create the `consistsOf` relationship of the workload controller. 

![image](https://user-images.githubusercontent.com/10012486/110535083-d2f7ed00-80ed-11eb-9567-f53fe2097480.png)

The fix is to skip the pending pods when building containerSpecs owned by workloadController. 

Verified that the error messages do not show up in `topology-processor` log any more.