### PR TITLE
Fix kubeturbo crashing due to nil pointer dereference

### DIFF
--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -348,7 +348,7 @@ func (m EntityStateMetric) GetValue() interface{} {
 
 func (m EntityStateMetric) UpdateValue(existing interface{}, maxMetricPointsSize int) Metric {
 	// NOP
-	return nil
+	return m
 }
 
 // Generate the UID for each metric entry based on entityType, entityID and resourceType.

--- a/pkg/turbostore/turbo_store.go
+++ b/pkg/turbostore/turbo_store.go
@@ -51,6 +51,9 @@ func (s *Cache) Get(key string) (interface{}, bool) {
 
 // Get all the keys of current cache.
 func (s *Cache) AllKeys() []string {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
 	keys := make([]string, 0, len(s.items))
 	for k := range s.items {
 		keys = append(keys, k)


### PR DESCRIPTION
This PR fixes two critical problems:

## Problem 1
* A `nil` pointer dereference issue:
```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xc1db43]
goroutine 522 [running]:
github.com/turbonomic/kubeturbo/pkg/discovery/metrics.(*EntityMetricSink).AddNewMetricEntries(0xc001e5c870, 0xc0011c8e48, 0x1, 0x1)
	/home/travis/gopath/src/github.com/turbonomic/kubeturbo/pkg/discovery/metrics/metric_sink.go:32 +0xc3
github.com/turbonomic/kubeturbo/pkg/discovery/metrics.(*EntityMetricSink).UpdateMetricEntry(0xc001e5c870, 0x426a720, 0xc0026594a0)
	/home/travis/gopath/src/github.com/turbonomic/kubeturbo/pkg/discovery/metrics/metric_sink.go:43 +0x9d
github.com/turbonomic/kubeturbo/pkg/discovery/metrics.(*EntityMetricSink).MergeSink(0xc001e5c870, 0xc001e5c880, 0x0)
	/home/travis/gopath/src/github.com/turbonomic/kubeturbo/pkg/discovery/metrics/metric_sink.go:76 +0x182
github.com/turbonomic/kubeturbo/pkg/discovery/worker.(*k8sDiscoveryWorker).executeTask.func1.1(0x423f660, 0xc000bb0f00, 0xc000bb0f50, 0xc0001d3e00, 0xc001df3140, 0xc00416bd60, 0xc001df3080)
	/home/travis/gopath/src/github.com/turbonomic/kubeturbo/pkg/discovery/worker/k8s_discovery_worker.go:221 +0x196
created by github.com/turbonomic/kubeturbo/pkg/discovery/worker.(*k8sDiscoveryWorker).executeTask.func1
	/home/travis/gopath/src/github.com/turbonomic/kubeturbo/pkg/discovery/worker/k8s_discovery_worker.go:207 +0x199
```
* Cause: 
  This is introduced by #555. In #555, we introduced a new `StateMetric` called `MetricsAvailability`.  This metric is discovered by the `kubelet_monitor` sampling worker which usually only discovers `ResourceMetric`. The `kubelet_monitor` samples resource metric data points every minute and then performs `ResourceMetric.UpdateValue` by appending a new data point to the existing data points. Because #555, the update operation is also done for the new  `MetricsAvailability` metric, but the implementation of the `StateMetric.UpdateValue` is a no-op and incorrectly returns `nil`.

* Fix:
  We should return the object itself instead of `nil` in `StateMetric.UpdateValue`.

## Problem 2
* As seen in the following stack trace. This problem doesn't happen very frequently
```
0302 00:22:00.586366       1 result_collector.go:57] Processing results from worker w2
fatal error: concurrent map iteration and map write
goroutine 8849 [running]:
runtime.throw(0x38d2365, 0x26)
	/usr/local/Cellar/go/1.15.2/libexec/src/runtime/panic.go:1116 +0x72 fp=0xc001c65d08 sp=0xc001c65cd8 pc=0x437572
runtime.mapiternext(0xc001c65df8)
	/usr/local/Cellar/go/1.15.2/libexec/src/runtime/map.go:853 +0x554 fp=0xc001c65d88 sp=0xc001c65d08 pc=0x410c94
github.com/turbonomic/kubeturbo/pkg/turbostore.(*Cache).AllKeys(0xc000c6d160, 0x3d9fe00, 0xc001df8300, 0x3d9fe00)
	/Users/meng/go/src/github.com/turbonomic/kubeturbo/pkg/turbostore/turbo_store.go:55 +0xf0 fp=0xc001c65e68 sp=0xc001c65d88 pc=0xc70510
github.com/turbonomic/kubeturbo/pkg/discovery/metrics.(*EntityMetricSink).MergeSink(0xc00215a670, 0xc000c79ee0, 0x0)
```
* Cause:
  We are not properly synchronize the data access in `turbostore`.

* Fix:
  Properly guard the `AllKeys` function.

## Test
Run the newly built `kubeturbo` for 30+ minutes and did not observe crash so far.


