### PR TITLE
Change all the discovered CPU type metrics to millicores

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20210715225224-e8539c776a5d
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20210719175123-bec8d82eae3d
 )
 
 // k8s and relevant dependencies

--- a/go.sum
+++ b/go.sum
@@ -773,10 +773,14 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/turbonomic/turbo-api v0.0.0-20210513030812-aca128ea36a0 h1:q3hPEL6M8BIvAxkxIGfY5vo+0bphDz6bA9d41PCoIoQ=
+github.com/turbonomic/turbo-api v0.0.0-20210513030812-aca128ea36a0/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca h1:kWhxdWkGgeMNZQgZ+FQVFW0FEau2fHwraM7OGFug6Tw=
 github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20210715225224-e8539c776a5d h1:MEO/4X/55ZUzTiU4xB5/uMclChJM1OYCjDIlu9aA38U=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20210715225224-e8539c776a5d/go.mod h1:WaHgsSYDOVV+5Jq2SGmvsl60SBVsf+LutnpsvuE2Ks8=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20210602130418-d2213f9b17de h1:ZY/jhJ+rZmUGuLkxIrfd/cG7eUG5m0Zlem6JR03n0+A=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20210602130418-d2213f9b17de/go.mod h1:C/3vkBwvmsdBH4AAgFUsmOe8BA6cQpomZaRVY4Bqo8g=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20210719175123-bec8d82eae3d h1:CIFSKiy23UP3zPx0LhUrjXcqF5jKzliKLja0/yJy30E=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20210719175123-bec8d82eae3d/go.mod h1:WaHgsSYDOVV+5Jq2SGmvsl60SBVsf+LutnpsvuE2Ks8=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -2,6 +2,7 @@ package dtofactory
 
 import (
 	"fmt"
+
 	api "k8s.io/api/core/v1"
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
@@ -38,28 +39,9 @@ func NewApplicationEntityDTOBuilder(sink *metrics.EntityMetricSink,
 	}
 }
 
-// get hosting node cpu frequency
-func (builder *applicationEntityDTOBuilder) getNodeCPUFrequency(pod *api.Pod) (float64, error) {
-	key := util.NodeKeyFromPodFunc(pod)
-	cpuFrequencyUID := metrics.GenerateEntityStateMetricUID(metrics.NodeType, key, metrics.CpuFrequency)
-	cpuFrequencyMetric, err := builder.metricsSink.GetMetric(cpuFrequencyUID)
-	if err != nil {
-		err := fmt.Errorf("Failed to get cpu frequency from sink for node %s: %v", key, err)
-		glog.Error(err)
-		return 0.0, err
-	}
-
-	cpuFrequency := cpuFrequencyMetric.GetValue().(float64)
-	return cpuFrequency, nil
-}
-
 func (builder *applicationEntityDTOBuilder) BuildEntityDTO(pod *api.Pod) ([]*proto.EntityDTO, error) {
 	var result []*proto.EntityDTO
 	podFullName := util.GetPodClusterID(pod)
-	nodeCPUFrequency, err := builder.getNodeCPUFrequency(pod)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build application DTOs for pod[%s]: %v", podFullName, err)
-	}
 	podId := string(pod.UID)
 	podMId := util.PodMetricIdAPI(pod)
 
@@ -85,7 +67,7 @@ func (builder *applicationEntityDTOBuilder) BuildEntityDTO(pod *api.Pod) ([]*pro
 		ebuilder.SellsCommodities(commoditiesSold)
 
 		//3. bought commodities: vcpu/vmem/application
-		commoditiesBought, err := builder.getApplicationCommoditiesBought(appMId, podFullName, containerId, nodeCPUFrequency)
+		commoditiesBought, err := builder.getApplicationCommoditiesBought(appMId, podFullName, containerId)
 		if err != nil {
 			glog.Warningf("Skip creating Application(%s) entityDTO: %v", displayName, err)
 			continue
@@ -172,13 +154,11 @@ func (builder *applicationEntityDTOBuilder) getCommoditiesSold(pod *api.Pod, ind
 
 // Build the bought commodities by each application.
 // An application buys vCPU, vMem and Application commodity from a container.
-func (builder *applicationEntityDTOBuilder) getApplicationCommoditiesBought(appMId, podName, containerId string, cpuFrequency float64) ([]*proto.CommodityDTO, error) {
+func (builder *applicationEntityDTOBuilder) getApplicationCommoditiesBought(appMId, podName, containerId string) ([]*proto.CommodityDTO, error) {
 	var commoditiesBought []*proto.CommodityDTO
 
-	converter := NewConverter().Set(func(input float64) float64 { return input * cpuFrequency }, metrics.CPU)
-
 	// Resource commodities.
-	resourceCommoditiesBought := builder.getResourceCommoditiesBought(metrics.ApplicationType, appMId, applicationResourceCommodityBought, converter, nil)
+	resourceCommoditiesBought := builder.getResourceCommoditiesBought(metrics.ApplicationType, appMId, applicationResourceCommodityBought, nil, nil)
 	if len(resourceCommoditiesBought) != len(applicationResourceCommodityBought) {
 		return nil, fmt.Errorf("mismatch num of commidities (%d Vs. %d) for application:%s, %s",
 			len(resourceCommoditiesBought), len(applicationResourceCommodityBought), podName, appMId)

--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -48,7 +48,6 @@ func (builder *applicationEntityDTOBuilder) BuildEntityDTO(pod *api.Pod) ([]*pro
 	if err != nil {
 		glog.Warningf("Failed to get node cpu frequency for pod[%s]."+
 			"\nHosted application usage data may not reflect right Mhz values: %v", podFullName, err)
-		nodeCPUFrequency = 1.0
 	}
 
 	for i := range pod.Spec.Containers {

--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -39,11 +39,29 @@ func NewApplicationEntityDTOBuilder(sink *metrics.EntityMetricSink,
 	}
 }
 
+func (builder *applicationEntityDTOBuilder) getNodeCPUFrequency(pod *api.Pod) (float64, error) {
+	key := util.NodeKeyFromPodFunc(pod)
+	cpuFrequencyUID := metrics.GenerateEntityStateMetricUID(metrics.NodeType, key, metrics.CpuFrequency)
+	cpuFrequencyMetric, err := builder.metricsSink.GetMetric(cpuFrequencyUID)
+	if err != nil {
+		err := fmt.Errorf("Failed to get cpu frequency from sink for node %s: %v", key, err)
+		glog.Error(err)
+		return 0.0, err
+	}
+
+	cpuFrequency := cpuFrequencyMetric.GetValue().(float64)
+	return cpuFrequency, nil
+}
+
 func (builder *applicationEntityDTOBuilder) BuildEntityDTO(pod *api.Pod) ([]*proto.EntityDTO, error) {
 	var result []*proto.EntityDTO
 	podFullName := util.GetPodClusterID(pod)
 	podId := string(pod.UID)
 	podMId := util.PodMetricIdAPI(pod)
+	nodeCPUFrequency, err := builder.getNodeCPUFrequency(pod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build application DTOs for pod[%s]: %v", podFullName, err)
+	}
 
 	for i := range pod.Spec.Containers {
 		//1. Id and Name
@@ -67,7 +85,7 @@ func (builder *applicationEntityDTOBuilder) BuildEntityDTO(pod *api.Pod) ([]*pro
 		ebuilder.SellsCommodities(commoditiesSold)
 
 		//3. bought commodities: vcpu/vmem/application
-		commoditiesBought, err := builder.getApplicationCommoditiesBought(appMId, podFullName, containerId)
+		commoditiesBought, err := builder.getApplicationCommoditiesBought(appMId, podFullName, containerId, nodeCPUFrequency)
 		if err != nil {
 			glog.Warningf("Skip creating Application(%s) entityDTO: %v", displayName, err)
 			continue
@@ -154,11 +172,12 @@ func (builder *applicationEntityDTOBuilder) getCommoditiesSold(pod *api.Pod, ind
 
 // Build the bought commodities by each application.
 // An application buys vCPU, vMem and Application commodity from a container.
-func (builder *applicationEntityDTOBuilder) getApplicationCommoditiesBought(appMId, podName, containerId string) ([]*proto.CommodityDTO, error) {
+func (builder *applicationEntityDTOBuilder) getApplicationCommoditiesBought(appMId, podName, containerId string, cpuFrequency float64) ([]*proto.CommodityDTO, error) {
 	var commoditiesBought []*proto.CommodityDTO
 
+	converter := NewConverter().Set(func(input float64) float64 { return util.MetricMilliToUnit(input) * cpuFrequency }, metrics.CPU)
 	// Resource commodities.
-	resourceCommoditiesBought := builder.getResourceCommoditiesBought(metrics.ApplicationType, appMId, applicationResourceCommodityBought, nil, nil)
+	resourceCommoditiesBought := builder.getResourceCommoditiesBought(metrics.ApplicationType, appMId, applicationResourceCommodityBought, converter, nil)
 	if len(resourceCommoditiesBought) != len(applicationResourceCommodityBought) {
 		return nil, fmt.Errorf("mismatch num of commidities (%d Vs. %d) for application:%s, %s",
 			len(resourceCommoditiesBought), len(applicationResourceCommodityBought), podName, appMId)

--- a/pkg/discovery/dtofactory/cluster_dto_builder.go
+++ b/pkg/discovery/dtofactory/cluster_dto_builder.go
@@ -107,10 +107,8 @@ func (builder *clusterDTOBuilder) BuildEntity(entityDTOs []*proto.EntityDTO, nam
 	})
 
 	entityDTOBuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
-
-	var properties []*proto.EntityDTO_EntityProperty
 	// The added property indicates that this cluster now uses millicore as unit for vcpu commodities
-	properties = append(properties, property.BuildClusterProperty())
+	properties := property.BuildClusterProperty()
 
 	// build entityDTO.
 	entityDto, err := entityDTOBuilder.
@@ -215,7 +213,7 @@ func (builder *clusterDTOBuilder) createClusterData(clusterName string, namespac
 		}
 	}
 
-	// Post 8.2.3 kubeturbo sends all vcpu related commodities in millicores
+	// Post 8.2.5 kubeturbo sends all vcpu related commodities in millicores
 	vcpuCommodityUnit := proto.EntityDTO_MILLICORE
 	return &proto.EntityDTO_ContainerPlatformClusterData{
 		VcpuOvercommitment: &vcpuOvercommitment,

--- a/pkg/discovery/dtofactory/cluster_dto_builder.go
+++ b/pkg/discovery/dtofactory/cluster_dto_builder.go
@@ -2,9 +2,11 @@ package dtofactory
 
 import (
 	"fmt"
+
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 
 	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/turbo-go-sdk/pkg/builder/group"
@@ -105,8 +107,14 @@ func (builder *clusterDTOBuilder) BuildEntity(entityDTOs []*proto.EntityDTO, nam
 
 	entityDTOBuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
 
+	var properties []*proto.EntityDTO_EntityProperty
+	// The added property indicates that this cluster now uses millicore as unit for vcpu commodities
+	properties = append(properties, property.BuildClusterProperty())
+
 	// build entityDTO.
-	entityDto, err := entityDTOBuilder.Create()
+	entityDto, err := entityDTOBuilder.
+		WithProperties(properties).
+		Create()
 	if err != nil {
 		glog.Errorf("Failed to build Cluster entityDTO: %s", err)
 		return nil, err

--- a/pkg/discovery/dtofactory/cluster_dto_builder.go
+++ b/pkg/discovery/dtofactory/cluster_dto_builder.go
@@ -203,9 +203,12 @@ func (builder *clusterDTOBuilder) createClusterData(clusterName string, namespac
 		}
 	}
 
+	// Post 8.2.3 kubeturbo sends all vcpu related commodities in millicores
+	vcpuCommodityUnit := proto.EntityDTO_MILLICORE
 	return &proto.EntityDTO_ContainerPlatformClusterData{
 		VcpuOvercommitment: &vcpuOvercommitment,
 		VmemOvercommitment: &vmemOvercommitment,
+		VcpuUnit:           &vcpuCommodityUnit,
 	}
 }
 

--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -142,11 +142,6 @@ func (builder generalBuilder) getSoldResourceCommodityWithKey(entityType metrics
 		return nil, fmt.Errorf("unsupported commodity type %s", resourceType)
 	}
 
-	// check for the unit converter for cpu resources
-	if metrics.IsCPUType(resourceType) && converter == nil {
-		return nil, fmt.Errorf("missing cpu converter")
-	}
-
 	commSoldBuilder := sdkbuilder.NewCommodityDTOBuilder(cType)
 
 	metricValue, err := builder.metricValue(entityType, entityID,
@@ -325,11 +320,6 @@ func (builder generalBuilder) getResourceCommodityBoughtWithKey(entityType metri
 	cType, exist := rTypeMapping[resourceType]
 	if !exist {
 		return nil, fmt.Errorf("unsupported commodity type %s", resourceType)
-	}
-
-	// check for the unit converter for cpu resources
-	if metrics.IsCPUType(resourceType) && converter == nil {
-		return nil, fmt.Errorf("missing cpu converter")
 	}
 
 	commBoughtBuilder := sdkbuilder.NewCommodityDTOBuilder(cType)

--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -120,7 +120,7 @@ func (builder generalBuilder) getNodeCPUFrequencyViaPod(pod *api.Pod) (float64, 
 	if err != nil {
 		err := fmt.Errorf("Failed to get cpu frequency from sink for node %s: %v", key, err)
 		glog.Error(err)
-		return 0.0, err
+		return 1.0, err
 	}
 
 	cpuFrequency := cpuFrequencyMetric.GetValue().(float64)

--- a/pkg/discovery/dtofactory/general_builder.go
+++ b/pkg/discovery/dtofactory/general_builder.go
@@ -292,7 +292,7 @@ func (builder generalBuilder) getResourceCommoditiesBought(entityType metrics.Di
 		commBoughtBuilder.Peak(metricValue.Peak)
 
 		if rType == metrics.VStorage {
-			// set commodity key only for vstorahge.
+			// set commodity key only for vstorage.
 			// currently pods only report and buy rootfs usage.
 			commBoughtBuilder.Key("k8s-node-rootfs")
 		}

--- a/pkg/discovery/dtofactory/general_builder_test.go
+++ b/pkg/discovery/dtofactory/general_builder_test.go
@@ -31,11 +31,6 @@ var (
 	memUsed_node1 = metrics.NewEntityResourceMetric(metrics.NodeType, node1, metrics.Memory, metrics.Used, 8010812.000000/4)
 
 	cpuFrequency = 2048.0
-	cpuConverter = NewConverter().Set(
-		func(input float64) float64 {
-			return input * cpuFrequency
-		},
-		metrics.CPU)
 )
 
 func TestBuildVCPUThrottlingSold(t *testing.T) {
@@ -47,7 +42,7 @@ func TestBuildVCPUThrottlingSold(t *testing.T) {
 	}
 
 	eType := metrics.ContainerType
-	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, container1, metrics.VCPUThrottling, "", cpuConverter, nil)
+	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, container1, metrics.VCPUThrottling, "", nil, nil)
 	fmt.Printf("%++v\n", commSold)
 	fmt.Printf("%++v\n", err)
 	assert.Nil(t, err)
@@ -68,14 +63,14 @@ func TestBuildCPUSold(t *testing.T) {
 	}
 
 	eType := metrics.PodType
-	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPU, "", cpuConverter, nil)
+	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPU, "", nil, nil)
 	fmt.Printf("%++v\n", commSold)
 	fmt.Printf("%++v\n", err)
 	assert.Nil(t, err)
 	assert.NotNil(t, commSold)
 	assert.Equal(t, proto.CommodityDTO_VCPU, commSold.GetCommodityType())
-	capacityValue := cpuConverter.Convert(metrics.CPU, cpuCap_pod1.GetValue().(float64))
-	usedValue := cpuConverter.Convert(metrics.CPU, cpuUsed_pod1.GetValue().(float64))
+	capacityValue := cpuCap_pod1.GetValue().(float64)
+	usedValue := cpuUsed_pod1.GetValue().(float64)
 	assert.Equal(t, usedValue, commSold.GetUsed())
 	assert.Equal(t, capacityValue, commSold.GetCapacity())
 }
@@ -120,7 +115,7 @@ func TestBuildCPUSoldWithMissingCap(t *testing.T) {
 	dtoBuilder := &generalBuilder{
 		metricsSink: metricsSink,
 	}
-	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPU, "", cpuConverter, nil)
+	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPU, "", nil, nil)
 	assert.Nil(t, commSold)
 	assert.NotNil(t, err)
 }
@@ -130,18 +125,6 @@ func TestBuildCPUSoldWithMissingUsed(t *testing.T) {
 	metricsSink = metrics.NewEntityMetricSink()
 	metricsSink.AddNewMetricEntries(cpuCap_pod1)
 
-	dtoBuilder := &generalBuilder{
-		metricsSink: metricsSink,
-	}
-	commSold, err := dtoBuilder.getSoldResourceCommodityWithKey(eType, pod1, metrics.CPU, "", cpuConverter, nil)
-	assert.Nil(t, commSold)
-	assert.NotNil(t, err)
-}
-
-func TestBuildCPUSoldWithMissingConverter(t *testing.T) {
-	eType := metrics.PodType
-	metricsSink = metrics.NewEntityMetricSink()
-	metricsSink.AddNewMetricEntries(cpuUsed_pod1, cpuCap_pod1)
 	dtoBuilder := &generalBuilder{
 		metricsSink: metricsSink,
 	}
@@ -176,7 +159,7 @@ func TestBuildCommSold(t *testing.T) {
 
 	eType := metrics.PodType
 	resourceTypesList := []metrics.ResourceType{metrics.CPU, metrics.Memory}
-	commSoldList := dtoBuilder.getResourceCommoditiesSold(eType, pod1, resourceTypesList, cpuConverter, nil)
+	commSoldList := dtoBuilder.getResourceCommoditiesSold(eType, pod1, resourceTypesList, nil, nil)
 	commMap := make(map[proto.CommodityDTO_CommodityType]*proto.CommodityDTO)
 
 	for _, commSold := range commSoldList {
@@ -201,7 +184,7 @@ func TestBuildCommBought(t *testing.T) {
 
 	eType := metrics.PodType
 	resourceTypesList := []metrics.ResourceType{metrics.CPU, metrics.Memory}
-	commBoughtList := dtoBuilder.getResourceCommoditiesBought(eType, pod1, resourceTypesList, cpuConverter, nil)
+	commBoughtList := dtoBuilder.getResourceCommoditiesBought(eType, pod1, resourceTypesList, nil, nil)
 	commMap := make(map[proto.CommodityDTO_CommodityType]*proto.CommodityDTO)
 
 	for _, commBought := range commBoughtList {

--- a/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
@@ -92,17 +92,6 @@ func (builder *namespaceEntityDTOBuilder) getQuotaCommoditiesSold(kubeNamespace 
 		}
 		capacityValue := resource.Capacity
 		usedValue := resource.Used
-		// For CPU resources, convert the capacity and usage values expressed in
-		// number of cores to MHz
-		if metrics.IsCPUType(resourceType) && kubeNamespace.AverageNodeCpuFrequency > 0.0 {
-			if capacityValue != repository.DEFAULT_METRIC_CAPACITY_VALUE {
-				// Modify the capacity value from cores to MHz if capacity is not default infinity
-				newVal := capacityValue * kubeNamespace.AverageNodeCpuFrequency
-				glog.V(4).Infof("Changing capacity of %s::%s from %f cores to %f MHz",
-					kubeNamespace.Name, resourceType, capacityValue, newVal)
-				capacityValue = newVal
-			}
-		}
 
 		commSoldBuilder := sdkbuilder.NewCommodityDTOBuilder(cType)
 		commSoldBuilder.Used(usedValue)

--- a/pkg/discovery/dtofactory/namespace_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/namespace_entity_dto_builder_test.go
@@ -2,6 +2,10 @@ package dtofactory
 
 import (
 	"fmt"
+	"math"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
@@ -10,9 +14,6 @@ import (
 	k8sres "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"math"
-	"testing"
-	"time"
 )
 
 const CPUFrequency float64 = 2663.778000
@@ -306,13 +307,13 @@ func TestBuildNamespaceDto(t *testing.T) {
 				if dto.GetId() == "namespace-3" {
 					assert.EqualValues(t, resource.Capacity, comm.GetCapacity())
 				} else {
-					assert.EqualValues(t, resource.Capacity*CPUFrequency, comm.GetCapacity())
+					assert.EqualValues(t, resource.Capacity, comm.GetCapacity())
 				}
 			} else {
 				assert.EqualValues(t, resource.Capacity, comm.GetCapacity())
 			}
 			if metrics.IsCPUType(allocationResource) && kubeNamespace.QuotaDefined[allocationResource] {
-				assert.EqualValues(t, resource.Used*CPUFrequency, comm.GetUsed())
+				assert.EqualValues(t, resource.Used, comm.GetUsed())
 			}
 		}
 

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -2,6 +2,7 @@ package dtofactory
 
 import (
 	"fmt"
+	"math"
 
 	api "k8s.io/api/core/v1"
 
@@ -144,7 +145,7 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) []*proto
 			glog.Errorf("Failed to get number of CPU in cores for VM %s: %v", nodeKey, err)
 			continue
 		}
-		cpuCores := int32(util.MetricMilliToUnit(cpuMetricValue.Avg))
+		cpuCores := int32(math.Round(util.MetricMilliToUnit(cpuMetricValue.Avg)))
 		vmdata := &proto.EntityDTO_VirtualMachineData{
 			IpAddress: getNodeIPs(node),
 			// Set numCPUs in cores.

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -144,7 +144,7 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) []*proto
 			glog.Errorf("Failed to get number of CPU in cores for VM %s: %v", nodeKey, err)
 			continue
 		}
-		cpuCores := int32(cpuMetricValue.Avg)
+		cpuCores := int32(util.MetricMilliToUnit(cpuMetricValue.Avg))
 		vmdata := &proto.EntityDTO_VirtualMachineData{
 			IpAddress: getNodeIPs(node),
 			// Set numCPUs in cores.
@@ -191,12 +191,14 @@ func (builder *nodeEntityDTOBuilder) getNodeCommoditiesSold(node *api.Node, clus
 	if err != nil {
 		return nil, true, fmt.Errorf("failed to get cpu frequency from sink for node %s: %s", key, err)
 	}
-	// cpu and cpu request needs to be converted from number of cores to frequency.
+	// cpu and cpu request needs to be converted from number of millicores to frequency.
 	converter := NewConverter().Set(
 		func(input float64) float64 {
-			return input * cpuFrequency
+			// All cpu metrics are stored in millicores in metrics sink for consistency
+			// But we send the node cpu metrics in MHz.
+			return util.MetricMilliToUnit(input) * cpuFrequency
 		},
-		metrics.CPU, metrics.CPURequest)
+		metrics.CPU)
 
 	// Resource Commodities
 	resourceCommoditiesSold := builder.getResourceCommoditiesSold(metrics.NodeType, key, nodeResourceCommoditiesSold, converter, nil)

--- a/pkg/discovery/dtofactory/node_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder_test.go
@@ -2,11 +2,12 @@ package dtofactory
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
-	"testing"
 
 	"github.com/golang/glog"
 
@@ -173,7 +174,7 @@ func TestGetNodeNumCPUs(t *testing.T) {
 	node := mockNode()
 	nodeKey := util.NodeKeyFunc(node)
 	metricsSink = metrics.NewEntityMetricSink()
-	cpuCapMetric := metrics.NewEntityResourceMetric(metrics.NodeType, nodeKey, metrics.CPU, metrics.Capacity, float64(10))
+	cpuCapMetric := metrics.NewEntityResourceMetric(metrics.NodeType, nodeKey, metrics.CPU, metrics.Capacity, float64(10000))
 	metricsSink.AddNewMetricEntries(cpuCapMetric)
 	kubernetesSvcID := "abcdef"
 	clusterInfo := metrics.NewEntityStateMetric(metrics.ClusterType, "", metrics.Cluster, kubernetesSvcID)
@@ -181,5 +182,6 @@ func TestGetNodeNumCPUs(t *testing.T) {
 	nodeEntityDTOBuilder := NewNodeEntityDTOBuilder(metricsSink, stitching.NewStitchingManager(stitching.UUID))
 	nodeEntityDTOs := nodeEntityDTOBuilder.BuildEntityDTOs([]*api.Node{node})
 	vmData := nodeEntityDTOs[0].GetVirtualMachineData()
+	// The capacity metric is set in millicores but numcpus is set in cores
 	assert.EqualValues(t, 10, vmData.GetNumCpus())
 }

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -505,7 +505,6 @@ func (builder *podEntityDTOBuilder) createContainerPodData(pod *api.Pod) *proto.
 	if err != nil {
 		glog.Warningf("Failed to get node cpu frequency for pod[%s/%s]."+
 			"\nHosted application usage data may not reflect right Mhz values: %v", ns, fullName, err)
-		nodeCPUFrequency = 1.0
 	}
 	podData := &proto.EntityDTO_ContainerPodData{
 		HostingNodeCpuFrequency: &nodeCPUFrequency,

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -27,7 +27,7 @@ func Test_podEntityDTOBuilder_getPodCommoditiesBought_Error(t *testing.T) {
 }
 
 func Test_podEntityDTOBuilder_getPodCommoditiesBoughtFromQuota_Error(t *testing.T) {
-	if _, err := builder.getQuotaCommoditiesBought("quota1", &api.Pod{}, 100.0); err == nil {
+	if _, err := builder.getQuotaCommoditiesBought("quota1", &api.Pod{}); err == nil {
 		t.Errorf("Error thrown expected")
 	}
 }
@@ -77,8 +77,8 @@ func Test_podEntityDTOBuilder_createContainerPodData(t *testing.T) {
 }
 
 func testGetCommoditiesWithError(t *testing.T,
-	f func(pod *api.Pod, cpuFrequency float64, resType []metrics.ResourceType) ([]*proto.CommodityDTO, error)) {
-	if _, err := f(createPodWithReadyCondition(), 100.0, runningPodResCommTypeSold); err == nil {
+	f func(pod *api.Pod, resType []metrics.ResourceType) ([]*proto.CommodityDTO, error)) {
+	if _, err := f(createPodWithReadyCondition(), runningPodResCommTypeSold); err == nil {
 		t.Errorf("Error thrown expected")
 	}
 }

--- a/pkg/discovery/dtofactory/property/cluster_properties.go
+++ b/pkg/discovery/dtofactory/property/cluster_properties.go
@@ -10,13 +10,14 @@ const (
 )
 
 // Build the cluster property to depict this cluster now uses millicores as units for vcpu & related commodities.
-func BuildClusterProperty() *proto.EntityDTO_EntityProperty {
+func BuildClusterProperty() []*proto.EntityDTO_EntityProperty {
+	var properties []*proto.EntityDTO_EntityProperty
 	propertyNamespace := k8sPropertyNamespace
 	propertyName := vcpuUnit
 	propertyValue := unitTypeMillicore
-	return &proto.EntityDTO_EntityProperty{
+	return append(properties, &proto.EntityDTO_EntityProperty{
 		Namespace: &propertyNamespace,
 		Name:      &propertyName,
 		Value:     &propertyValue,
-	}
+	})
 }

--- a/pkg/discovery/dtofactory/property/cluster_properties.go
+++ b/pkg/discovery/dtofactory/property/cluster_properties.go
@@ -1,0 +1,22 @@
+package property
+
+import (
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+const (
+	vcpuUnit          = "VCPUUnit"
+	unitTypeMillicore = "Millicore"
+)
+
+// Build the cluster property to depict this cluster now uses millicores as units for vcpu & related commodities.
+func BuildClusterProperty() *proto.EntityDTO_EntityProperty {
+	propertyNamespace := k8sPropertyNamespace
+	propertyName := vcpuUnit
+	propertyValue := unitTypeMillicore
+	return &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &propertyName,
+		Value:     &propertyValue,
+	}
+}

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
@@ -114,7 +114,7 @@ func checkPodMetrics(sink *metrics.EntityMetricSink, podMId string, pod *stats.P
 			for _, c := range pod.Containers {
 				expected += float64(*c.CPU.UsageNanoCores)
 			}
-			expected = util.MetricNanoToUnit(expected)
+			expected = util.MetricNanoToMilli(expected)
 		} else {
 			for _, c := range pod.Containers {
 				expected += float64(*c.Memory.WorkingSetBytes)
@@ -150,7 +150,7 @@ func checkContainerMetrics(sink *metrics.EntityMetricSink, containerMId string, 
 		expected := float64(0.0)
 		if res == metrics.CPU {
 			expected += float64(*container.CPU.UsageNanoCores)
-			expected = util.MetricNanoToUnit(expected)
+			expected = util.MetricNanoToMilli(expected)
 		} else {
 			expected += float64(*container.Memory.WorkingSetBytes)
 			expected = util.Base2BytesToKilobytes(expected)
@@ -183,7 +183,7 @@ func checkApplicationMetrics(sink *metrics.EntityMetricSink, appMId string, cont
 		expected := float64(0.0)
 		if res == metrics.CPU {
 			expected += float64(*container.CPU.UsageNanoCores)
-			expected = util.MetricNanoToUnit(expected)
+			expected = util.MetricNanoToMilli(expected)
 		} else {
 			expected += float64(*container.Memory.WorkingSetBytes)
 			expected = util.Base2BytesToKilobytes(expected)

--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -2,8 +2,9 @@ package master
 
 import (
 	"fmt"
-	client "k8s.io/client-go/kubernetes"
 	"testing"
+
+	client "k8s.io/client-go/kubernetes"
 
 	"github.com/golang/glog"
 	"github.com/stretchr/testify/assert"
@@ -14,36 +15,37 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// All cpu metrics are generated in millicores
 var expectedMetrics = map[string]float64{
 	// Node metrics
-	"Node-mynode-CPU-Capacity":           2,
+	"Node-mynode-CPU-Capacity":           2000,
 	"Node-mynode-Memory-Capacity":        8.388608e+06,
-	"Node-mynode-CPURequest-Capacity":    1.9,
+	"Node-mynode-CPURequest-Capacity":    1900,
 	"Node-mynode-MemoryRequest-Capacity": 7.340032e+06,
-	"Node-mynode-CPURequest-Used":        0.26,
+	"Node-mynode-CPURequest-Used":        260,
 	"Node-mynode-MemoryRequest-Used":     262144,
 
 	// Pod metrics
-	"Pod-default/mypod-CPU-Capacity":       2,
+	"Pod-default/mypod-CPU-Capacity":       2000,
 	"Pod-default/mypod-Memory-Capacity":    8.388608e+06,
-	"Pod-default/mypod-CPURequest-Used":    0.26,
+	"Pod-default/mypod-CPURequest-Used":    260,
 	"Pod-default/mypod-MemoryRequest-Used": 262144,
 
 	// Container metrics
-	"Container-default/mypod/twitter-cass-tweet-CPU-Capacity":            0.25,
+	"Container-default/mypod/twitter-cass-tweet-CPU-Capacity":            250,
 	"Container-default/mypod/twitter-cass-tweet-Memory-Capacity":         262144,
-	"Container-default/mypod/twitter-cass-tweet-CPURequest-Capacity":     0.25,
+	"Container-default/mypod/twitter-cass-tweet-CPURequest-Capacity":     250,
 	"Container-default/mypod/twitter-cass-tweet-MemoryRequest-Capacity":  262144,
-	"Container-default/mypod/istio-proxy-CPU-Capacity":                   2,
+	"Container-default/mypod/istio-proxy-CPU-Capacity":                   2000,
 	"Container-default/mypod/istio-proxy-Memory-Capacity":                8.388608e+06,
-	"Container-default/mypod/istio-proxy-CPURequest-Capacity":            0.01,
+	"Container-default/mypod/istio-proxy-CPURequest-Capacity":            10,
 	"Container-default/mypod/istio-proxy-MemoryRequest-Capacity":         0,
-	"Container-default/mypod/twitter-cass-tweet-CPULimitQuota-Used":      0.25,
+	"Container-default/mypod/twitter-cass-tweet-CPULimitQuota-Used":      250,
 	"Container-default/mypod/twitter-cass-tweet-MemoryLimitQuota-Used":   262144,
-	"Container-default/mypod/twitter-cass-tweet-CPURequestQuota-Used":    0.25,
+	"Container-default/mypod/twitter-cass-tweet-CPURequestQuota-Used":    250,
 	"Container-default/mypod/twitter-cass-tweet-MemoryRequestQuota-Used": 262144,
-	"Container-default/mypod/istio-proxy-CPULimitQuota-Used":             2,
-	"Container-default/mypod/istio-proxy-CPURequestQuota-Used":           0.01,
+	"Container-default/mypod/istio-proxy-CPULimitQuota-Used":             2000,
+	"Container-default/mypod/istio-proxy-CPURequestQuota-Used":           10,
 	"Container-default/mypod/istio-proxy-MemoryLimitQuota-Used":          8.388608e+06,
 	"Container-default/mypod/istio-proxy-MemoryRequestQuota-Used":        0,
 }
@@ -134,6 +136,7 @@ func mockNode(name string, capacity, allocatable api.ResourceList) *api.Node {
 }
 
 func TestGenNodeResourceMetrics(t *testing.T) {
+	// Build a node
 	// Build a node
 	node := mockNode(
 		"mynode",

--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -137,7 +137,6 @@ func mockNode(name string, capacity, allocatable api.ResourceList) *api.Node {
 
 func TestGenNodeResourceMetrics(t *testing.T) {
 	// Build a node
-	// Build a node
 	node := mockNode(
 		"mynode",
 		buildResource(2.0, 8192), // node capacity: 2.0 cores, 8 GiB mem

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -96,6 +96,15 @@ func (summary *ClusterSummary) GetKubeNamespace(namespace string) *KubeNamespace
 	return kubeNamespace
 }
 
+func (summary *ClusterSummary) GetNodeCPUFrequency(nodeName string) float64 {
+	node, exists := summary.NodeMap[nodeName]
+	if !exists {
+		glog.Errorf("Cannot find KubeNamespace entity for namespace %s", nodeName)
+		return 0
+	}
+	return node.NodeCpuFrequency
+}
+
 func (summary *ClusterSummary) GetReadyPods() (readyPods []*v1.Pod) {
 	for _, pod := range summary.Pods {
 		if util.PodIsReady(pod) {

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -243,8 +243,7 @@ func parseResourceValue(computeResourceType metrics.ResourceType, resourceList v
 	if computeResourceType == metrics.CPU ||
 		computeResourceType == metrics.CPURequest {
 		ctnCpuCapacityMilliCore := resourceList.Cpu().MilliValue()
-		cpuCapacityCore := util.MetricMilliToUnit(float64(ctnCpuCapacityMilliCore))
-		return cpuCapacityCore
+		return float64(ctnCpuCapacityMilliCore)
 	}
 
 	if computeResourceType == metrics.Memory ||
@@ -437,7 +436,7 @@ func (kubeNamespace *KubeNamespace) ReconcileQuotas(quotas []*v1.ResourceQuota) 
 		resourceStatus := item.Status
 		resourceHardList := resourceStatus.Hard
 
-		for resource, _ := range resourceHardList {
+		for resource := range resourceHardList {
 			// This will return resourceType as "limits.cpu" for resource as both "cpu" and "limits.cpu"
 			// Likewise for memory.
 			resourceType, isAllocationType := metrics.KubeQuotaResourceTypes[resource]
@@ -447,7 +446,7 @@ func (kubeNamespace *KubeNamespace) ReconcileQuotas(quotas []*v1.ResourceQuota) 
 			// Quota is defined for the quota resource
 			kubeNamespace.QuotaDefined[resourceType] = true
 
-			// Parse the CPU  values into number of cores, Memory values into KBytes
+			// Parse the CPU  values into number of millicores, Memory values into KBytes
 			capacityValue := parseAllocationResourceValue(resource, resourceType, resourceHardList)
 
 			// Update the namespace entity resource with the most restrictive quota value
@@ -475,14 +474,13 @@ func (kubeNamespace *KubeNamespace) ReconcileQuotas(quotas []*v1.ResourceQuota) 
 }
 
 // Parse the CPU and Memory resource values.
-// CPU is represented in number of cores, Memory in KBytes
+// CPU is represented in number of millicores, Memory in KBytes
 func parseAllocationResourceValue(resource v1.ResourceName, allocationResourceType metrics.ResourceType, resourceList v1.ResourceList) float64 {
 
 	if allocationResourceType == metrics.CPULimitQuota || allocationResourceType == metrics.CPURequestQuota {
 		quantity := resourceList[resource]
 		cpuMilliCore := quantity.MilliValue()
-		cpuCore := util.MetricMilliToUnit(float64(cpuMilliCore))
-		return cpuCore
+		return float64(cpuMilliCore)
 	}
 
 	if allocationResourceType == metrics.MemoryLimitQuota || allocationResourceType == metrics.MemoryRequestQuota {

--- a/pkg/discovery/util/const.go
+++ b/pkg/discovery/util/const.go
@@ -28,6 +28,22 @@ func MetricNanoToUnit(val float64) float64 {
 	return val / METRICGIGA
 }
 
+func MetricNanoToMilli(val float64) float64 {
+	return val / METRICMEGA
+}
+
+func MetricMilliToUnit(val float64) float64 {
+	return val / METRICKILO
+}
+
+func MetricUnitToMilli(val float64) float64 {
+	return val * METRICKILO
+}
+
+func MetricKiloToMega(val float64) float64 {
+	return val / METRICKILO
+}
+
 func Base2BytesToKilobytes(val float64) float64 {
 	return val / BASE2KILO
 }
@@ -38,12 +54,4 @@ func Base2BytesToMegabytes(val float64) float64 {
 
 func Base2MegabytesToBytes(val float64) float64 {
 	return val * BASE2MEGA
-}
-
-func MetricMilliToUnit(val float64) float64 {
-	return val / METRICKILO
-}
-
-func MetricKiloToMega(val float64) float64 {
-	return val / METRICKILO
 }

--- a/pkg/discovery/util/resource.go
+++ b/pkg/discovery/util/resource.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"errors"
 	"math"
 	"net"
 
@@ -9,28 +8,11 @@ import (
 	api "k8s.io/api/core/v1"
 )
 
-// CPU returned is in KHz; Mem is in Kb
-func GetPodResourceLimits(pod *api.Pod) (cpuCapacity float64, memCapacity float64, err error) {
-	if pod == nil {
-		err = errors.New("pod passed in is nil.")
-		return
-	}
-
-	for _, container := range pod.Spec.Containers {
-		limits := container.Resources.Limits
-		ctnCpuCap, ctnMemoryCap := GetCpuAndMemoryValues(limits)
-		cpuCapacity += ctnCpuCap
-		memCapacity += ctnMemoryCap
-	}
-	return
-}
-
 // CPU returned is in core; Memory is in Kb
-func GetCpuAndMemoryValues(resource api.ResourceList) (cpuCapacityCore, memoryCapacityKiloBytes float64) {
+func GetCpuAndMemoryValues(resource api.ResourceList) (ctnCpuCapacityMilliCore, memoryCapacityKiloBytes float64) {
+	ctnCpuCapacityMilliCore = float64(resource.Cpu().MilliValue())
 	ctnMemoryCapacityBytes := resource.Memory().Value()
-	ctnCpuCapacityMilliCore := resource.Cpu().MilliValue()
 	memoryCapacityKiloBytes = Base2BytesToKilobytes(float64(ctnMemoryCapacityBytes))
-	cpuCapacityCore = MetricMilliToUnit(float64(ctnCpuCapacityMilliCore))
 
 	return
 }

--- a/pkg/discovery/worker/container_spec_discovery_worker.go
+++ b/pkg/discovery/worker/container_spec_discovery_worker.go
@@ -80,8 +80,6 @@ func (worker *k8sContainerSpecDiscoveryWorker) createContainerSpecMetricsMap(con
 					continue
 				}
 				// Append resource capacity values of same resource type of container replicas from different nodes.
-				// We have already converted CPU capacity from milli-cores into MHz based on node CPU frequency. Different
-				// node CPU frequency leads to different container CPU capacity in MHz although CPU in milli-cores is the same.
 				// To make sure CPU capacity of container spec is consistent, we collect capacity values from all container
 				// replicas here and will use max value when building container spec entity dto.
 				existingResourceMetrics.Capacity = append(existingResourceMetrics.Capacity, containerMetrics.Capacity...)

--- a/pkg/discovery/worker/container_spec_metrics_collector_test.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector_test.go
@@ -96,10 +96,9 @@ var (
 		},
 	}
 
-	pod4OwnerUIDMetric  = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod4), metrics.OwnerUID, controllerUID)
-	pod5OwnerUIDMetric  = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod5), metrics.OwnerUID, controllerUID)
-	pod6OwnerUIDMetric  = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod6), metrics.OwnerUID, controllerUID)
-	podNodeCPUFrequency = metrics.NewEntityStateMetric(metrics.NodeType, nodeName, metrics.CpuFrequency, cpuFrequency)
+	pod4OwnerUIDMetric = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod4), metrics.OwnerUID, controllerUID)
+	pod5OwnerUIDMetric = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod5), metrics.OwnerUID, controllerUID)
+	pod6OwnerUIDMetric = metrics.NewEntityStateMetric(metrics.PodType, discoveryutil.PodKeyFunc(testPod6), metrics.OwnerUID, controllerUID)
 
 	containerFooCPUCapMetric = metrics.NewEntityResourceMetric(metrics.ContainerType,
 		discoveryutil.ContainerMetricId(discoveryutil.PodMetricIdAPI(testPod4), containerFoo), metrics.CPU, metrics.Capacity, containerFooCPUCap)
@@ -180,7 +179,7 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithoutReques
 	pods := []*api.Pod{testPod4}
 	metricsSink := metrics.NewEntityMetricSink().WithMaxMetricPointsSize(10)
 	// Add pod owner UID and node CPU frequency metrics
-	metricsSink.AddNewMetricEntries(pod4OwnerUIDMetric, podNodeCPUFrequency)
+	metricsSink.AddNewMetricEntries(pod4OwnerUIDMetric)
 
 	// Add and update containerFoo CPU and memory metrics
 	metricsSink.AddNewMetricEntries(containerFooCPUCapMetric, containerFooCPUUsedMetric1, containerFooMemCapMetric, containerFooMemUsedMetric1)
@@ -198,10 +197,10 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithoutReques
 		ContainerReplicas: 1,
 		ContainerMetrics: map[metrics.ResourceType]*repository.ContainerMetrics{
 			metrics.CPU: {
-				Capacity: []float64{cpuFrequency * containerFooCPUCap},
+				Capacity: []float64{containerFooCPUCap},
 				Used: []metrics.Point{
-					createContainerMetricPoint(cpuFrequency*containerFooCPUUsed1, 1),
-					createContainerMetricPoint(cpuFrequency*containerFooCPUUsed2, 2),
+					createContainerMetricPoint(containerFooCPUUsed1, 1),
+					createContainerMetricPoint(containerFooCPUUsed2, 2),
 				},
 			},
 			metrics.Memory: {
@@ -229,7 +228,7 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithRequestMe
 	pods := []*api.Pod{testPod5, testPod6}
 	metricsSink := metrics.NewEntityMetricSink().WithMaxMetricPointsSize(10)
 	// Add pod owner UID and node CPU frequency metrics
-	metricsSink.AddNewMetricEntries(pod5OwnerUIDMetric, pod6OwnerUIDMetric, podNodeCPUFrequency)
+	metricsSink.AddNewMetricEntries(pod5OwnerUIDMetric, pod6OwnerUIDMetric)
 
 	// Add and update containerFoo CPURequest and MemoryRequest metrics
 	metricsSink.AddNewMetricEntries(containerBarCPURequestCapMetric, containerBarCPURequestUsedMetric1,
@@ -251,10 +250,10 @@ func TestContainerSpecMetricsCollector_CollectContainerSpecMetrics_WithRequestMe
 		ContainerReplicas: 1,
 		ContainerMetrics: map[metrics.ResourceType]*repository.ContainerMetrics{
 			metrics.CPURequest: {
-				Capacity: []float64{cpuFrequency * containerBarCPURequestCap},
+				Capacity: []float64{containerBarCPURequestCap},
 				Used: []metrics.Point{
-					createContainerMetricPoint(cpuFrequency*containerBarCPURequestUsed1, 1),
-					createContainerMetricPoint(cpuFrequency*containerBarCPURequestUsed2, 2),
+					createContainerMetricPoint(containerBarCPURequestUsed1, 1),
+					createContainerMetricPoint(containerBarCPURequestUsed2, 2),
 				},
 			},
 			metrics.MemoryRequest: {

--- a/pkg/discovery/worker/controller_discovery_worker.go
+++ b/pkg/discovery/worker/controller_discovery_worker.go
@@ -2,9 +2,9 @@ package worker
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
@@ -26,35 +26,12 @@ func NewK8sControllerDiscoveryWorker(cluster *repository.ClusterSummary) *K8sCon
 // Then it creates entity DTOs for the K8s controllers to be sent to the Turbonomic server.
 // This runs after cluster NamespaceMap is populated.
 func (worker *K8sControllerDiscoveryWorker) Do(cluster *repository.ClusterSummary, kubeControllers []*repository.KubeController) ([]*proto.EntityDTO, error) {
-	namespacesMap := worker.cluster.NamespaceMap
 	// Map from controller UID to the corresponding kubeController
 	kubeControllersMap := make(map[string]*repository.KubeController)
 	// Combine the pods and allocation resources usage from different discovery workers but belonging to the same K8s controller.
 	for _, kubeController := range kubeControllers {
 		existingKubeController, exists := kubeControllersMap[kubeController.UID]
 		if !exists {
-			kubeNamespace, exists := namespacesMap[kubeController.Namespace]
-			if !exists {
-				glog.Errorf("Namespace %s does not exist in cluster %s", kubeController.Namespace, worker.cluster.Name)
-				continue
-			}
-			averageNodeCpuFrequency := kubeNamespace.AverageNodeCpuFrequency
-			if averageNodeCpuFrequency <= 0.0 {
-				glog.Errorf("Average node CPU frequency is not larger than zero in namespace %s. Skip KubeController %s",
-					kubeNamespace.Name, kubeController.GetFullName())
-				continue
-			}
-			for resourceType, resource := range kubeController.AllocationResources {
-				// For CPU resources, convert the capacity values expressed in number of cores to MHz.
-				// Skip the conversion if capacity value is repository.DEFAULT_METRIC_CAPACITY_VALUE (infinity), which
-				// means resource quota is not configured on the corresponding namespace.
-				if metrics.IsCPUType(resourceType) && resource.Capacity != repository.DEFAULT_METRIC_CAPACITY_VALUE {
-					newCapacity := resource.Capacity * kubeNamespace.AverageNodeCpuFrequency
-					glog.V(4).Infof("Changing capacity of %s::%s from %f cores to %f MHz",
-						kubeController.GetFullName(), resourceType, resource.Capacity, newCapacity)
-					resource.Capacity = newCapacity
-				}
-			}
 			kubeControllersMap[kubeController.UID] = kubeController
 		} else {
 			for resourceType, resource := range existingKubeController.AllocationResources {
@@ -64,8 +41,7 @@ func (worker *K8sControllerDiscoveryWorker) Do(cluster *repository.ClusterSummar
 					continue
 				}
 				// Aggregate allocation resource usage of the same kubeController discovered by different discovery worker.
-				// The usage values of CPU resources have already been converted from cores to MHz based on the CPU
-				// frequency of the corresponding node in controller_metrics_collector.
+				// The usage values of CPU resources are all in millicores.
 				resource.Used += usedValue
 			}
 			// Update the pod lists of the existing KubeController

--- a/pkg/discovery/worker/metrics_collector_test.go
+++ b/pkg/discovery/worker/metrics_collector_test.go
@@ -230,8 +230,9 @@ func TestAccumulatingOverPodMetricsList(t *testing.T) {
 	podMetricsList = append(podMetricsList, pm2)
 
 	quotaUsedSumMap := podMetricsList.SumQuotaUsage()
-	cpuLimitQuotaUsed := cpuLimits_container1 + cpuLimits_container2
-	cpuRequestQuotaUsed := cpuRequests_container1 + cpuRequests_container2
+	// The generated metrics all all in millicores
+	cpuLimitQuotaUsed := util.MetricUnitToMilli(cpuLimits_container1 + cpuLimits_container2)
+	cpuRequestQuotaUsed := util.MetricUnitToMilli(cpuRequests_container1 + cpuRequests_container2)
 	memLimitQuotaUsed := 0.0
 	memRequestQuotaUsed := 0.0
 	assert.Equal(t, cpuLimitQuotaUsed, quotaUsedSumMap[metrics.CPULimitQuota])


### PR DESCRIPTION
This implements https://vmturbo.atlassian.net/browse/OM-71836
This updates all the CPU relevant metrics to millicore, except the node metrics, which is still in MHz.
All the cpu type metrics are stored as millicores in metrics sink, for overall consistency. The node metrics are converted to MHz when creating the entity DTOs.

I have verified the discovery and updated the unit tests such that they all pass. The end to end validation will happen with the server side changes.


The image for further server side work is available as `irfdocker/kubeturbo:millicore`.