### PR TITLE
Update action executor to allow daemonset resize actions

### DIFF
--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -93,6 +93,11 @@ func GetSupportedResUsingKind(kind, namespace, name string) (schema.GroupVersion
 			Group:    util.OpenShiftAPIDeploymentConfigGV.Group,
 			Version:  util.OpenShiftAPIDeploymentConfigGV.Version,
 			Resource: util.DeploymentConfigResName}
+	case util.KindDaemonSet:
+		res = schema.GroupVersionResource{
+			Group:    util.K8sAPIDaemonsetGV.Group,
+			Version:  util.K8sAPIDaemonsetGV.Version,
+			Resource: util.DaemonSetResName}
 	default:
 		err = fmt.Errorf("unsupport controller type %s for %s/%s", kind, namespace, name)
 	}

--- a/pkg/action/util/util.go
+++ b/pkg/action/util/util.go
@@ -104,7 +104,8 @@ func BuildIdentifier(namespace, name string) string {
 
 // check whether parentKind is supported for MovePod/ResizeContainer actions
 // currently, these actions can only works on barePod, ReplicaSet, and ReplicationController
-//   Note: pod's parent cannot be Deployment. Deployment will create/control ReplicaSet, and ReplicaSet will create/control Pods.
+// and on Daemonsets if the action is resize.
+//  Note: pod's parent cannot be Deployment. Deployment will create/control ReplicaSet, and ReplicaSet will create/control Pods.
 func SupportedParent(ownerInfo discoveryutil.OwnerInfo, isResize bool) bool {
 	if discoveryutil.IsOwnerInfoEmpty(ownerInfo) {
 		return true


### PR DESCRIPTION
This PR implements the desired behavior of daemonset resize actions as needed in https://vmturbo.atlassian.net/browse/OM-71325.

After this fix the daemonset resize actions can be executed successfully:

![image](https://user-images.githubusercontent.com/10027921/121184717-b7e17880-c8a8-11eb-976e-b4f2043cd49e.png)

```
I0608 12:19:00.576583       1 remote_mediation_client.go:424] Received: action request RIGHT_SIZE for probe type: Kubernetes
I0608 12:19:00.576610       1 remote_mediation_client.go:456] New ActionResponseProtocolWorker for 2349 &{ProbeConfiguration:0xc000a63b00 RegistrationClient:0xc000cf7c70 TargetsToAdd:map[Kubernetes-pt-dc11-k18:true] DiscoveryClient:0xc000bacc30 ActionClient:0xc000a63980} RIGHT_SIZE
I0608 12:19:00.576651       1 turbo_probe.go:196] Execute Action for Target: [key:"image" stringValue:"docker.io/irfdocker/kubeturbo:latest"  key:"targetIdentifier" stringValue:"Kubernetes-pt-dc11-k18"  key:"serverVersion" stringValue:"v1.21.1"  key:"imageID" stringValue:"sha256:2642eeb898df0084304ad00b0477bbaa1dc7dc01bf0f173b6c5df02da2a3092b"  key:"masterHost" stringValue:"https://10.233.0.1:443" ]
I0608 12:19:00.576741       1 action_handler.go:356] Received an action RIGHT_SIZE for entity WORKLOAD_CONTROLLER [beekman-orig]
I0608 12:19:00.576841       1 action_handler.go:173] Now wait for action result
I0608 12:19:00.576924       1 remote_mediation_client.go:488] Sent action progress for 2349.
I0608 12:19:00.576961       1 remote_mediation_client.go:239] [probeCallback] received response on probe channel 0xc000a6fec0
 
I0608 12:19:00.576979       1 client_protobuf_endpoint.go:78] [ServerRequestEndpoint] : Sending protobuf message
I0608 12:19:00.579132       1 client_websocket_transport.go:266] Successfully sent message on client transport
I0608 12:19:00.579156       1 remote_mediation_client.go:233] [probeCallback] waiting for probe responses
I0608 12:19:00.639949       1 resize_container.go:133] Resize beekman-orig VCPU Capacity to 363
I0608 12:19:00.640035       1 workload_controller_resizer.go:165] Begin to resize workload controller default/beekman-orig.
I0608 12:19:00.640075       1 k8s_controller_updater.go:124] Begin to update DaemonSet default/beekman-orig
I0608 12:19:00.662763       1 k8s_controller_updater.go:174] Try to update resources for container indexes: 0, in pod template spec of DaemonSet default/beekman-orig .
I0608 12:19:00.662808       1 resize_container_util.go:49] Begin to update Capacity.
I0608 12:19:00.662823       1 resize_container_util.go:68] Try to update container beekman-1 resource limit from map[cpu:{i:{value:250 scale:-3} d:{Dec:<nil>} s:250m Format:DecimalSI} memory:{i:{value:134217728 scale:0} d:{Dec:<nil>} s: Format:BinarySI}] to map[cpu:{{363 -3} {<nil>} 363m DecimalSI} memory:{{134217728 0} {<nil>}  BinarySI}]
I0608 12:19:00.662899       1 resize_container_util.go:129] Container beekman-1 resources changed.
I0608 12:19:00.681380       1 k8s_controller_updater.go:142] Successfully updated DaemonSet default/beekman-orig
I0608 12:19:00.681440       1 go_util.go:65] [retry-1/3] success
I0608 12:19:00.681473       1 remote_mediation_client.go:469] Sent action response for 2349.
I0608 12:19:00.681490       1 remote_mediation_client.go:239] [probeCallback] received response on probe channel 0xc000a6fec0
 
I0608 12:19:00.681506       1 client_protobuf_endpoint.go:78] [ServerRequestEndpoint] : Sending protobuf message
I0608 12:19:00.681720       1 client_websocket_transport.go:266] Successfully sent message on client transport
I0608 12:19:00.681735       1 remote_mediation_client.go:233] [probeCallback] waiting for probe responses
I0608 12:19:00.681760       1 action_handler.go:333] action keepAlive goroutine exit.
```
The merged action gets cleared from the workload controller immediately, but the individual action still remains on the container spec until next market cycle.
![image](https://user-images.githubusercontent.com/10027921/121185152-1c043c80-c8a9-11eb-953c-db3e6f07e13d.png)


