### PR TITLE
Customize service account for role binding

### DIFF
--- a/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
+++ b/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
@@ -43,6 +43,12 @@ spec:
         spec:
           type: object
           properties:
+            roleBinding:
+              description: The name of cluster role binding. Default is turbo-all-binding
+              type: string
+            serviceAccountName:
+              description: The name of the service account name. Default is turbo-user
+              type: string
             replicaCount:
               description: Kubeturbo replicaCount
               type: integer

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: {{ include "kubeturbo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: turbo-user
+      serviceAccountName: {{ .Values.serviceAccountName }}
 {{- if .Values.image.imagePullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.imagePullSecret }}

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/serviceaccount.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/serviceaccount.yaml
@@ -94,7 +94,7 @@ metadata:
   name: {{ .Values.roleBinding }}
 subjects:
   - kind: ServiceAccount
-    name: turbo-user
+    name: {{ .Values.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   # User creating this resource must have permissions to add this policy to the SA


### PR DESCRIPTION
In #507 , we added support to customize service account during `kubeturbo` operator deployment, but there are places where we did not update the customized service account and still hardcoded to `turbo-user`.
