### PR TITLE
Discover cpu throttling commodity 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20210312042142-5a5a8362b499
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20210326125330-5d184a461727
 )
 
 // k8s and relevant dependencies
@@ -39,6 +39,8 @@ require (
 	github.com/openshift/client-go v0.0.0-20201020074620-f8fd44879f7c
 	// openshift cluster api for cluster-api based node provision and suspend
 	github.com/openshift/machine-api-operator v0.2.1-0.20201216110516-d9e48bb9fc0b
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
 	k8s.io/kubelet v0.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -777,6 +777,8 @@ github.com/turbonomic/turbo-api v0.0.0-20210114025310-0e31e19c3312 h1:e5Tmfc07zR
 github.com/turbonomic/turbo-api v0.0.0-20210114025310-0e31e19c3312/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20210312042142-5a5a8362b499 h1:v8f5S8YI/F+64Ei1NhM45PZTRloEejzqZuzGN+Zolj0=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20210312042142-5a5a8362b499/go.mod h1:0zAmM4Mj+lZQtgz4pqfELgxEElwrSzsfWI480fQwa08=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20210326125330-5d184a461727 h1:Lj6Hv/Cdur5JzZcsdIoOHhiKvNCW9QGfbdbu0QVErjA=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20210326125330-5d184a461727/go.mod h1:0zAmM4Mj+lZQtgz4pqfELgxEElwrSzsfWI480fQwa08=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -45,6 +45,10 @@ var (
 		metrics.MemoryRequest,
 	}
 
+	throttlingCommodity = []metrics.ResourceType{
+		metrics.VCPUThrottling,
+	}
+
 	commodityBought = []metrics.ResourceType{
 		metrics.CPU,
 		metrics.Memory,
@@ -149,7 +153,7 @@ func (builder *containerDTOBuilder) BuildEntityDTOs(pods []*api.Pod) []*proto.En
 			commoditiesSold, err := builder.getCommoditiesSold(name, containerId, containerMId, nodeCPUFrequency,
 				isCpuLimitSet, isMemLimitSet, isCpuRequestSet, isMemRequestSet)
 			if err != nil {
-				glog.Warningf("failed to create commoditiesSold for container[%s]: %v", name, err)
+				glog.Warningf("Failed to create commoditiesSold for container[%s]: %v", name, err)
 				continue
 			}
 			ebuilder.SellsCommodities(commoditiesSold)
@@ -240,6 +244,9 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 		memRequestCommodities := builder.createCommoditiesSold(containerEntityType, memRequestCommodity, containerMId, nil, true)
 		result = append(result, memRequestCommodities...)
 	}
+
+	throttlingCommodities := builder.createCommoditiesSold(containerEntityType, throttlingCommodity, containerMId, nil, false)
+	result = append(result, throttlingCommodities...)
 
 	//2. Application
 	appCommodity, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_APPLICATION).

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder_test.go
@@ -1,11 +1,13 @@
 package dtofactory
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
-	"testing"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
 func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
@@ -41,6 +43,13 @@ func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
 					createContainerMetricPoint(3.0, 2),
 				},
 			},
+			metrics.VCPUThrottling: {
+				Capacity: []float64{100, 100},
+				Used: [][]metrics.ThrottlingCumulative{
+					createContainerMetricCumulativeThrottling(1, 4, 2, 5, 4, 10, 1, 2, 3),
+					createContainerMetricCumulativeThrottling(2, 8, 4, 12, 8, 20, 1, 2, 3),
+				},
+			},
 		},
 	}
 
@@ -51,15 +60,21 @@ func Test_containerSpecDTOBuilder_getCommoditiesSold(t *testing.T) {
 	}
 	commodityDTOs, err := builder.getCommoditiesSold(&containerSpecMetrics)
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(commodityDTOs))
+	assert.Equal(t, 4, len(commodityDTOs))
 	for _, commodityDTO := range commodityDTOs {
 		assert.Equal(t, true, *commodityDTO.Active)
 		assert.Equal(t, true, *commodityDTO.Resizable)
 		// Parse values to int to avoid tolerance of float values
-		assert.Equal(t, 2, int(*commodityDTO.Used))
-		assert.Equal(t, 3, int(*commodityDTO.Peak))
-		assert.Equal(t, 4, int(*commodityDTO.Capacity))
-		assert.Equal(t, 2, len(commodityDTO.UtilizationData.Point))
+		if commodityDTO.GetCommodityType() == proto.CommodityDTO_VCPU_THROTTLING {
+			assert.Equal(t, 50, int(*commodityDTO.Used))
+			assert.Equal(t, 100, int(*commodityDTO.Peak))
+			assert.Equal(t, 100, int(*commodityDTO.Capacity))
+		} else {
+			assert.Equal(t, 2, int(*commodityDTO.Used))
+			assert.Equal(t, 3, int(*commodityDTO.Peak))
+			assert.Equal(t, 4, int(*commodityDTO.Capacity))
+			assert.Equal(t, 2, len(commodityDTO.UtilizationData.Point))
+		}
 	}
 }
 
@@ -67,5 +82,25 @@ func createContainerMetricPoint(value float64, timestamp int64) metrics.Point {
 	return metrics.Point{
 		Value:     value,
 		Timestamp: timestamp,
+	}
+}
+
+func createContainerMetricCumulativeThrottling(thr1, tot1, thr2, tot2, thr3, tot3 float64, t1, t2, t3 int64) []metrics.ThrottlingCumulative {
+	return []metrics.ThrottlingCumulative{
+		{
+			Throttled: thr1,
+			Total:     tot1,
+			Timestamp: t1,
+		},
+		{
+			Throttled: thr2,
+			Total:     tot2,
+			Timestamp: t2,
+		},
+		{
+			Throttled: thr3,
+			Total:     tot3,
+			Timestamp: t3,
+		},
 	}
 }

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -358,17 +358,17 @@ func (s *MockClusterScrapper) GetResources(schema.GroupVersionResource) (*unstru
 // Implements the KubeHttpClientInterface
 // Method implementation will check to see if the test has provided the mockXXX method function
 type MockNodeScrapper struct {
-	mockExecuteRequestAndGetValue func(ip, nodeName, path string) ([]byte, error)
-	mockGetSummary                func(ip, nodeName string) (*stats.Summary, error)
-	mockGetMachineInfo            func(ip, nodeName string) (*cadvisorapi.MachineInfo, error)
-	mockGetNodeCpuFrequency       func(node *v1.Node) (float64, error)
+	mockExecuteRequest      func(ip, nodeName, path string) ([]byte, error)
+	mockGetSummary          func(ip, nodeName string) (*stats.Summary, error)
+	mockGetMachineInfo      func(ip, nodeName string) (*cadvisorapi.MachineInfo, error)
+	mockGetNodeCpuFrequency func(node *v1.Node) (float64, error)
 }
 
-func (s *MockNodeScrapper) ExecuteRequestAndGetValue(ip, nodeName, path string) ([]byte, error) {
-	if s.mockExecuteRequestAndGetValue != nil {
-		return s.mockExecuteRequestAndGetValue(ip, "", path)
+func (s *MockNodeScrapper) ExecuteRequest(ip, nodeName, path string) ([]byte, error) {
+	if s.mockExecuteRequest != nil {
+		return s.mockExecuteRequest(ip, "", path)
 	}
-	return nil, fmt.Errorf("ExecuteRequestAndGetValue Not implemented")
+	return nil, fmt.Errorf("ExecuteRequest Not implemented")
 }
 
 func (s *MockNodeScrapper) GetSummary(ip, nodeName string) (*stats.Summary, error) {

--- a/pkg/discovery/repository/entity_metrics.go
+++ b/pkg/discovery/repository/entity_metrics.go
@@ -82,10 +82,17 @@ func (namespaceMetrics *NamespaceMetrics) AggregateUsed(partialUsed map[metrics.
 // same ContainerSpec.
 type ContainerMetrics struct {
 	Capacity []float64
-	Used     []metrics.Point
+	// Used could be []metrics.Point or [][]metrics.ThrottlingCumulative
+	// [][]metrics. ThrottlingCumulative stores multipoints segregated per container.
+	// Storing it this way helps in identifying metrics per container while aggregating
+	// the metrics for containerSpecs.
+	// TODO: At some point this can be converted to a typed UsedMetric interface which
+	// implements the methods like len(), append() and getPoints() and have the implementation
+	// hidden from the users of this metric.
+	Used interface{}
 }
 
-func NewContainerMetrics(capacity []float64, used []metrics.Point) *ContainerMetrics {
+func NewContainerMetrics(capacity []float64, used interface{}) *ContainerMetrics {
 	return &ContainerMetrics{
 		Capacity: capacity,
 		Used:     used,

--- a/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_usage_data_aggregator.go
@@ -1,8 +1,9 @@
 package aggregation
 
 import (
-	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"math"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 )
 
 const (
@@ -37,18 +38,18 @@ func (avgUsageDataAggregator *avgUsageDataAggregator) String() string {
 }
 
 func (avgUsageDataAggregator *avgUsageDataAggregator) Aggregate(resourceMetrics *repository.ContainerMetrics) (float64, float64, float64, error) {
-	isValid, err := isResourceMetricsValid(resourceMetrics, avgUsageDataAggregator)
+	usedPoints, isValid, err := isResourceMetricsValid(resourceMetrics, avgUsageDataAggregator)
 	if !isValid || err != nil {
 		return 0.0, 0.0, 0.0, err
 	}
 	capacity := getResourceCapacity(resourceMetrics)
 	usedSum := 0.0
 	peak := 0.0
-	for _, usedPoint := range resourceMetrics.Used {
+	for _, usedPoint := range usedPoints {
 		usedSum += usedPoint.Value
 		peak = math.Max(peak, usedPoint.Value)
 	}
-	avgUsed := usedSum / float64(len(resourceMetrics.Used))
+	avgUsed := usedSum / float64(len(usedPoints))
 	return capacity, avgUsed, peak, nil
 }
 
@@ -62,7 +63,7 @@ func (maxUsageDataAggregator *maxUsageDataAggregator) String() string {
 }
 
 func (maxUsageDataAggregator *maxUsageDataAggregator) Aggregate(resourceMetrics *repository.ContainerMetrics) (float64, float64, float64, error) {
-	isValid, err := isResourceMetricsValid(resourceMetrics, maxUsageDataAggregator)
+	usedPoints, isValid, err := isResourceMetricsValid(resourceMetrics, maxUsageDataAggregator)
 	if !isValid || err != nil {
 		return 0.0, 0.0, 0.0, err
 	}
@@ -71,7 +72,7 @@ func (maxUsageDataAggregator *maxUsageDataAggregator) Aggregate(resourceMetrics 
 		capacity = math.Max(capacity, capVal)
 	}
 	maxUsed := 0.0
-	for _, usedPoint := range resourceMetrics.Used {
+	for _, usedPoint := range usedPoints {
 		maxUsed = math.Max(maxUsed, usedPoint.Value)
 	}
 	return capacity, maxUsed, maxUsed, nil

--- a/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
+++ b/pkg/discovery/worker/aggregation/container_utilization_data_aggregator.go
@@ -2,8 +2,9 @@ package aggregation
 
 import (
 	"fmt"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"math"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 )
 
 const (
@@ -39,7 +40,7 @@ func (allDataAggregator *allUtilizationDataAggregator) String() string {
 }
 
 func (allDataAggregator *allUtilizationDataAggregator) Aggregate(resourceMetrics *repository.ContainerMetrics) ([]float64, int64, int32, error) {
-	isValid, err := isResourceMetricsValid(resourceMetrics, allDataAggregator)
+	usedPoints, isValid, err := isResourceMetricsValid(resourceMetrics, allDataAggregator)
 	if !isValid || err != nil {
 		return []float64{}, 0, 0, err
 	}
@@ -51,7 +52,8 @@ func (allDataAggregator *allUtilizationDataAggregator) Aggregate(resourceMetrics
 	var utilizationDataPoints []float64
 	var firstTimestamp int64
 	var lastTimestamp int64
-	for _, usedPoint := range resourceMetrics.Used {
+
+	for _, usedPoint := range usedPoints {
 		utilization := usedPoint.Value / capacity * 100
 		utilizationDataPoints = append(utilizationDataPoints, utilization)
 		if firstTimestamp == 0 || usedPoint.Timestamp < firstTimestamp {
@@ -79,7 +81,7 @@ func (maxDataAggregator *maxUtilizationDataAggregator) String() string {
 }
 
 func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(resourceMetrics *repository.ContainerMetrics) ([]float64, int64, int32, error) {
-	isValid, err := isResourceMetricsValid(resourceMetrics, maxDataAggregator)
+	usedPoints, isValid, err := isResourceMetricsValid(resourceMetrics, maxDataAggregator)
 	if !isValid || err != nil {
 		return []float64{}, 0, 0, err
 	}
@@ -90,7 +92,8 @@ func (maxDataAggregator *maxUtilizationDataAggregator) Aggregate(resourceMetrics
 	}
 	var maxUtilization float64
 	var lastTimestamp int64
-	for _, usedPoint := range resourceMetrics.Used {
+
+	for _, usedPoint := range usedPoints {
 		utilization := usedPoint.Value / capacity * 100
 		maxUtilization = math.Max(utilization, maxUtilization)
 		if usedPoint.Timestamp > lastTimestamp {

--- a/pkg/discovery/worker/container_spec_metrics_collector.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
@@ -106,6 +107,8 @@ func (collector *ContainerSpecMetricsCollector) collectContainerMetrics(containe
 		containerResourceMetrics := repository.NewContainerMetrics([]float64{capVal}, usedValPoints)
 		containerSpecMetric.ContainerMetrics[resourceType] = containerResourceMetrics
 	}
+	// TODO: Collect the throttling metrics data, whose collection is slightly different from other metrics.
+
 }
 
 func (collector *ContainerSpecMetricsCollector) getResourceMetricValue(containerMId string, rType metrics.ResourceType,


### PR DESCRIPTION
This change implements part of [this story](https://vmturbo.atlassian.net/browse/OM-67606)

This implements below points:
- Collects and parses the throttling metrics from kubelet’s /metrics/cadvisor endpoint for all containers.
- Introduces a new multi point metrics type ThrottlingCumulative to be able to calculate iterative increase from counter type throttling metrics.
- Stores the metrics in the metrics sync
- Collects and updates the metric on container DTO as sold commodity.

Tests done:
Container DTO sample from kubeturbo discovery:
```json
entityDTO:<
entityType:CONTAINER 
id:"6de223eb-b99f-468f-8cfb-7a3053f75b33-0" 
displayName:"lens-metrics/node-exporter-9xnkd/node-exporter" 
commoditiesSold:<commodityType:VCPU used:40.971243105195 capacity:532.7556 peak:52.624833663714 resizable:true >
commoditiesSold:<commodityType:VMEM used:6740 capacity:102400 peak:6768 resizable:true > 
commoditiesSold:<commodityType:VCPU_REQUEST used:40.971243105195 capacity:26.63778 peak:52.624833663714 resizable:true > 
commoditiesSold:<commodityType:VMEM_REQUEST used:6740 capacity:24576 peak:6768 resizable:true > 
commoditiesSold:<commodityType:VCPU_THROTTLING used:31.97663904413157 capacity:100 peak:38.83495145631068 resizable:false > 
commoditiesSold:<commodityType:APPLICATION key:"6de223eb-b99f-468f-8cfb-7a3053f75b33-0" capacity:100000 >
.....
.....
```
![image](https://user-images.githubusercontent.com/10027921/112633894-07113300-8e8e-11eb-846e-555e76edfdc4.png)

Further work.
- Push the string constants to ux-app to get the commodity name recognised in UI.
- Update the merged utilization values on containerSpec
- Put the kubeturbo changes behind a feature flag