### PR TITLE
Added support to specify communication binding channel when registering probe and adding target

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20210326125330-5d184a461727
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20210513033620-9b641b508d10
 )
 
 // k8s and relevant dependencies

--- a/go.sum
+++ b/go.sum
@@ -773,12 +773,10 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/turbonomic/turbo-api v0.0.0-20210114025310-0e31e19c3312 h1:e5Tmfc07zR3aCaBy7fx4Cvgipx8zXlvyOj958VjU3BI=
-github.com/turbonomic/turbo-api v0.0.0-20210114025310-0e31e19c3312/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20210312042142-5a5a8362b499 h1:v8f5S8YI/F+64Ei1NhM45PZTRloEejzqZuzGN+Zolj0=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20210312042142-5a5a8362b499/go.mod h1:0zAmM4Mj+lZQtgz4pqfELgxEElwrSzsfWI480fQwa08=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20210326125330-5d184a461727 h1:Lj6Hv/Cdur5JzZcsdIoOHhiKvNCW9QGfbdbu0QVErjA=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20210326125330-5d184a461727/go.mod h1:0zAmM4Mj+lZQtgz4pqfELgxEElwrSzsfWI480fQwa08=
+github.com/turbonomic/turbo-api v0.0.0-20210513030812-aca128ea36a0 h1:q3hPEL6M8BIvAxkxIGfY5vo+0bphDz6bA9d41PCoIoQ=
+github.com/turbonomic/turbo-api v0.0.0-20210513030812-aca128ea36a0/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20210513033620-9b641b508d10 h1:jBopaYOSy03Ua3bcXIJJvXzxOBz2quo04pOk88m8w0Y=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20210513033620-9b641b508d10/go.mod h1:C/3vkBwvmsdBH4AAgFUsmOe8BA6cQpomZaRVY4Bqo8g=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/discovery/configs/target_config.go
+++ b/pkg/discovery/configs/target_config.go
@@ -44,10 +44,9 @@ func (config *K8sTargetConfig) ValidateK8sTargetConfig() error {
 	// Determine target type
 	prefix := defaultTargetType + "-"
 	if config.TargetType == "" {
-		config.TargetType = config.TargetIdentifier
-	}
-	// Prefix targetType with Kubernetes if needed
-	if !strings.HasPrefix(config.TargetType, prefix) {
+		config.TargetType = defaultTargetType
+	} else if !strings.HasPrefix(config.TargetType, prefix) {
+		// Prefix targetType with "Kubernetes-"
 		config.TargetType = prefix + config.TargetType
 	}
 	if config.ProbeCategory == "" {

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -198,8 +198,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 
 	k8sSvcId, err := probeConfig.ClusterScraper.GetKubernetesServiceID()
 	if err != nil {
-		glog.Errorf("Error retrieving the Kubernetes service id: %v", err)
-		k8sSvcId = ""
+		glog.Fatalf("Error retrieving the Kubernetes service id: %v", err)
 	}
 	tapService, err :=
 		service.NewTAPServiceBuilder().

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -196,8 +196,14 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 		probeBuilder = probeBuilder.WithDiscoveryClient(discoveryClient)
 	}
 
+	k8sSvcId, err := probeConfig.ClusterScraper.GetKubernetesServiceID()
+	if err != nil {
+		glog.Errorf("Error retrieving the Kubernetes service id: %v", err)
+		k8sSvcId = ""
+	}
 	tapService, err :=
 		service.NewTAPServiceBuilder().
+			WithCommunicationBindingChannel(k8sSvcId).
 			WithTurboCommunicator(config.tapSpec.TurboCommunicationConfig).
 			WithTurboProbe(probeBuilder).
 			Create()

--- a/pkg/k8s_tap_service_test.go
+++ b/pkg/k8s_tap_service_test.go
@@ -19,7 +19,7 @@ func TestParseK8sTAPServiceSpecWithMissingTargetConfig(t *testing.T) {
 
 	// Check target config
 	checkStartWith(config.ProbeCategory, "Cloud Native", t)
-	check(config.TargetType, "Kubernetes-"+defaultTargetName, t)
+	check(config.TargetType, "Kubernetes", t)
 	check(config.TargetIdentifier, "Kubernetes-"+defaultTargetName, t)
 
 	// Check comm config
@@ -52,7 +52,7 @@ func TestParseK8sTAPServiceSpecWithEmptyTargetConfig(t *testing.T) {
 
 	// Check target config
 	checkStartWith(config.ProbeCategory, "Cloud Native", t)
-	check(config.TargetType, "Kubernetes-"+defaultTargetName, t)
+	check(config.TargetType, "Kubernetes", t)
 	check(config.TargetIdentifier, "Kubernetes-"+defaultTargetName, t)
 }
 
@@ -88,7 +88,7 @@ func TestParseK8sTAPServiceSpecWithTargetName(t *testing.T) {
 	// Check target config
 	checkStartWith(config.ProbeCategory, "Cloud Native", t)
 	// The target name should be the one from the config file
-	check(config.TargetType, "Kubernetes-cluster-foo", t)
+	check(config.TargetType, "Kubernetes", t)
 	check(config.TargetIdentifier, "Kubernetes-cluster-foo", t)
 	check(config.OpsManagerUsername, "foo", t)
 	check(config.OpsManagerPassword, "bar", t)


### PR DESCRIPTION
Enhanced Kubeturbo to inject the k8s service id as the communication binding channel during both probe registration and target creation so to leverage the capability to bind the target with the probe.  This also means that we could get rid of the target type suffix which was the old way of sticking the target with the probe.

**Overall solution**
- If the target type is configured, then that will be used as the probe type suffix; this is the current behavior.
- If the target type is not configured, then a normalized probe type will be used (e.g. "Kubernetes" for kubeturbo probe); this is a new behavior.
Please see a more detailed summary below:
<img width="1101" alt="kubeturbo-binding-channel" src="https://user-images.githubusercontent.com/6045065/115904327-a6e0c300-a432-11eb-841d-e7ac35960ae6.png">

This is also translated to a simple adjustment in Kubeturbo to adopt the default target type ("Kubernetes") if no target type is specified in the configuration, rather than using the target name as the target type.

**Tests done** (with corresponding changes in [turbo-go-sdk](https://github.com/turbonomic/turbo-go-sdk/pull/120) and [turbo-api](https://github.com/turbonomic/turbo-api/pull/11)):
- Tested adding a new target using the binding channel method
- Tested upgrade scenarios with different combinations of target type, target name and whether credentials are specified; please see the attached screenshot
<img width="895" alt="kubeturbo-binding-channel-test-scenarios" src="https://user-images.githubusercontent.com/6045065/115904430-c11aa100-a432-11eb-8ca1-a27768f1d73a.png">
- Tested triggering discovery requests on one of the targets with the normalized probe type, and ensured that the request only went to the specific probe/cluster to prove that the binding channel method is working.
- Triggered discoveries multiple times on the same target and confirmed they all went to the same probe.

========
Note: go.mod dependencies will be adjusted once the [turbo-go-sdk PR](https://github.com/turbonomic/turbo-go-sdk/pull/120) is merged.