### PR TITLE
Support multi-arch build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 env:
   global:
     - DOCKER_IMAGE_NAME=$TRAVIS_REPO_SLUG
+    - PLATFORM_OS_ARCH_LIST="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
 
 services:
   - docker
@@ -19,22 +20,36 @@ before_install:
 script:
   - make fmtcheck
   - make vet
-  - make build
   - $HOME/gopath/bin/goveralls -v -race -service=travis-ci -package='github.com/turbonomic/kubeturbo/cmd/kubeturbo github.com/turbonomic/kubeturbo/cmd/kubeturbo/app github.com/turbonomic/kubeturbo/pkg github.com/turbonomic/kubeturbo/pkg/action github.com/turbonomic/kubeturbo/pkg/action/executor github.com/turbonomic/kubeturbo/pkg/action/util github.com/turbonomic/kubeturbo/pkg/cluster github.com/turbonomic/kubeturbo/pkg/discovery github.com/turbonomic/kubeturbo/pkg/discovery/configs github.com/turbonomic/kubeturbo/pkg/discovery/detectors github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property github.com/turbonomic/kubeturbo/pkg/discovery/metrics github.com/turbonomic/kubeturbo/pkg/discovery/monitoring github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types github.com/turbonomic/kubeturbo/pkg/discovery/processor github.com/turbonomic/kubeturbo/pkg/discovery/repository github.com/turbonomic/kubeturbo/pkg/discovery/stitching github.com/turbonomic/kubeturbo/pkg/discovery/task github.com/turbonomic/kubeturbo/pkg/discovery/util github.com/turbonomic/kubeturbo/pkg/discovery/worker github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation github.com/turbonomic/kubeturbo/pkg/discovery/worker/compliance github.com/turbonomic/kubeturbo/pkg/kubeclient github.com/turbonomic/kubeturbo/pkg/registration github.com/turbonomic/kubeturbo/pkg/resourcemapping github.com/turbonomic/kubeturbo/pkg/turbostore github.com/turbonomic/kubeturbo/pkg/util github.com/turbonomic/kubeturbo/pkg/discovery/worker/k8sappcomponents'
-  - cp ./kubeturbo build
-  - cd build
-  - docker build -t $DOCKER_IMAGE_NAME --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" .
+  - make product
 
 after_success:
   - |
     if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-      if [ -n "$TRAVIS_TAG" ]; then
-          # Push a release image triggered by a git tag
-          docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:$TRAVIS_TAG
-          docker push $DOCKER_IMAGE_NAME:$TRAVIS_TAG
-      elif [ "$TRAVIS_BRANCH" == "master" ]; then
-          # Push the latest image built from master branch
-          docker push $DOCKER_IMAGE_NAME
+      if [ -n "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" == "master" ]; then
+        # Update docker
+        sudo rm -rf /var/lib/apt/lists/*
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+        sudo apt-get update
+        sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+        docker version
+        # Install buildx plugin
+        mkdir -vp ~/.docker/cli-plugins/
+        curl --silent -L "https://github.com/docker/buildx/releases/download/v0.6.0/buildx-v0.6.0.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+        chmod a+x ~/.docker/cli-plugins/docker-buildx
+        # Login to docker
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        # Create and set a new buildx builder instance
+        docker buildx create --use
+        # Build and push the image
+        cd build
+        if [ -n "$TRAVIS_TAG" ]; then
+            # Push a release image triggered by a git tag
+            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME:$TRAVIS_TAG .
+        else
+            # Push the latest image built from master branch
+            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME .
+        fi
       fi
     fi

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 OUTPUT_DIR=build
-SOURCE_DIRS = cmd pkg
-PACKAGES := go list ./... | grep -v /vendor | grep -v /out
-SHELL := '/bin/bash'
+SOURCE_DIRS=cmd pkg
+PACKAGES=go list ./... | grep -v /vendor | grep -v /out
+SHELL='/bin/bash'
 
-product: clean
-	env GOOS=linux GOARCH=amd64 go build -o ${OUTPUT_DIR}/kubeturbo ./cmd/kubeturbo
+LINUX_ARCH=amd64 arm64 ppc64le s390x
+
+$(LINUX_ARCH): clean
+	env GOOS=linux GOARCH=$@ go build -o ${OUTPUT_DIR}/linux/$@/kubeturbo ./cmd/kubeturbo
+
+product: $(LINUX_ARCH)
 
 debug-product: clean
 	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -gcflags "-N -l" -o ${OUTPUT_DIR}/kubeturbo.debug ./cmd/kubeturbo
@@ -38,7 +42,7 @@ test: clean
 
 .PHONY: clean
 clean:
-	@: if [ -f ${OUTPUT_DIR} ] then rm -rf ${OUTPUT_DIR} fi
+	@if [ -f ${OUTPUT_DIR} ]; then rm -rf ${OUTPUT_DIR}/linux; fi
 
 .PHONY: fmtcheck
 fmtcheck:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,6 +2,10 @@ FROM registry.access.redhat.com/ubi8
 MAINTAINER Enlin Xu <enlin.xu@turbonomic.com>
 ARG GIT_COMMIT
 ENV GIT_COMMIT ${GIT_COMMIT}
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN echo "Running on $BUILDPLATFORM, and building for $TARGETPLATFORM"
 
 ### Atomic/OpenShift Labels - https://github.com/projectatomic/ContainerApplicationGenericLabels
 LABEL name="Hybrid Cloud Container" \
@@ -28,7 +32,7 @@ COPY licenses /licenses
 COPY Dockerfile /Dockerfile
 
 ### Add md2man package
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf install -y --setopt=tsflags=nodocs golang-github-cpuguy83-go-md2man && \
     dnf clean all && \
 
@@ -42,7 +46,7 @@ ENV APP_ROOT=/opt/turbonomic \
 ENV PATH=$PATH:${APP_ROOT}/bin
 
 RUN mkdir -p ${APP_ROOT}/bin
-COPY kubeturbo ${APP_ROOT}/bin/kubeturbo
+COPY ${TARGETPLATFORM}/kubeturbo ${APP_ROOT}/bin/kubeturbo
 RUN chmod -R ug+x ${APP_ROOT}/bin && sync && \
     useradd -l -u ${USER_UID} -r -g 0 -d ${APP_ROOT} -s /sbin/nologin -c "${USER_NAME} user" ${USER_NAME} && \
     chown -R ${USER_UID}:0 ${APP_ROOT} && \


### PR DESCRIPTION
## Intention

This PR supports building a multi-arch manifest of `kubeturbo` that contains multiple images supporting different architectures behind the same image tag.

## Solution

* Update the `product` target in the `Makefile` to produce 4 `kubeturbo` binaries that supports `linux/amd64`, `linux/arm64`, `linux/ppc64le` and `linux/s390x` OS/Arch combinations respectively
* Update the `Dockerfile` with the following changes:
  * Install `epel-release-latest-8.noarch.rpm` for better multi-arch support
  * Copy the appropriate `kubeturbo` binary using the built-in `TARGETPLATFORM` environment variable supported by `docker build`
* Update `.travis.yml` with the following changes:
  * Only build docker image when image push is needed (i.e., `master` branch and `release` tag builds)
  * Install `docker buildx` plugin. This is needed when building docker manifest on x64 (default platform used by Travis). We may need to update the `buildx` version in the future when necessary
  * Create a new `buildx` instance, build and push the image

## Test

* The pushed image looks like the following in Docker Hub:

  ![image](https://user-images.githubusercontent.com/10012486/128752774-1a895c6b-6c06-4fe6-a993-8c3bf7273997.png)
  ![image](https://user-images.githubusercontent.com/10012486/128752835-7af69af1-5d8e-4a4d-9ce4-8c0f515e3d24.png)

* On the command line
```
mengding@mengding-mac$ docker manifest inspect ading1977/kubeturbo
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2203,
         "digest": "sha256:c188b131b84090af60dac55198a420dadbe3706fe57ac588d856aa0cee90b8bd",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2203,
         "digest": "sha256:be6090530d3de3ff12bad0305c15b133e865a4829bea0f512a012e8beef2f515",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2203,
         "digest": "sha256:7fdb900ba25c1ddc3109efe5fa325f4fd4436a3a6afa02032b18215663f2f1c1",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2203,
         "digest": "sha256:5e0a8cdff14a1e6bb50e6fe6e452e0e5e8f6fca281c8b7825727de5e171ff97b",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```
```
mengding@mengding-mac$ docker buildx imagetools inspect ading1977/kubeturbo
Name:      docker.io/ading1977/kubeturbo:latest
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:7d91f7ef36ee88b26ef6f7ef244252814f0197dc5a891d6957cf8249e2374d38
           
Manifests: 
  Name:      docker.io/ading1977/kubeturbo:latest@sha256:c188b131b84090af60dac55198a420dadbe3706fe57ac588d856aa0cee90b8bd
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64
             
  Name:      docker.io/ading1977/kubeturbo:latest@sha256:be6090530d3de3ff12bad0305c15b133e865a4829bea0f512a012e8beef2f515
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
             
  Name:      docker.io/ading1977/kubeturbo:latest@sha256:7fdb900ba25c1ddc3109efe5fa325f4fd4436a3a6afa02032b18215663f2f1c1
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/ppc64le
             
  Name:      docker.io/ading1977/kubeturbo:latest@sha256:5e0a8cdff14a1e6bb50e6fe6e452e0e5e8f6fca281c8b7825727de5e171ff97b
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/s390x
```

* The kubeturbo image tag displayed on the target page is the manifest digest, **NOT** the individual image digest:

  ![image](https://user-images.githubusercontent.com/10012486/128754053-2976bb9a-7dd1-4ddb-9000-868c0eb0f94f.png)
