### PR TITLE
Update step3_turbo_serviceAccountRoleBinding_admin_sample.yaml

### DIFF
--- a/deploy/kubeturbo_yamls/step3_turbo_serviceAccountRoleBinding_admin_sample.yaml
+++ b/deploy/kubeturbo_yamls/step3_turbo_serviceAccountRoleBinding_admin_sample.yaml
@@ -7,7 +7,6 @@ metadata:
   # use this yaml to create a binding that will assign cluster-admin to your turbo ServiceAccount 
   # Provide a value for the binding name: and update namespace if needed
   name: turbo-all-binding
-  namespace: turbo
 subjects:
 - kind: ServiceAccount
   # Provide the correct value for service account name: and namespace if needed


### PR DESCRIPTION
took out namespace because it is irrelevant to CRB