### PR TITLE
Revert refactor unschedulable nodes

### DIFF
--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -162,16 +162,10 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) []*proto
 			continue
 		}
 
+		entityDto.ProviderPolicy = &proto.EntityDTO_ProviderPolicy{AvailableForPlacement: &isAvailableForPlacement}
 		if !isAvailableForPlacement {
 			glog.Warningf("Node %s has been marked unavailable for placement due to disk pressure.", node.GetName())
 		}
-		nodeSchedulable := nodeActive && util.NodeIsSchedulable(node)
-		if !nodeSchedulable {
-			glog.Warningf("Node %s has been marked unavailable for placement because its Unschedulable.", node.GetName())
-		}
-		isAvailableForPlacement = isAvailableForPlacement && nodeSchedulable
-		entityDto.ProviderPolicy = &proto.EntityDTO_ProviderPolicy{AvailableForPlacement: &isAvailableForPlacement}
-
 		result = append(result, entityDto)
 
 		glog.V(4).Infof("Node DTO : %+v", entityDto)

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -381,14 +381,22 @@ func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*prot
 	glog.V(2).Infof("Successfully processed affinity.")
 
 	// Taint-toleration process to create access commodities
+	// Also handles the creation of access commodities to handle unschedulable nodes
 	glog.V(2).Infof("Begin to process taints and tolerations")
-	taintTolerationProcessor, err := compliance.NewTaintTolerationProcessor(clusterSummary)
+	nodesManager := compliance.NewNodeSchedulabilityManager(clusterSummary)
+
+	taintTolerationProcessor, err := compliance.NewTaintTolerationProcessor(clusterSummary, nodesManager)
 	if err != nil {
 		glog.Errorf("Failed during process taints and tolerations: %v", err)
 	} else {
 		// Add access commodities to entity DOTs based on the taint-toleration rules
 		taintTolerationProcessor.Process(result.EntityDTOs)
 	}
+
+	// Anti-Affinity policy to prevent pods on unschedulable nodes to move to other unschedulable nodes
+	nodesAntiAffinityGroupBuilder := compliance.NewUnschedulableNodesAntiAffinityGroupDTOBuilder(
+		clusterSummary, targetID, nodesManager)
+	nodeAntiAffinityGroupDTOs := nodesAntiAffinityGroupBuilder.Build()
 
 	glog.V(2).Infof("Successfully processed taints and tolerations.")
 
@@ -404,6 +412,8 @@ func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*prot
 				groupDto.GetMemberList().Member)
 		}
 	}
+
+	groupDTOs = append(groupDTOs, nodeAntiAffinityGroupDTOs...)
 
 	// Create the cluster DTO
 	clusterEntityDTO, err := dtofactory.NewClusterDTOBuilder(clusterSummary, targetID).BuildEntity(result.EntityDTOs, namespaceDtos)

--- a/pkg/discovery/worker/compliance/node_schedulability_manager.go
+++ b/pkg/discovery/worker/compliance/node_schedulability_manager.go
@@ -1,0 +1,85 @@
+package compliance
+
+import (
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	api "k8s.io/api/core/v1"
+)
+
+// Structure to keep track of the schedulable state of the nodes
+type NodeSchedulabilityManager struct {
+	cluster *repository.ClusterSummary
+
+	// Map of node name and boolean indicating its schedulable state
+	schedulableStateMap map[string]bool
+
+	// List of names of all the unschedulable nodes
+	unSchedulableNodes []string
+}
+
+// Return a new NodeSchedulabilityManager struct.
+// Input parameter ClusterSummary holds the list of nodes in the cluster.
+func NewNodeSchedulabilityManager(cluster *repository.ClusterSummary) *NodeSchedulabilityManager {
+	manager := &NodeSchedulabilityManager{
+		cluster:             cluster,
+		schedulableStateMap: make(map[string]bool),
+	}
+
+	manager.checkNodes()
+	return manager
+}
+
+// Helper method to build a map for identifying the UIDs of the pods on the unschedulable nodes
+func (manager *NodeSchedulabilityManager) buildNodeNameToPodUIDsMap() map[string][]string {
+	nodeNameToPodUIDsMap := make(map[string][]string)
+
+	nodeNameToPodMap := manager.cluster.NodeToRunningPods
+	for nodeName, schedulable := range manager.schedulableStateMap {
+		// skip over pods on schedulable nodes
+		if schedulable {
+			continue
+		}
+		podList := nodeNameToPodMap[nodeName]
+		var podUIDList []string
+		for _, pod := range podList {
+			podUIDList = append(podUIDList, string(pod.UID))
+		}
+		nodeNameToPodUIDsMap[nodeName] = podUIDList
+	}
+
+	return nodeNameToPodUIDsMap
+}
+
+// Check the schedulable state of all the nodes in the cluster
+func (manager *NodeSchedulabilityManager) checkNodes() {
+
+	manager.unSchedulableNodes = nil
+
+	for _, node := range manager.cluster.Nodes {
+		// check for schedulable property
+		schedulable := util.NodeIsReady(node) && util.NodeIsSchedulable(node)
+		manager.schedulableStateMap[node.Name] = schedulable
+
+		if !schedulable {
+			manager.unSchedulableNodes = append(manager.unSchedulableNodes, node.Name)
+		}
+	}
+}
+
+// Return if the given node state is in schedulable state
+func (manager *NodeSchedulabilityManager) CheckSchedulable(node *api.Node) bool {
+	// Retrieve the schedulable state of the node from the schedulable state map
+	// If the map is not computed, then first check all the nodes
+	if len(manager.schedulableStateMap) == 0 {
+		manager.checkNodes()
+	}
+	return manager.schedulableStateMap[node.Name]
+}
+
+// Return if the given node state is in scchedulable state
+func (manager *NodeSchedulabilityManager) CheckSchedulableByName(nodeName string) bool {
+	if len(manager.schedulableStateMap) == 0 {
+		manager.checkNodes()
+	}
+	return manager.schedulableStateMap[nodeName]
+}

--- a/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
@@ -2,9 +2,8 @@ package compliance
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"testing"
 
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	api "k8s.io/api/core/v1"
@@ -59,7 +58,8 @@ func TestProcess(t *testing.T) {
 	clusterSummary.NodeToRunningPods[n2.Name] = []*api.Pod{pod2}
 	clusterSummary.NodeToRunningPods[n3.Name] = []*api.Pod{pod3}
 
-	taintTolerationProcessor, err := NewTaintTolerationProcessor(clusterSummary)
+	nodesManager := NewNodeSchedulabilityManager(clusterSummary)
+	taintTolerationProcessor, err := NewTaintTolerationProcessor(clusterSummary, nodesManager)
 
 	if err != nil {
 		t.Errorf("Failed to create TaintTolerationProcessor: %v", err)

--- a/pkg/discovery/worker/compliance/unschedulable_node_anti_affinity_group_dto_builder.go
+++ b/pkg/discovery/worker/compliance/unschedulable_node_anti_affinity_group_dto_builder.go
@@ -1,0 +1,100 @@
+package compliance
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/turbo-go-sdk/pkg/builder/group"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+// In Turbo, Schedulable nodes are marked with an access commodity 'schedulable'. Pods are required to buy
+// this commodity so they can be moved to schedulable nodes
+// Unchedulable nodes do not sell this commodity, hence pods will not be moved to these nodes.
+// We want to address the issue that pods that are already running on the unschedulable nodes are not moved out
+// due to compliance issues. This is done by not requiring the pods already on the unschedulable nodes at the time
+// of discovery to buy the 'schedulable' commodity. Without the schedulable commodity the pod continues to stay
+// on the current node unless there are resource constraints or unless moved by the kubernetes controller.
+// In addition, we need pods which do not buy the schedulable commodity to not move to other unschedulable nodes.
+// This is achieved by creating an anti-affinity policy for these pods against other unschedulable nodes.
+type UnschedulableNodesAntiAffinityGroupDTOBuilder struct {
+	cluster  *repository.ClusterSummary
+	targetId string
+	// Manager for tracking schedulable nodes
+	nodesManager *NodeSchedulabilityManager
+}
+
+func NewUnschedulableNodesAntiAffinityGroupDTOBuilder(cluster *repository.ClusterSummary,
+	targetId string, nodesManager *NodeSchedulabilityManager) *UnschedulableNodesAntiAffinityGroupDTOBuilder {
+	return &UnschedulableNodesAntiAffinityGroupDTOBuilder{
+		cluster:      cluster,
+		targetId:     targetId,
+		nodesManager: nodesManager,
+	}
+}
+
+// Creates DTOs for anti-affinity policy between the pods running on a unschedulable nodes to other unschedulable nodes.
+// This will prevent the pods running on a unschedulable nodes to be moved to other other unschedulable nodes.
+func (builder *UnschedulableNodesAntiAffinityGroupDTOBuilder) Build() []*proto.GroupDTO {
+	var policyDTOs []*proto.GroupDTO
+
+	if len(builder.nodesManager.unSchedulableNodes) <= 1 {
+		glog.V(3).Info("Zero or one unschedulable node in the cluster, anti-affinity policies will not be created")
+		return policyDTOs
+	}
+
+	// Map of unschedulable node name to list of UIDs of pods running on these unschedulable nodes
+	nodeToPodsMap := builder.nodesManager.buildNodeNameToPodUIDsMap()
+
+	// List of UIDs of all unschedulable nodes
+	var nodeUIDs []string // UIDs of all unschedulable nodes
+	var nodeUIDtoNameMap = make(map[string]string)
+	for _, nodeName := range builder.nodesManager.unSchedulableNodes {
+		nodeUID := builder.cluster.NodeNameUIDMap[nodeName]
+		nodeUIDs = append(nodeUIDs, nodeUID)
+		nodeUIDtoNameMap[nodeUID] = nodeName
+	}
+
+	// Iterate over all the unschedulable nodes
+	for idx, nodeUID := range nodeUIDs {
+		// policy is being created for the pods on this unschedulable node
+		nodeName := nodeUIDtoNameMap[nodeUID]
+
+		// pod members on the current unschedulable node for the policy
+		podMembers := nodeToPodsMap[nodeName]
+
+		if len(podMembers) == 0 {
+			glog.V(3).Infof("No pods on unschedulable node %s, skipping anti-affinity policy", nodeName)
+			continue
+		}
+
+		// node members comprising of other unschedulable nodes for the policy
+		var otherNodeUIDs []string
+		otherNodeUIDs = append(otherNodeUIDs, nodeUIDs[:idx]...)
+		otherNodeUIDs = append(otherNodeUIDs, nodeUIDs[idx+1:]...)
+
+		nodeMembers := otherNodeUIDs
+
+		// policy id and display name
+		groupID := fmt.Sprintf("UnschedulableNodesAntiAffinity-%s-%s", nodeName, builder.targetId)
+		displayName := fmt.Sprintf("UnschedulableNodesAntiAffinity::%s [%s]", nodeName, builder.targetId)
+
+		// dto for the policy
+		groupDTOs, err := group.DoNotPlace(groupID).
+			WithDisplayName(displayName).
+			OnSellers(group.StaticSellers(nodeMembers).OfType(proto.EntityDTO_VIRTUAL_MACHINE)).
+			WithBuyers(group.StaticBuyers(podMembers).OfType(proto.EntityDTO_CONTAINER_POD)).
+			Build()
+		if err != nil {
+			glog.Errorf("Failed to build anti affinity policy DTO for pods on unschedulable node %s: %v", nodeName, err)
+			continue
+		}
+		glog.V(3).Infof("Created anti-affinity policy for pods on the Unschedulable node:%s", nodeName)
+
+		glog.V(4).Infof("Anti-affinity policy for pods on the Unschedulable node: %+v", groupDTOs)
+
+		policyDTOs = append(policyDTOs, groupDTOs...)
+	}
+
+	return policyDTOs
+}

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -88,11 +88,8 @@ var (
 	VMUUID         = supplychain.SUPPLY_CHAIN_CONSTANT_ID
 
 	// Common property
-	path                       = "path"
-	ActionEligibilityField     = "actionEligibility"
-	providerPolicyPath         = "providerPolicy"
-	availableForPlacementField = "availableForPlacement"
-	powerStateField            = "powerState"
+	path                   = "path"
+	ActionEligibilityField = "actionEligibility"
 )
 
 type SupplyChainFactory struct {
@@ -233,7 +230,6 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 	mergedEntityMetadataBuilder := builder.NewMergedEntityMetadataBuilder()
 
 	mergedEntityMetadataBuilder.PatchField(ActionEligibilityField, []string{})
-	mergedEntityMetadataBuilder.PatchField(availableForPlacementField, []string{providerPolicyPath})
 	// Set up matching criteria based on stitching type
 	switch f.stitchingPropertyType {
 	case stitching.UUID:
@@ -248,7 +244,6 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 		return nil, fmt.Errorf("stitching property type %s is not supported",
 			f.stitchingPropertyType)
 	}
-
 	return mergedEntityMetadataBuilder.
 		PatchSoldMetadata(proto.CommodityDTO_CLUSTER, fieldsCapactiy).
 		PatchSoldMetadata(proto.CommodityDTO_VMPM_ACCESS, fieldsCapactiy).
@@ -488,7 +483,7 @@ func (f *SupplyChainFactory) buildVolumeMergedEntityMetadata() (*proto.MergedEnt
 	mergedEntityMetadataBuilder := builder.NewMergedEntityMetadataBuilder()
 
 	mergedEntityMetadataBuilder.PatchField(ActionEligibilityField, []string{}).
-		PatchField(powerStateField, []string{}).
+		PatchField("powerState", []string{}).
 		InternalMatchingProperty(proxyVolumeUUID).
 		ExternalMatchingField(supplychain.SUPPLY_CHAIN_CONSTANT_ID, []string{}).
 		InternalMatchingProperty(path).


### PR DESCRIPTION
This PR reverts #557 and #561 to exclude these from 8.2.1 kubeturbo release.
These will be merged again after https://vmturbo.atlassian.net/browse/OM-71121 is fixed.