### PR TITLE
Set VM provision and suspend action eligibility based on cluster-api availability

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	kubeturbo "github.com/turbonomic/kubeturbo/pkg"
+	"github.com/turbonomic/kubeturbo/pkg/action/executor"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/worker"
 	"github.com/turbonomic/kubeturbo/pkg/util"
 	"github.com/turbonomic/kubeturbo/test/flag"
@@ -348,6 +349,7 @@ func (s *VMTServer) Run() {
 	}
 
 	ormClient := resourcemapping.NewORMClient(dynamicClient, apiExtClient)
+	clusterAPIEnabled := executor.IsClusterAPIEnabled(caClient, kubeClient)
 
 	// Configuration for creating the Kubeturbo TAP service
 	vmtConfig := kubeturbo.NewVMTConfig2()
@@ -372,7 +374,8 @@ func (s *VMTServer) Run() {
 		WithContainerUtilizationDataAggStrategy(s.containerUtilizationDataAggStrategy).
 		WithContainerUsageDataAggStrategy(s.containerUsageDataAggStrategy).
 		WithVolumePodMoveConfig(s.FailVolumePodMoves).
-		WithQuotaUpdateConfig(s.UpdateQuotaToAllowMoves)
+		WithQuotaUpdateConfig(s.UpdateQuotaToAllowMoves).
+		WithClusterAPIEnabled(clusterAPIEnabled)
 	glog.V(3).Infof("Finished creating turbo configuration: %+v", vmtConfig)
 
 	// The KubeTurbo TAP service

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -141,8 +141,8 @@ func (h *ActionHandler) registerActionExecutors() {
 	controllerResizer := executor.NewWorkloadControllerResizer(ae, c.kubeletClient, c.sccAllowedSet)
 	h.actionExecutors[turboActionControllerResize] = controllerResizer
 
-	// Only register the actions when API client is non-nil.
-	if ok, err := executor.IsClusterAPIEnabled(c.cAPINamespace, c.cApiClient, c.clusterScraper.Clientset); ok && err == nil {
+	// Only register the actions when API client is non-nil and cluster-api is available.
+	if executor.IsClusterAPIEnabled(c.cApiClient, c.clusterScraper.Clientset) {
 		machineScaler := executor.NewMachineActionExecutor(c.cAPINamespace, ae)
 		h.actionExecutors[turboActionMachineProvision] = machineScaler
 		h.actionExecutors[turboActionMachineSuspend] = machineScaler

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -157,7 +157,8 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	}
 
 	// Create the configurations for the registration, discovery and action clients
-	registrationClientConfig := registration.NewRegistrationClientConfig(config.StitchingPropType, config.VMPriority, config.VMIsBase)
+	registrationClientConfig := registration.NewRegistrationClientConfig(config.StitchingPropType, config.VMPriority,
+		config.VMIsBase, config.clusterAPIEnabled)
 
 	probeConfig := createProbeConfigOrDie(config)
 	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig,

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -50,6 +50,7 @@ type Config struct {
 
 	failVolumePodMoves      bool
 	updateQuotaToAllowMoves bool
+	clusterAPIEnabled       bool
 }
 
 func NewVMTConfig2() *Config {
@@ -172,5 +173,10 @@ func (c *Config) WithVolumePodMoveConfig(failVolumePodMoves bool) *Config {
 
 func (c *Config) WithQuotaUpdateConfig(updateQuotaToAllowMoves bool) *Config {
 	c.updateQuotaToAllowMoves = updateQuotaToAllowMoves
+	return c
+}
+
+func (c *Config) WithClusterAPIEnabled(clusterAPIEnabled bool) *Config {
+	c.clusterAPIEnabled = clusterAPIEnabled
 	return c
 }

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -33,7 +33,7 @@ func xcheck(expected map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_Ac
 }
 
 func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
-	conf := NewRegistrationClientConfig(stitching.UUID, 0, true)
+	conf := NewRegistrationClientConfig(stitching.UUID, 0, true, true)
 	targetConf := &configs.K8sTargetConfig{}
 	reg := NewK8sRegistrationClient(conf, targetConf)
 
@@ -136,7 +136,7 @@ func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
 }
 
 func TestK8sRegistrationClient_GetEntityMetadata(t *testing.T) {
-	conf := NewRegistrationClientConfig(stitching.UUID, 0, true)
+	conf := NewRegistrationClientConfig(stitching.UUID, 0, true, true)
 	targetConf := &configs.K8sTargetConfig{}
 	reg := NewK8sRegistrationClient(conf, targetConf)
 


### PR DESCRIPTION
Fixes https://vmturbo.atlassian.net/browse/OM-65636.

On a cluster which does not have cluster-api available kubeturbo sends below action eligibility DTO for VMs.

```
        "entityType": 10,
          "capabilityElement": [
            {
              "actionType": "RESIZE",
              "actionCapability": "NOT_SUPPORTED"
            },
            {
              "actionType": "SCALE",
              "actionCapability": "NOT_SUPPORTED"
            },
            {
              "actionType": "PROVISION",
              "actionCapability": "NOT_EXECUTABLE"
            },
            {
              "actionType": "DEACTIVATE",
              "actionCapability": "NOT_EXECUTABLE"
            }
          ]
```

On a cluster with cluster api available below is the DTO

```
       "entityType": 10,
          "capabilityElement": [
            {
              "actionType": "PROVISION",
              "actionCapability": "SUPPORTED"
            },
            {
              "actionType": "RESIZE",
              "actionCapability": "NOT_SUPPORTED"
            },
            {
              "actionType": "SCALE",
              "actionCapability": "NOT_SUPPORTED"
            },
            {
              "actionType": "DEACTIVATE",
              "actionCapability": "SUPPORTED"
            }
          ]
```