### PR TITLE
Fix rounding issue of CPU and memory quantity when executing resizing actions

### DIFF
--- a/pkg/action/executor/resize_container_test.go
+++ b/pkg/action/executor/resize_container_test.go
@@ -278,6 +278,17 @@ func TestBuildResourceListsWithRequests(t *testing.T) {
 	assert.EqualValues(t, "20Ki", newMemoryRequests.String())
 }
 
+func TestGenCPUAndMemQuantity(t *testing.T) {
+	amount, _ := genCPUQuantity(1.9999)
+	assert.Equal(t, "2m", amount.String())
+	amount, _ = genMemoryQuantity(1.9999)
+	assert.Equal(t, "2Ki", amount.String())
+	amount, _ = genCPUQuantity(1.001)
+	assert.Equal(t, "1m", amount.String())
+	amount, _ = genMemoryQuantity(1.001)
+	assert.Equal(t, "1Ki", amount.String())
+}
+
 func mockCommodity(commodityType proto.CommodityDTO_CommodityType, capacity float64) *proto.CommodityDTO {
 	return &proto.CommodityDTO{
 		CommodityType: &commodityType,

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/golang/glog"
 
@@ -140,7 +141,8 @@ func updateResourceAmount(podSpec *k8sapi.PodSpec, specs []*containerResizeSpec,
 // Generate a resource.Quantity for CPU.
 // @newValue is from Turbo platform, in millicores
 func genCPUQuantity(newValue float64) (resource.Quantity, error) {
-	cpuTime := int(newValue)
+	// Round the value to nearest integer
+	cpuTime := int(math.Round(newValue))
 	if cpuTime < 1 {
 		cpuTime = 1
 	}
@@ -149,7 +151,8 @@ func genCPUQuantity(newValue float64) (resource.Quantity, error) {
 
 // generate a resource.Quantity for Memory
 func genMemoryQuantity(newValue float64) (resource.Quantity, error) {
-	tmp := int64(newValue)
+	// Round the value to nearest integer
+	tmp := int64(math.Round(newValue))
 	if tmp < 1 {
 		tmp = 1
 	}


### PR DESCRIPTION
JIRA: https://vmturbo.atlassian.net/browse/OM-72960

# Intent
The intent is to fix improper integer cast on CPU/memory capacity float values when executing container resizing actions.

# Problem and Diagnosis
When executing a VCPU resizing action from 1000 millicores to 500 millicores, the new CPU limits of the deployment became 499 millicores instead of 500 millicores.

In AO log,
```
action-orchestrator-5cb4c7bf96-q 2021-07-15 16:01:49,857  INFO [ActionStateUpdater]	: Action executed successfully: Action Id=637002884245611, RecommendationOid=637002884246608, Type=ATOMICRESIZE, Mode=MANUAL, State=SUCCEEDED, Recommendation=id: 637002884245611
action-orchestrator-5cb4c7bf96-q info {
action-orchestrator-5cb4c7bf96-q   atomicResize {
action-orchestrator-5cb4c7bf96-q     execution_target {
action-orchestrator-5cb4c7bf96-q       id: 74052533629488
action-orchestrator-5cb4c7bf96-q       type: 65
action-orchestrator-5cb4c7bf96-q       environment_type: CLOUD
action-orchestrator-5cb4c7bf96-q     }
action-orchestrator-5cb4c7bf96-q     resizes {
action-orchestrator-5cb4c7bf96-q       source_entities {
action-orchestrator-5cb4c7bf96-q         id: 74054239784768
action-orchestrator-5cb4c7bf96-q         type: 40
action-orchestrator-5cb4c7bf96-q         environment_type: CLOUD
action-orchestrator-5cb4c7bf96-q       }
action-orchestrator-5cb4c7bf96-q       source_entities {
action-orchestrator-5cb4c7bf96-q         id: 74054239784784
action-orchestrator-5cb4c7bf96-q         type: 40
action-orchestrator-5cb4c7bf96-q         environment_type: CLOUD
action-orchestrator-5cb4c7bf96-q       }
action-orchestrator-5cb4c7bf96-q       target {
action-orchestrator-5cb4c7bf96-q         id: 74052533629360
action-orchestrator-5cb4c7bf96-q         type: 66
action-orchestrator-5cb4c7bf96-q         environment_type: CLOUD
action-orchestrator-5cb4c7bf96-q       }
action-orchestrator-5cb4c7bf96-q       commodity_type {
action-orchestrator-5cb4c7bf96-q         type: 26
action-orchestrator-5cb4c7bf96-q       }
action-orchestrator-5cb4c7bf96-q       old_capacity: 1000.0
action-orchestrator-5cb4c7bf96-q       new_capacity: 499.99997
action-orchestrator-5cb4c7bf96-q       commodity_attribute: CAPACITY
action-orchestrator-5cb4c7bf96-q     }
```
New VCPU capacity is 499.99997 because of floating point.

While in kubeturbo log when executing this action:
```
I0715 16:01:48.065740       1 resize_container_util.go:68] Try to update container dummy-spec 
resource limit from map[cpu:{i:{value:1 scale:0} d:{Dec:<nil>} s:1 Format:DecimalSI} memory:{i:{value:1073741824 scale:0} d:{Dec:<nil>} s:1Gi Format:BinarySI}] 
to map[cpu:{{499 -3} {<nil>} 499m DecimalSI} memory:{{1073741824 0} {<nil>} 1Gi BinarySI}]
```
New CPU limit value is set to 499m.

This is because in `resize_container_util.go`, `genCPUQuantity` and `genMemotyQuantity` functions cast float64 value by: 
```
cpuTime := int(newValue)
```

And based on https://golang.org/ref/spec#Conversions,
> When converting a floating-point number to an integer, the fraction is discarded (truncation towards zero).

So 499.99997 is recognized as 499 instead of 500.

# Solution
To fix such improper truncation of casting float to int, round the value to nearest integer by using `math.Round`.

Added unit tests.

This is a tricky corner case. When I tried to execute the same action from 1000 millicores to 500 millicores, the new capacity sent from AO is "500.00003". So the same issue cannot be easily reproduced every time which depends on the floating points. But I think the additional unit tests are sufficient to verify the fix.