### PR TITLE
Fix handling of stop channnel addressing a possible race condition

### DIFF
--- a/pkg/discovery/monitoring/monitoring_worker.go
+++ b/pkg/discovery/monitoring/monitoring_worker.go
@@ -17,8 +17,7 @@ type MonitorWorkerConfig interface {
 }
 
 type MonitoringWorker interface {
-	Do() *metrics.EntityMetricSink
-	Stop()
+	Do(stopChan <-chan struct{}) *metrics.EntityMetricSink
 	ReceiveTask(task *task.Task)
 	GetMonitoringSource() types.MonitoringSource
 }

--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -3,6 +3,8 @@ package worker
 import (
 	"fmt"
 
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/configs"
@@ -11,7 +13,6 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
 	api "k8s.io/api/core/v1"
-	"time"
 )
 
 type DispatcherConfig struct {
@@ -218,8 +219,9 @@ func (d *SamplingDispatcher) dispatchSamplingDiscoveries(nodes []*api.Node, samp
 }
 
 // Assign task to the k8sDiscoveryWorker
-func (d *Dispatcher) assignTask(t *task.Task) {
+func (d *Dispatcher) assignTask(task *task.Task) {
 	// assignTask to a task channel of a worker.
-	taskChannel := <-d.workerPool // pick a free worker from the worker pool, when its channel frees up
-	taskChannel <- t
+	// Worker pool is channel of channels.
+	workerChannel := <-d.workerPool // pick a free worker from the worker pool, when its channel frees up
+	workerChannel <- task
 }

--- a/pkg/discovery/worker/dispatcher_test.go
+++ b/pkg/discovery/worker/dispatcher_test.go
@@ -3,18 +3,20 @@ package worker
 import (
 	"flag"
 	"fmt"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"math"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/configs"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/task"
-	"k8s.io/api/core/v1"
 )
 
 func init() {
@@ -143,6 +145,8 @@ func TestDispatcher_Dispatch_With_Task_Timeout(t *testing.T) {
 			}
 		}()
 		result = resultCollector.Collect(len(nodes))
+		// Sleep a little to give chance to defer funcs to be called
+		time.Sleep(time.Second * 5)
 		done <- true
 	}()
 


### PR DESCRIPTION
- Fixes https://vmturbo.atlassian.net/browse/OM-71964
- Improves the overall handling of stopping all the monitoring (kubelet and cluster) goroutines when forced to stop (eg at a timeout).
- Enhances the dummy monitoring worker used for testing to mimic the actual workers.

***Tests***
The updated unit tests pass
Long running kubeturbo continues with valid discovery and mornitoring cycles, with all entities discovered fine.