### PR TITLE
Set pod state to power state unknown if its container metrics are missing

### DIFF
--- a/pkg/action/util/expiration_map_test.go
+++ b/pkg/action/util/expiration_map_test.go
@@ -2,9 +2,10 @@ package util
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"testing"
 	"time"
+
+	"github.com/golang/glog"
 )
 
 const (
@@ -83,7 +84,9 @@ func TestExpirationMap_Touch(t *testing.T) {
 		t.Errorf("Add failed.")
 	}
 
-	for i := 0; i < 10; i++ {
+	// Latest version of go (1.16+) has the test timeout set a 30 seconds
+	// for each individual test by default. We try to have this finish under that.
+	for i := 0; i < 5; i++ {
 		flag := store.Touch(key, v)
 		if !flag {
 			t.Errorf("Touch test1 failed.")

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -38,12 +38,13 @@ const (
 	StorageAmount      ResourceType = "StorageAmount"
 	VCPUThrottling     ResourceType = "VCPUThrottling"
 
-	Access       ResourceType = "Access"
-	Cluster      ResourceType = "Cluster"
-	CpuFrequency ResourceType = "CpuFrequency"
-	Owner        ResourceType = "Owner"
-	OwnerType    ResourceType = "OwnerType"
-	OwnerUID     ResourceType = "OwnerUID"
+	Access              ResourceType = "Access"
+	Cluster             ResourceType = "Cluster"
+	CpuFrequency        ResourceType = "CpuFrequency"
+	Owner               ResourceType = "Owner"
+	OwnerType           ResourceType = "OwnerType"
+	OwnerUID            ResourceType = "OwnerUID"
+	MetricsAvailability ResourceType = "MetricsAvailability"
 )
 
 var (


### PR DESCRIPTION
Fixes https://vmturbo.atlassian.net/browse/OM-69338.

This PR sets the Pod power state to `unknown` if we cannot get cpu and mem used metrics for any of its containers.

~~I am still trying to test this somehow, as there is no straightforward way to have the kubelet skip metrics from some containers. In any case, I will update a unit tests to ensure code functionality works as expected.~~
Have updated the unit tests for this. There is no clear way I could identify to recreate the missing container metrics from kubelet in a real env. Please let me know if there are any suggestions for e2e test of this.