### PR TITLE
Provide stitching information for availableForPlacement set from kubeturbo

### DIFF
--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -88,8 +88,11 @@ var (
 	VMUUID         = supplychain.SUPPLY_CHAIN_CONSTANT_ID
 
 	// Common property
-	path                   = "path"
-	ActionEligibilityField = "actionEligibility"
+	path                       = "path"
+	ActionEligibilityField     = "actionEligibility"
+	providerPolicyPath         = "providerPolicy"
+	availableForPlacementField = "availableForPlacement"
+	powerStateField            = "powerState"
 )
 
 type SupplyChainFactory struct {
@@ -230,6 +233,7 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 	mergedEntityMetadataBuilder := builder.NewMergedEntityMetadataBuilder()
 
 	mergedEntityMetadataBuilder.PatchField(ActionEligibilityField, []string{})
+	mergedEntityMetadataBuilder.PatchField(availableForPlacementField, []string{providerPolicyPath})
 	// Set up matching criteria based on stitching type
 	switch f.stitchingPropertyType {
 	case stitching.UUID:
@@ -244,6 +248,7 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 		return nil, fmt.Errorf("stitching property type %s is not supported",
 			f.stitchingPropertyType)
 	}
+
 	return mergedEntityMetadataBuilder.
 		PatchSoldMetadata(proto.CommodityDTO_CLUSTER, fieldsCapactiy).
 		PatchSoldMetadata(proto.CommodityDTO_VMPM_ACCESS, fieldsCapactiy).
@@ -483,7 +488,7 @@ func (f *SupplyChainFactory) buildVolumeMergedEntityMetadata() (*proto.MergedEnt
 	mergedEntityMetadataBuilder := builder.NewMergedEntityMetadataBuilder()
 
 	mergedEntityMetadataBuilder.PatchField(ActionEligibilityField, []string{}).
-		PatchField("powerState", []string{}).
+		PatchField(powerStateField, []string{}).
 		InternalMatchingProperty(proxyVolumeUUID).
 		ExternalMatchingField(supplychain.SUPPLY_CHAIN_CONSTANT_ID, []string{}).
 		InternalMatchingProperty(path).


### PR DESCRIPTION
Fixes https://vmturbo.atlassian.net/browse/OM-71010

The field `isAvailableAsProvider` is correctly set post stitching to the value passed from kubeturbo for `availableForPlacement`.
For example 
for `pt-k8s-node-1`
```
 "isAvailableAsProvider": true,
```
for `pt-k8s-master-1`
```
"isAvailableAsProvider": false,
```
No move actions generated with master nodes in question with the same cluster (pt-test-k8s-dc11) and the same workloads in the stitched env.

![image](https://user-images.githubusercontent.com/10027921/119301906-8e203300-bca6-11eb-8d2e-b7690cab2fff.png)

![image](https://user-images.githubusercontent.com/10027921/119302329-477f0880-bca7-11eb-9655-90a6586d7650.png)



