### PR TITLE
Exclude windows labeled nodes from running cpu frequency getter

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -135,6 +136,10 @@ type VMTServer struct {
 	// Busybox image uri used for cpufreq getter job
 	BusyboxImage string
 
+	// CpufreqJobExcludeNodeLabels is used to specify node labels for nodes to be
+	// excluded from running cpufreq job
+	CpufreqJobExcludeNodeLabels string
+
 	// Strategy to aggregate Container utilization data on ContainerSpec entity
 	containerUtilizationDataAggStrategy string
 	// Strategy to aggregate Container usage data on ContainerSpec entity
@@ -186,6 +191,7 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=* to allow all.")
 	fs.StringVar(&s.ClusterAPINamespace, "cluster-api-namespace", "default", "The Cluster API namespace.")
 	fs.StringVar(&s.BusyboxImage, "busybox-image", "busybox", "The complete image uri used for fallback node cpu frequency getter job.")
+	fs.StringVar(&s.CpufreqJobExcludeNodeLabels, "cpufreq-job-exclude-node-labels", "", "The comma separated list of key=value node label pairs for the nodes (for example windows nodes) to be excluded from running job based cpufrequency getter.")
 	fs.StringVar(&s.containerUtilizationDataAggStrategy, "cnt-utilization-data-agg-strategy", agg.DefaultContainerUtilizationDataAggStrategy, "Container utilization data aggregation strategy.")
 	fs.StringVar(&s.containerUsageDataAggStrategy, "cnt-usage-data-agg-strategy", agg.DefaultContainerUsageDataAggStrategy, "Container usage data aggregation strategy.")
 }
@@ -225,13 +231,14 @@ func (s *VMTServer) createKubeClientOrDie(kubeConfig *restclient.Config) *kubern
 	return kubeClient
 }
 
-func (s *VMTServer) CreateKubeletClientOrDie(kubeConfig *restclient.Config, fallbackClient *kubernetes.Clientset, busyboxImage string, useProxyEndpoint bool) *kubeclient.KubeletClient {
+func (s *VMTServer) CreateKubeletClientOrDie(kubeConfig *restclient.Config, fallbackClient *kubernetes.Clientset,
+	busyboxImage string, cpufreqJobExcludeNodeLabels map[string]string, useProxyEndpoint bool) *kubeclient.KubeletClient {
 	kubeletClient, err := kubeclient.NewKubeletConfig(kubeConfig).
 		WithPort(s.KubeletPort).
 		EnableHttps(s.EnableKubeletHttps).
 		ForceSelfSignedCerts(s.ForceSelfSignedCerts).
 		// Timeout(to).
-		Create(fallbackClient, busyboxImage, useProxyEndpoint)
+		Create(fallbackClient, busyboxImage, cpufreqJobExcludeNodeLabels, useProxyEndpoint)
 	if err != nil {
 		glog.Errorf("Fatal error: failed to create kubeletClient: %v", err)
 		os.Exit(1)
@@ -328,7 +335,12 @@ func (s *VMTServer) Run() {
 	// Collect target and probe info such as master host, server version, probe container image, etc
 	k8sTAPSpec.CollectK8sTargetAndProbeInfo(kubeConfig, kubeClient)
 
-	kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, s.BusyboxImage, s.UseNodeProxyEndpoint)
+	excludeLabelsMap, err := mapFromSelector(s.CpufreqJobExcludeNodeLabels)
+	if err != nil {
+		glog.Fatalf("Invalid cpu frequency exclude node label selectors: %v. The selectors "+
+			"should be a comma saperated list of key=value node label pairs", err)
+	}
+	kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, s.BusyboxImage, excludeLabelsMap, s.UseNodeProxyEndpoint)
 	caClient, err := clusterclient.NewForConfig(kubeConfig)
 	if err != nil {
 		glog.Errorf("Failed to generate correct TAP config: %v", err.Error())
@@ -490,4 +502,24 @@ func latestComparedVersion(newVersion, existingVersion string) string {
 		return existingVersion
 	}
 	return newVersion
+}
+
+func mapFromSelector(selector string) (map[string]string, error) {
+	labelsMap := make(map[string]string)
+
+	if len(selector) == 0 {
+		return labelsMap, nil
+	}
+
+	labels := strings.Split(selector, ",")
+	for _, label := range labels {
+		l := strings.Split(label, "=")
+		if len(l) != 2 {
+			return labelsMap, fmt.Errorf("invalid selector: %s", l)
+		}
+		key := strings.TrimSpace(l[0])
+		value := strings.TrimSpace(l[1])
+		labelsMap[key] = value
+	}
+	return labelsMap, nil
 }

--- a/pkg/discovery/util/node_util.go
+++ b/pkg/discovery/util/node_util.go
@@ -3,8 +3,9 @@ package util
 import (
 	"errors"
 	"fmt"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"strings"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types"
@@ -43,6 +44,31 @@ func NodeIsReady(node *api.Node) bool {
 		}
 	}
 	glog.Errorf("Node %s does not have Ready status.", node.Name)
+	return false
+}
+
+func NodeMatchesLabels(node *api.Node, defaultLabels, mustMatchLabels map[string]string) bool {
+	if len(mustMatchLabels) > 0 {
+		// All labels must match
+		for k, v := range mustMatchLabels {
+			value, ok := node.Labels[k]
+			if !ok {
+				return false
+			}
+			if value != v {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Any label matched from default is a match
+	for k, v := range defaultLabels {
+		value, ok := node.Labels[k]
+		if ok && value == v {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/discovery/util/node_util_test.go
+++ b/pkg/discovery/util/node_util_test.go
@@ -1,0 +1,102 @@
+package util
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNodeMatchesLabels(t *testing.T) {
+	defaultExcludeLabels := map[string]string{
+		"kubernetes.io/os":      "windows",
+		"beta.kubernetes.io/os": "windows",
+	}
+
+	windowsLabels1 := map[string]string{
+		"kubernetes.io/os":      "windows",
+		"beta.kubernetes.io/os": "windows",
+		"node1":                 "value1",
+	}
+
+	windowsLabels2 := map[string]string{
+		"beta.kubernetes.io/os": "windows",
+		"node1":                 "value1",
+	}
+
+	windowsLabels3 := map[string]string{
+		"beta.kubernetes.io/os": "windows",
+		"key1":                  "value1",
+		"key2":                  "value2",
+	}
+
+	linuxLabels := map[string]string{
+		"kubernetes.io/os": "linux",
+		"node2":            "value2",
+	}
+
+	customLabels := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	type labelTest struct {
+		mustMatchLabels map[string]string
+		node            *v1.Node
+		expectMatch     bool
+	}
+
+	tests := []labelTest{
+		{
+			mustMatchLabels: nil,
+			node:            getNodeWithLabels(windowsLabels1),
+			expectMatch:     true,
+		},
+		{
+			mustMatchLabels: nil,
+			node:            getNodeWithLabels(windowsLabels2),
+			expectMatch:     true,
+		},
+		{
+			mustMatchLabels: nil,
+			node:            getNodeWithLabels(linuxLabels),
+			expectMatch:     false,
+		},
+		{
+			mustMatchLabels: defaultExcludeLabels,
+			node:            getNodeWithLabels(windowsLabels1),
+			expectMatch:     true,
+		},
+		{
+			mustMatchLabels: defaultExcludeLabels,
+			node:            getNodeWithLabels(windowsLabels2),
+			expectMatch:     false,
+		},
+		{
+			mustMatchLabels: defaultExcludeLabels,
+			node:            getNodeWithLabels(linuxLabels),
+			expectMatch:     false,
+		},
+		{
+			mustMatchLabels: customLabels,
+			node:            getNodeWithLabels(windowsLabels3),
+			expectMatch:     true,
+		},
+	}
+
+	for _, test := range tests {
+		match := NodeMatchesLabels(test.node, defaultExcludeLabels, test.mustMatchLabels)
+		if match != test.expectMatch {
+			t.Errorf("Label match failed, Nodes labels: %++v, excludeLabels: %++v, mustMatchLabels: %++v."+
+				"Expected match: %v, got: %v", test.node.Labels, defaultExcludeLabels, test.mustMatchLabels, test.expectMatch, match)
+		}
+	}
+}
+
+func getNodeWithLabels(labels map[string]string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: labels,
+		},
+	}
+}

--- a/pkg/kubeclient/cpufrequency.go
+++ b/pkg/kubeclient/cpufrequency.go
@@ -24,8 +24,13 @@ import (
 const (
 	kubeturboNamespace = "KUBETURBO_NAMESPACE"
 	defaultNamespace   = "default"
-	DefaultCpuFreq     = float64(2000) //MHz
+	defaultCpuFreq     = float64(2000) //MHz
 )
+
+var DefaultCpufreqJobExcludeNodeLabels = map[string]string{
+	"kubernetes.io/os":      "windows",
+	"beta.kubernetes.io/os": "windows",
+}
 
 type NodeCpuFrequencyGetter struct {
 	kubeClient   *kubernetes.Clientset

--- a/pkg/kubeclient/kubelet_client_test.go
+++ b/pkg/kubeclient/kubelet_client_test.go
@@ -68,7 +68,7 @@ func TestKubeletClientCacheNil(t *testing.T) {
 	kubeConf := &rest.Config{}
 	conf := NewKubeletConfig(kubeConf)
 
-	kc, _ := conf.Create(nil, "busybox", false)
+	kc, _ := conf.Create(nil, "busybox", map[string]string{}, false)
 	entry := &CacheEntry{}
 	kc.cache["host_1"] = entry
 	assert.False(t, kc.HasCacheBeenUsed("host_1"))

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -80,7 +80,7 @@ var _ = Describe("Discover Cluster", func() {
 			}
 
 			s := app.NewVMTServer()
-			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "busybox", true)
+			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "busybox", map[string]string{}, true)
 
 			apiExtClient, err := apiextclient.NewForConfig(kubeConfig)
 			if err != nil {


### PR DESCRIPTION
Implements https://vmturbo.atlassian.net/browse/OM-69572

The details of implementation are in the jira issue.
As a gist:
After this PR, the windows nodes will be automatically identified using the below default labels (nodes labelled with either):
`kubernetes.io/os: windows`
`beta.kubernetes.io/os: windows`

This can be overridden with a strict set of labels passed as kubeturbo cmd line argument `cpufreq-job-exclude-node-labels`.
eg. `--cpufreq-job-exclude-node-labels=kubernetes.io/os=windows,product=turbo`

Tested both the default and the cmd line argument to be working as expected. 
Logs for a windows node (first discover, default cpu freq hasn't been filled from linux nodes):
```
E0419 03:19:05.953938       1 kubelet_client.go:322] Failed to get machine[ip-192-168-18-158.ec2.internal] cpu.frequency from kubelet: "https://192.168.18.158:10250/spec" was not found. Will try pod based getter.
W0419 03:19:05.953984       1 kubelet_client.go:326] Node ip-192-168-18-158.ec2.internal seems to be a windows node, default cpu frequency will be used.
I0419 03:19:05.953995       1 kubelet_monitor.go:255] node-ip-192-168-18-158.ec2.internal cpuFrequency = 2000.00MHz
```

Logs for a windows node (further discoveries, default cpu freq has been filled from linux nodes):
```
E0419 03:29:03.197224       1 kubelet_client.go:322] Failed to get machine[ip-192-168-18-158.ec2.internal] cpu.frequency from kubelet: "https://192.168.18.158:10250/spec" was not found. Will try pod based getter.
W0419 03:29:03.197260       1 kubelet_client.go:326] Node ip-192-168-18-158.ec2.internal seems to be a windows node, default cpu frequency will be used.
I0419 03:29:03.197269       1 kubelet_monitor.go:255] node-ip-192-168-18-158.ec2.internal cpuFrequency = 2528.97MHz
```
