### PR TITLE
Change go version to 1.16.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 
 go:
-  - 1.16
+  - 1.16.6
  
 go_import_path: github.com/turbonomic/kubeturbo
 


### PR DESCRIPTION
Upgrade the go version to the latest stable version 1.16.6.

We don't need to update the go version for `turbo-api` or `turbo-go-sdk` repo, because the `kubeturbo` build copies the source of `turbo-api` and `turbo-go-sdk`.