### PR TITLE
Option to specify image pull secret for cpu freq job busybox image

### DIFF
--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           {{- if .Values.image.busyboxRepository }}
           - --busybox-image={{ .Values.image.busyboxRepository }}
           {{- end }}
+          {{- if .Values.image.imagePullSecret }}
+          - --busybox-image-pull-secret={{ .Values.image.imagePullSecret }}
+          {{- end }}
           {{- if .Values.args.busyboxExcludeNodeLabels }}
           - --cpufreq-job-exclude-node-labels={{ .Values.args.busyboxExcludeNodeLabels }}
           {{- end }}

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -10,6 +10,7 @@ image:
   tag: 8.1.6
   pullPolicy: IfNotPresent
 #  busyboxRepository: busybox
+#  imagePullSecret: ""
 
 annotations:
   kubeturbo.io/controllable: "false"

--- a/deploy/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           {{- if .Values.image.busyboxRepository }}
           - --busybox-image={{ .Values.image.busyboxRepository }}
           {{- end }}
+          {{- if .Values.image.imagePullSecret }}
+          - --busybox-image-pull-secret={{ .Values.image.imagePullSecret }}
+          {{- end }}
           {{- if .Values.args.busyboxExcludeNodeLabels }}
           - --cpufreq-job-exclude-node-labels={{ .Values.args.busyboxExcludeNodeLabels }}
           {{- end }}

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -10,6 +10,7 @@ image:
   tag: 8.1.6
   pullPolicy: IfNotPresent
 #  busyboxRepository: busybox
+#  imagePullSecret: ""
 
 annotations:
   kubeturbo.io/controllable: "false"

--- a/deploy/kubeturbo_yamls/step5_turbo_kubeturboDeploy.yaml
+++ b/deploy/kubeturbo_yamls/step5_turbo_kubeturboDeploy.yaml
@@ -21,6 +21,11 @@ spec:
       serviceAccountName: turbo-user
       containers:
       - name: kubeturbo
+        env:
+          - name: KUBETURBO_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         # Replace the image with desired version:6.4.4 or latest
         image: turbonomic/kubeturbo:8.1.6
         args:
@@ -30,9 +35,17 @@ spec:
           # change to https=false and port=10255 if unsecure kubelet read only is configured
           - --kubelet-https=true
           - --kubelet-port=10250
-          #- --busybox-image=registry.access.redhat.com/ubi8/ubi-minimal
+          # Uncomment for pod moves in OpenShift
+          #- --scc-support=*
+          # Uncomment for pod moves with pvs
+          #- --fail-volume-pod-moves=false
           # Uncomment to stitch using IP, or if using Openstack, Hyper-V/VMM
           #- --stitch-uuid=false
+          # Uncomment to specify a non default image for cpu freq getter job, for example ubi-minimal from RHCC
+          # Default is "busybox".
+          #- --busybox-image=registry.access.redhat.com/ubi8/ubi-minimal
+          # Uncomment to specify the secret name which holds the credentials to busybox image
+          #- --busybox-image-pull-secret=<secret-name>
         volumeMounts:
           # volume will be created, any name will work and must match below
           - name: turbo-volume

--- a/deploy/kubeturbo_yamls/turbo_kubeturbo_full.yaml
+++ b/deploy/kubeturbo_yamls/turbo_kubeturbo_full.yaml
@@ -114,10 +114,13 @@ spec:
           #- --scc-support=*
           # Uncomment for pod moves with pvs
           #- --fail-volume-pod-moves=false
-          # Uncomment for specifying cpu frequency getter job from RHCC
-          #- --busybox-image=registry.access.redhat.com/ubi8/ubi-minimal
           # Uncomment to stitch using IP, or if using Openstack, Hyper-V/VMM
           #- --stitch-uuid=false
+          # Uncomment to specify a non default image for cpu freq getter job, for example ubi-minimal from RHCC
+          # Default is "busybox".
+          #- --busybox-image=registry.access.redhat.com/ubi8/ubi-minimal
+          # Uncomment to specify the secret name which holds the credentials to busybox image
+          #- --busybox-image-pull-secret=<secret-name>
         volumeMounts:
           # volume will be created, any name will work and must match below
           - name: turbo-volume

--- a/pkg/kubeclient/kubelet_client.go
+++ b/pkg/kubeclient/kubelet_client.go
@@ -432,7 +432,7 @@ func (kc *KubeletConfig) Timeout(timeout int) *KubeletConfig {
 	return kc
 }
 
-func (kc *KubeletConfig) Create(fallbackClient *kubernetes.Clientset, busyboxImage string,
+func (kc *KubeletConfig) Create(fallbackClient *kubernetes.Clientset, busyboxImage, imagePullSecret string,
 	excludeLabelsMap map[string]string, useProxyEndpoint bool) (*KubeletClient, error) {
 	// 1. http transport
 	transport, err := makeTransport(kc.kubeConfig, kc.enableHttps, kc.tlsTimeOut, kc.forceSelfSignedCerts)
@@ -456,7 +456,7 @@ func (kc *KubeletConfig) Create(fallbackClient *kubernetes.Clientset, busyboxIma
 		scheme:                      scheme,
 		port:                        kc.port,
 		cache:                       make(map[string]*CacheEntry),
-		fallbkCpuFreqGetter:         NewNodeCpuFrequencyGetter(fallbackClient, busyboxImage),
+		fallbkCpuFreqGetter:         NewNodeCpuFrequencyGetter(fallbackClient, busyboxImage, imagePullSecret),
 		cpufreqJobExcludeNodeLabels: excludeLabelsMap,
 		defaultCpuFreq:              defaultCpuFreq,
 		kubeClient:                  fallbackClient,

--- a/pkg/kubeclient/kubelet_client_test.go
+++ b/pkg/kubeclient/kubelet_client_test.go
@@ -68,7 +68,7 @@ func TestKubeletClientCacheNil(t *testing.T) {
 	kubeConf := &rest.Config{}
 	conf := NewKubeletConfig(kubeConf)
 
-	kc, _ := conf.Create(nil, "busybox", map[string]string{}, false)
+	kc, _ := conf.Create(nil, "busybox", "", map[string]string{}, false)
 	entry := &CacheEntry{}
 	kc.cache["host_1"] = entry
 	assert.False(t, kc.HasCacheBeenUsed("host_1"))

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -80,7 +80,7 @@ var _ = Describe("Discover Cluster", func() {
 			}
 
 			s := app.NewVMTServer()
-			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "busybox", map[string]string{}, true)
+			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "", "busybox", map[string]string{}, true)
 
 			apiExtClient, err := apiextclient.NewForConfig(kubeConfig)
 			if err != nil {


### PR DESCRIPTION
Implements https://vmturbo.atlassian.net/browse/OM-71032

@esara for your reference I updated the helm charts too, reusing the `imagePullSecret` already there. You will need to update the operator image with the next release.

@evat-pm The usage for this option is as below:
1. With yamls alone:
a cmd line argument needs to be added to kubetubro deployment yaml, ie. `--busybox-image-pull-secret=<secret-name>`.
I have updated the yamls, with this argument in a comment.
2. With operator:
once the new operator is built and published (by @esara), the already existing `imagePullSecret` field value is used for both the kubeturbo imagePullSecrets and  busybox job imagePullSecrets.

