### PR TITLE
Only take active nodes into account for cluster resource commodities.

### DIFF
--- a/pkg/discovery/dtofactory/cluster_dto_builder.go
+++ b/pkg/discovery/dtofactory/cluster_dto_builder.go
@@ -131,7 +131,8 @@ func (builder *clusterDTOBuilder) getCommoditiesSold(entityDTOs []*proto.EntityD
 	used := make(map[proto.CommodityDTO_CommodityType]float64)
 	capacity := make(map[proto.CommodityDTO_CommodityType]float64)
 	for _, entityDTO := range entityDTOs {
-		if entityDTO.GetEntityType() == proto.EntityDTO_VIRTUAL_MACHINE {
+		// Only take active nodes into account for cluster resource commodities.
+		if entityDTO.GetEntityType() == proto.EntityDTO_VIRTUAL_MACHINE && entityDTO.GetPowerState() == proto.EntityDTO_POWERED_ON {
 			for _, commodity := range entityDTO.GetCommoditiesSold() {
 				// skip aggregating access commodities with keys
 				if commodity.GetKey() == "" {

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -7,7 +7,6 @@ import (
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"github.com/stretchr/testify/assert"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -117,31 +116,6 @@ func TestWaitForCompletionFailed(t *testing.T) {
 	totalWaitTime = time.Second
 	assert.False(t, waitForCompletion(done))
 	totalWaitTime = 60 * time.Second
-}
-
-func TestComputeClusterResources(t *testing.T) {
-	kubeCluster := repository.NewKubeCluster(testClusterName, createMockNodes(allocatableMap, schedulableNodeMap))
-	var resourceMap map[metrics.ResourceType]*repository.KubeDiscoveredResource
-	clusterSummary := repository.CreateClusterSummary(kubeCluster)
-	resourceMap = clusterSummary.ClusterResources
-	for _, computeTypeList := range metrics.KubeComputeResourceTypes {
-		for _, computeType := range computeTypeList {
-			_, exists := resourceMap[computeType]
-			assert.True(t, exists)
-		}
-	}
-	// Among all nodes, one of the nodes is not schedulable, so the capacity should be 3 * node capacity
-	assert.Equal(t, int32(24032436), int32(resourceMap["Memory"].Capacity))
-	assert.Equal(t, int8(12), int8(resourceMap["CPU"].Capacity))
-
-	kubeCluster = repository.NewKubeCluster(testClusterName, createMockNodes(allocatableCpuOnlyMap, schedulableNodeMap))
-	resourceMap = clusterSummary.ClusterResources
-	for _, computeTypeList := range metrics.KubeComputeResourceTypes {
-		for _, computeType := range computeTypeList {
-			_, exists := resourceMap[computeType]
-			assert.True(t, exists, fmt.Sprintf("missing %s resource", computeType))
-		}
-	}
 }
 
 func TestDiscoverCluster(t *testing.T) {

--- a/pkg/discovery/worker/namespace_discovery_worker.go
+++ b/pkg/discovery/worker/namespace_discovery_worker.go
@@ -55,7 +55,7 @@ func (worker *k8sNamespaceDiscoveryWorker) Do(namespaceMetricsList []*repository
 	var totalNodeFrequency float64
 	activeNodeCount := 0
 	for _, node := range kubeNodes {
-		nodeActive := util.NodeIsReady(node.Node) && util.NodeIsSchedulable(node.Node)
+		nodeActive := util.NodeIsReady(node.Node)
 		if nodeActive {
 			nodeUIDs = append(nodeUIDs, node.UID)
 			totalNodeFrequency += node.NodeCpuFrequency

--- a/pkg/kubeclient/kubelet_client.go
+++ b/pkg/kubeclient/kubelet_client.go
@@ -246,7 +246,7 @@ func (client *KubeletClient) GetNodeCpuFrequency(node *v1.Node) (float64, error)
 	freqDiscovered := true
 	if err != nil {
 		glog.Errorf("Failed to get machine[%s] cpu.frequency from kubelet: %v. Will try pod based getter.", node.Name, err)
-		nodeIsActive := util.NodeIsReady(node) && util.NodeIsSchedulable(node)
+		nodeIsActive := util.NodeIsReady(node)
 		if nodeIsActive {
 			nodeFreq, err = client.fallbkCpuFreqGetter.GetFrequency(node.Name)
 			if err != nil {


### PR DESCRIPTION
JIRA: https://vmturbo.atlassian.net/browse/OM-68477
# Intent
1. Update `cluster_dto_builder` to take only active nodes when calculating commodity capacity. Unschedule nodes should be counted as cluster capacity if they are in Ready status. 
2. We need to be consistent everywhere in kubeturbo (node builder, cluster builder, cluster summary) to count active nodes.

# Background
In kubeturbo discovery, we identify following nodes:
1. Nodes in ready status - `NodeCondition` type is ready and `NodeCondition` status is true
2. Nodes which are unschedulable — `node.Spec.Unschedulable` (controls node schedulability of new pods)

Unschedulable nodes can be ready or not ready.

# Implementation
1. In `cluster_dto_builder.go`, only take active nodes into account for cluster resource commodities.
2. In `namespace_discovery_worker.go` and `kubelet_client.go`, set `nodeActive` only if node is in Ready status.
3. In `kube_cluster.go`, remove the redundant `ClusterResources` field and `computeClusterResources()` function. The field and function were introduced in PR #173 but looks not used anywhere since then. A background of a previous use case of clusterResource during discovery is that we used to set namespace (which was modeled as VDC entity) capacity as cluster capacity (sum of node capacity) if quota is not defined. After the refactoring to model namespace as Namespace entity in our new container model in #398 , Namespace capacity has been set to an super large number (representing infinity) so that clusterResource is not needed anymore during discovery before creating cluster entity dto. So it should be safe to delete `computeClusterResources()` function here.
4. Updated unit test