### PR TITLE
Addon tasks for throttling metrics collection

### DIFF
--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
+	"github.com/turbonomic/kubeturbo/pkg/features"
 
 	"github.com/golang/glog"
 	api "k8s.io/api/core/v1"
@@ -14,6 +15,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 var (
@@ -245,8 +247,10 @@ func (builder *containerDTOBuilder) getCommoditiesSold(containerName, containerI
 		result = append(result, memRequestCommodities...)
 	}
 
-	throttlingCommodities := builder.createCommoditiesSold(containerEntityType, throttlingCommodity, containerMId, nil, false)
-	result = append(result, throttlingCommodities...)
+	if utilfeature.DefaultFeatureGate.Enabled(features.ThrottlingMetrics) {
+		throttlingCommodities := builder.createCommoditiesSold(containerEntityType, throttlingCommodity, containerMId, nil, false)
+		result = append(result, throttlingCommodities...)
+	}
 
 	//2. Application
 	appCommodity, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_APPLICATION).

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -8,8 +8,10 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
+	"github.com/turbonomic/kubeturbo/pkg/features"
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 var (
@@ -81,6 +83,9 @@ func (builder *containerSpecDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, error) 
 func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpecMetrics *repository.ContainerSpecMetrics) ([]*proto.CommodityDTO, error) {
 	var commoditiesSold []*proto.CommodityDTO
 	for _, resourceType := range ContainerSpecResourceTypes {
+		if resourceType == metrics.VCPUThrottling && !utilfeature.DefaultFeatureGate.Enabled(features.ThrottlingMetrics) {
+			continue
+		}
 		commodityType, exist := rTypeMapping[resourceType]
 		if !exist {
 			glog.Errorf("Unsupported resource type %s when building commoditiesSold for ContainerSpec %s",

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -174,7 +174,11 @@ func aggregateThrottlingSamples(samples [][]metrics.ThrottlingCumulative) (float
 	}
 	avgThrottledOverall := float64(0)
 	if totalOverall > 0 {
-		avgThrottledOverall = throttledOverall * 100 / totalOverall
+		if throttledOverall > totalOverall {
+			avgThrottledOverall = 100
+		} else {
+			avgThrottledOverall = throttledOverall * 100 / totalOverall
+		}
 	}
 
 	return 100, avgThrottledOverall, peakOverall

--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -235,7 +235,11 @@ func (builder generalBuilder) metricValue(entityType metrics.DiscoveredEntityTyp
 		}
 
 		if total > 0 {
-			metricValue.Avg = throttled * 100 / total
+			if throttled > total {
+				metricValue.Avg = 100
+			} else {
+				metricValue.Avg = throttled * 100 / total
+			}
 		}
 		metricValue.Peak = peak
 	case float64:
@@ -381,16 +385,37 @@ func aggregateContainerThrottlingSamples(entityID string, samples []metrics.Thro
 	sort.SliceStable(samples, func(i, j int) bool {
 		return samples[i].Timestamp < samples[j].Timestamp
 	})
-	throttled = (samples[numberOfSamples-1].Throttled - samples[0].Throttled)
-	total = samples[numberOfSamples-1].Total - samples[0].Total
 
+	lastReset := 0
 	for i := 0; i < numberOfSamples-1; i++ {
-		total := samples[i+1].Total - samples[i].Total
+		if samples[i+1].Total < samples[i].Total || samples[i+1].Throttled < samples[i].Throttled {
+			// This probably means the counter was reset for some reason
+			throttled += (samples[i].Throttled - samples[lastReset].Throttled)
+			total += samples[i].Total - samples[lastReset].Total
+			lastReset = i + 1
+			// we ignore this samples diff for our peak calculations
+			continue
+		}
+
+		totalSingleSample := samples[i+1].Total - samples[i].Total
 		throttledPercent := float64(0)
-		if total > 0 {
-			throttledPercent = (samples[i+1].Throttled - samples[i].Throttled) * 100 / total
+		if totalSingleSample > 0 {
+			throttledSingleSample := samples[i+1].Throttled - samples[i].Throttled
+			if throttledSingleSample > totalSingleSample {
+				// This is unlikely but possible because of errors at cadvisors end.
+				throttledPercent = 100
+			} else {
+				throttledPercent = throttledSingleSample * 100 / totalSingleSample
+			}
 		}
 		peak = math.Max(peak, throttledPercent)
 	}
+
+	// handle last window if there ever was one, else this calculates the diff of the first and the last sample.
+	if lastReset != numberOfSamples-1 {
+		throttled += (samples[numberOfSamples-1].Throttled - samples[lastReset].Throttled)
+		total += samples[numberOfSamples-1].Total - samples[lastReset].Total
+	}
+
 	return throttled, total, peak, true
 }

--- a/pkg/discovery/repository/entity_metrics.go
+++ b/pkg/discovery/repository/entity_metrics.go
@@ -83,7 +83,7 @@ func (namespaceMetrics *NamespaceMetrics) AggregateUsed(partialUsed map[metrics.
 type ContainerMetrics struct {
 	Capacity []float64
 	// Used could be []metrics.Point or [][]metrics.ThrottlingCumulative
-	// [][]metrics. ThrottlingCumulative stores multipoints segregated per container.
+	// [][]metrics.ThrottlingCumulative stores multipoints segregated per container.
 	// Storing it this way helps in identifying metrics per container while aggregating
 	// the metrics for containerSpecs.
 	// TODO: At some point this can be converted to a typed UsedMetric interface which

--- a/pkg/discovery/worker/container_spec_metrics_collector_test.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector_test.go
@@ -1,6 +1,9 @@
 package worker
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
@@ -8,8 +11,6 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/util"
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
-	"testing"
 )
 
 const (
@@ -210,6 +211,11 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithoutReques
 					createContainerMetricPoint(containerFooMemUsed2, 2),
 				},
 			},
+			// We add throttling metrics in all cases
+			metrics.VCPUThrottling: {
+				Capacity: []float64{100},
+				Used:     [][]metrics.ThrottlingCumulative{},
+			},
 		},
 	}
 	assert.EqualValues(t, 1, len(containerSpecMetricsList))
@@ -257,6 +263,11 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithRequestMe
 					createContainerMetricPoint(containerBarMemRequestUsed1, 1),
 					createContainerMetricPoint(containerBarMemRequestUsed2, 2),
 				},
+			},
+			// We add throttling metrics in all cases
+			metrics.VCPUThrottling: {
+				Capacity: []float64{100},
+				Used:     [][]metrics.ThrottlingCumulative{},
 			},
 		},
 	}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -19,6 +19,12 @@ const (
 	//
 	// Persistent volumes support.
 	PersistentVolumes featuregate.Feature = "PersistentVolumes"
+
+	// owner: @irfanurrehman
+	// beta:
+	//
+	// Persistent volumes support.
+	ThrottlingMetrics featuregate.Feature = "ThrottlingMetrics"
 )
 
 func init() {
@@ -34,4 +40,5 @@ func init() {
 // Note: We use the config to feed the values, not the command line params.
 var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	PersistentVolumes: {Default: true, PreRelease: featuregate.Beta},
+	ThrottlingMetrics: {Default: true, PreRelease: featuregate.Beta},
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -23,7 +23,7 @@ const (
 	// owner: @irfanurrehman
 	// beta:
 	//
-	// Persistent volumes support.
+	// Throttling Metrics support.
 	ThrottlingMetrics featuregate.Feature = "ThrottlingMetrics"
 )
 


### PR DESCRIPTION
This change places the throttling metrics collection and discovery code behind a feature gate, but feature enabled by default.

To disable the feature following needs to be added to the kubeturbo config:

```
        "featureGates": {
          "disabledFeatures": ["ThrottlingMetrics"]
        }
```

@evat-pm do you think we need to add the option to configure this in the kubeturbo operator also? As far as I understand the gate gives us the ability to disable this feature in case we see any problems in some customer environment.

--------------------------------------------

EDIT:
I have added 2 more commits on this one (instead of a separate PR), to enable a faster review cycle.
1. Add support for throttling metrics counter resets and tests for that.
2. Add throttling commodity on containers and container specs even when we don't get these metrics from kubelet. Please note that if the metrics are not collected because of intermittent issues with kubelet connection, we would see a separate error in the logs, but the metrics would still be added with current value as zero.
3. Fix [this](https://github.com/turbonomic/kubeturbo/pull/542#discussion_r608281509) review comment from the previous PR.