### PR TITLE
Fix duplicate access commodities

### DIFF
--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -208,8 +208,6 @@ func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node, clus
 	// Access commodities: labels.
 	for key, value := range node.ObjectMeta.Labels {
 		label := key + "=" + value
-		glog.V(4).Infof("label for this Node is : %s", label)
-
 		accessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
 			Key(label).
 			Capacity(accessCommodityDefaultCapacity).
@@ -217,6 +215,7 @@ func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node, clus
 		if err != nil {
 			return nil, isAvailableForPlacement, err
 		}
+		glog.V(5).Infof("Adding access commodity for Node %s with key : %s", node.Name, label)
 		commoditiesSold = append(commoditiesSold, accessComm)
 	}
 

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -405,6 +405,7 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBought(
 		if err != nil {
 			return nil, err
 		}
+		glog.V(5).Infof("Adding access commodity for Pod %s with key : %s", pod.Name, selector)
 		commoditiesBought = append(commoditiesBought, accessComm)
 	}
 

--- a/pkg/discovery/worker/compliance/affinity_processor.go
+++ b/pkg/discovery/worker/compliance/affinity_processor.go
@@ -142,6 +142,7 @@ func (am *AffinityProcessor) addCommoditySoldByNode(node *api.Node, affinityAcce
 		glog.Errorf("Cannot find the entityDTO: %s", err)
 		return
 	}
+	glog.V(4).Infof("Adding affinity access commodities for node: %s, Commodities: %v", node.Name, affinityAccessCommodityDTOs)
 	err = am.AddCommoditiesSold(nodeEntityDTO, affinityAccessCommodityDTOs...)
 	if err != nil {
 		glog.Errorf("Failed to add commodityDTO to %s: %s", node.Name, err)
@@ -154,6 +155,7 @@ func (am *AffinityProcessor) addCommodityBoughtByPod(pod *api.Pod, node *api.Nod
 		glog.Errorf("Cannot find the entityDTO: %s", err)
 		return
 	}
+	glog.V(4).Infof("Adding affinity access commodities for pod: %s, Commodities: %v", pod.Name, affinityAccessCommodityDTOs)
 	provider := sdkbuilder.CreateProvider(proto.EntityDTO_VIRTUAL_MACHINE, string(node.UID))
 	err = am.AddCommoditiesBought(podEntityDTO, provider, affinityAccessCommodityDTOs...)
 	if err != nil {

--- a/pkg/discovery/worker/compliance/compliance_processor.go
+++ b/pkg/discovery/worker/compliance/compliance_processor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/golang/glog"
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
@@ -83,6 +84,8 @@ func (cp *ComplianceProcessor) AddCommoditiesSold(entityDTO *proto.EntityDTO, co
 	for _, comm := range commodities {
 		if !hasCommoditySold(entityDTO, comm) {
 			commoditiesSold = append(commoditiesSold, comm)
+		} else {
+			glog.V(4).Info("Access commodity sold exists. Skip adding access commodity: %v.", comm)
 		}
 	}
 
@@ -112,6 +115,8 @@ func (cp *ComplianceProcessor) AddCommoditiesBought(entityDTO *proto.EntityDTO, 
 			for _, comm := range commodities {
 				if !hasCommodityBought(commBoughtType, comm) {
 					commBoughtType.Bought = append(commBoughtType.GetBought(), comm)
+				} else {
+					glog.V(4).Info("Access commodity bought exists. Skip adding access commodity: %v.", comm)
 				}
 			}
 			foundProvider = true

--- a/pkg/discovery/worker/compliance/taint_toleration_processor.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor.go
@@ -225,14 +225,13 @@ func createTaintAccessComms(node *api.Node, taintCollection map[api.Taint]string
 				return nil, err
 			}
 			visited[key] = true
-			glog.V(4).Infof("Created access commodity with key %s for node %s", key, node.GetName())
+			glog.V(5).Infof("Created access commodity with key %s for node %s", key, node.GetName())
 
 			accessComms = append(accessComms, accessComm)
 		}
 	}
 
 	glog.V(4).Infof("Created %d access commodities for node %s", len(accessComms), node.GetName())
-
 	return accessComms, nil
 }
 
@@ -257,7 +256,7 @@ func createTolerationAccessComms(pod *api.Pod, taintCollection map[api.Taint]str
 				return nil, err
 			}
 			visited[key] = true
-			glog.V(4).Infof("Created access commodity with key %s for pod %s", key, pod.GetName())
+			glog.V(5).Infof("Created access commodity with key %s for pod %s", key, pod.GetName())
 
 			accessComms = append(accessComms, accessComm)
 		}
@@ -298,7 +297,7 @@ func createSchedulableSoldComms(node *api.Node, nodesManager *NodeSchedulability
 
 		return schedAccessComm, nil
 	} else {
-		glog.V(4).Infof("Skip schedulable commodity for node %s", node.Name)
+		glog.V(5).Infof("Skip schedulable commodity for node %s", node.Name)
 	}
 
 	return nil, nil


### PR DESCRIPTION
Fixes https://vmturbo.atlassian.net/browse/OM-71091.

The issue happens when (but not limited to) duplicate new Affinity rules are specified in the podSpec.
This happens when this commodity is not already present on the node, ie. no other pod has similar affinity or this pods affinity is the one being processed as the first one.
Eg.
```
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: kubernetes.io/arch
                operator: In
                values:
                - amd64
            - matchExpressions:
              - key: kubernetes.io/arch
                operator: In
                values:
                - amd64
```
Have added an some unit tests and an integration test which validates the same. These tests fail without the fix.
Have additionally also improved the loggin around these commodities.