### PR TITLE
Add service UUID to service property for stitching purpose

### DIFF
--- a/pkg/discovery/dtofactory/service_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/service_entity_dto_builder.go
@@ -91,7 +91,7 @@ func (builder *ServiceEntityDTOBuilder) BuildDTOs() []*proto.EntityDTO {
 		ebuilder.ServiceData(serviceData)
 
 		// set the ip property for stitching
-		ebuilder.WithProperty(getIPProperty(pods))
+		ebuilder.WithProperty(getIPProperty(pods)).WithProperty(getUUIDProperty(id))
 
 		ebuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
 
@@ -232,6 +232,17 @@ func (builder *ServiceEntityDTOBuilder) getCommoditiesBought(appDTO *proto.Entit
 	}
 
 	return commoditiesBoughtFromApp, nil
+}
+
+// Get the UUID property of the service for stitching purpose
+func getUUIDProperty(uuid string) *proto.EntityDTO_EntityProperty {
+	ns := stitching.DefaultPropertyNamespace
+	attr := string(stitching.UUID)
+	return &proto.EntityDTO_EntityProperty{
+		Namespace: &ns,
+		Name:      &attr,
+		Value:     &uuid,
+	}
 }
 
 // Get the IP property of the service for stitching purpose


### PR DESCRIPTION
## Intention
To be able to stitch k8s services discovered from APM probes with services discovered from `kubeturbo`.

## Implementation
Add a `UUID` field to the property of Service.

## Test
Make sure the `UUID` field exists in the topology.

```
              "entityPropertyMap": {
                "IP": "Service-172.17.10.69,Service-172.17.19.83",
                "UUID": "a7f56657-3f93-4aed-83c0-e6f400d9d800"
              },
```