### PR TITLE
Do not autocreate pod by parent controller groups

### DIFF
--- a/pkg/discovery/worker/group_metrics_collector.go
+++ b/pkg/discovery/worker/group_metrics_collector.go
@@ -2,12 +2,14 @@ package worker
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
-	"k8s.io/api/core/v1"
 )
 
 // Collects parent info for the pods and containers and converts to EntityGroup objects
@@ -60,8 +62,18 @@ func (collector *GroupMetricsCollector) CollectGroupMetrics() []*repository.Enti
 		}
 		entityGroupByParentKind := entityGroupsByParentKind[ownerTypeString]
 
-		// Add pod member to the group1
-		entityGroup.AddMember(metrics.PodType, podId)
+		// We currently skip adding pod members which results in no groups of
+		// pods per parent controller for each namespace being created. These groups
+		// are not needed and cause performance overhead, especially in large topologies.
+		//
+		// TODO: Cleanup all the relevant group creation code after the alternative
+		// mechanism for consistent scaling of containers across pods of one parent
+		// is in place.
+		// TODO: Also consider having code for atleast some of these autocreated groups,
+		// behind a flag useful for smaller topologies.
+		//
+		// entityGroup.AddMember(metrics.PodType, podId)
+
 		// Add pod member to the group2
 		entityGroupByParentKind.AddMember(metrics.PodType, podId)
 


### PR DESCRIPTION
Implements https://vmturbo.atlassian.net/browse/OM-70837

Please not that this update is temperory. Once the overall change of depending the server side code on the `controls` and `controlled by` relationships for consistent scaling is in place, most of the group creation code will be cleaned up.

After this change, the individual groups of pods per parent controller per namespace will not be created. The global groups will still be created.

![image](https://user-images.githubusercontent.com/10027921/118960100-48adee00-b9a6-11eb-8dc0-7e2d3de27455.png)
