### PR TITLE
Support running CPU frequency job on Power linux

### DIFF
--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -73,10 +73,10 @@ func (m *KubeletMonitor) Do(stopChan <-chan struct{}) *metrics.EntityMetricSink 
 	return m.metricSink
 }
 
-// Start to retrieve resource stats for the received list of nodes.
+// RetrieveResourceStat retrieves resource stats for the received list of nodes.
 func (m *KubeletMonitor) RetrieveResourceStat(stopChan <-chan struct{}) error {
 	if m.nodeList == nil || len(m.nodeList) == 0 {
-		return errors.New("Invalid nodeList or empty nodeList. Finish Immediately...")
+		return errors.New("empty node list")
 	}
 
 	m.wg.Add(len(m.nodeList))

--- a/pkg/discovery/util/node_util.go
+++ b/pkg/discovery/util/node_util.go
@@ -23,10 +23,10 @@ const (
 	NodeLabelRolePrefix = "node-role.kubernetes.io/"
 	// NodeLabelRole specifies the role of a node
 	NodeLabelRole = "kubernetes.io/role"
-	// NodeLabelOS and NodeLabelOSBeta specifies the OS of a node
+	// NodeLabelOS and NodeLabelOSBeta specify the OS of a node
 	NodeLabelOS     = "kubernetes.io/os"
 	NodeLabelOSBeta = "beta.kubernetes.io/os"
-	// NodeLabelArch and NodeLabelArchBeta specifies the arch of a node
+	// NodeLabelArch and NodeLabelArchBeta specify the arch of a node
 	NodeLabelArch     = "kubernetes.io/arch"
 	NodeLabelArchBeta = "beta.kubernetes.io/arch"
 )
@@ -83,6 +83,11 @@ func NodeIsReady(node *api.Node) bool {
 	return false
 }
 
+// LabelMapFromNodeSelectorString constructs a map of labels from the label selector string specified in the command
+// line arguments.
+// Example input label selector strings:
+//   "kubernetes.io/arch=s390x,beta.kubernetes.io/arch=s390x"
+//   "kubernetes.io/arch=s390x,kubernetes.io/arch=arm64"
 func LabelMapFromNodeSelectorString(selector string) (map[string]set.Set, error) {
 	labelsMap := make(map[string]set.Set)
 
@@ -94,7 +99,7 @@ func LabelMapFromNodeSelectorString(selector string) (map[string]set.Set, error)
 	for _, label := range labels {
 		l := strings.Split(label, "=")
 		if len(l) != 2 {
-			return labelsMap, fmt.Errorf("invalid selector: %s", l)
+			return labelsMap, fmt.Errorf("invalid selector: %v", l)
 		}
 		key := strings.TrimSpace(l[0])
 		value := strings.TrimSpace(l[1])

--- a/pkg/discovery/util/node_util.go
+++ b/pkg/discovery/util/node_util.go
@@ -56,6 +56,16 @@ func GetNodeOSArch(node *api.Node) (os string, arch string) {
 	os = "unknown"
 	arch = "unknown"
 	labelsMap := node.ObjectMeta.Labels
+	defer func() {
+		if os == "unknown" {
+			glog.Warningf("Unable to parse os of node %s. Current labels %v. Missing labels %s.",
+				node.Name, labelsMap, strings.Join([]string{NodeLabelOS, NodeLabelOSBeta}, ","))
+		}
+		if arch == "unknown" {
+			glog.Warningf("Unable to parse arch of node %s. Current labels %v. Missing labels %s.",
+				node.Name, labelsMap, strings.Join([]string{NodeLabelArch, NodeLabelArchBeta}, ","))
+		}
+	}()
 	if len(labelsMap) == 0 {
 		return
 	}

--- a/pkg/kubeclient/cpufrequency.go
+++ b/pkg/kubeclient/cpufrequency.go
@@ -151,7 +151,7 @@ func (n *NodeCpuFrequencyGetter) GetFrequency(i iNodeCpuFrequencyGetter, nodeNam
 
 	pod, err := n.getJobsPod(jobName, namespace)
 	if err != nil {
-		return 0, fmt.Errorf("get popd for job %s/%s failed on node %s: %v", namespace, jobName, nodeName, err)
+		return 0, fmt.Errorf("get pod for job %s/%s failed on node %s: %v", namespace, jobName, nodeName, err)
 	}
 
 	return n.getCpuFreqFromPodLog(i, pod)

--- a/pkg/kubeclient/cpufrequency_test.go
+++ b/pkg/kubeclient/cpufrequency_test.go
@@ -1,0 +1,26 @@
+package kubeclient
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLinuxAmd64NodeCpuFrequencyGetter_ParseCpuFrequency(t *testing.T) {
+	jobLog := "cpu MHz\t\t: 2199.999"
+	getter := &LinuxAmd64NodeCpuFrequencyGetter{
+		NodeCpuFrequencyGetter: *NewNodeCpuFrequencyGetter(nil, "", ""),
+	}
+	cpuFreq, err := getter.ParseCpuFrequency(jobLog)
+	assert.Nil(t, err)
+	assert.Equal(t, 2199.999, cpuFreq)
+}
+
+func TestLinuxPpc64leNodeCpuFrequencyGetter_ParseCpuFrequency(t *testing.T) {
+	jobLog := "clock\t\t: 2500.000000MHz"
+	getter := &LinuxPpc64leNodeCpuFrequencyGetter{
+		NodeCpuFrequencyGetter: *NewNodeCpuFrequencyGetter(nil, "", ""),
+	}
+	cpuFreq, err := getter.ParseCpuFrequency(jobLog)
+	assert.Nil(t, err)
+	assert.Equal(t, 2500.0, cpuFreq)
+}

--- a/pkg/kubeclient/kubelet_client_test.go
+++ b/pkg/kubeclient/kubelet_client_test.go
@@ -1,6 +1,7 @@
 package kubeclient
 
 import (
+	set "github.com/deckarep/golang-set"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,7 +69,7 @@ func TestKubeletClientCacheNil(t *testing.T) {
 	kubeConf := &rest.Config{}
 	conf := NewKubeletConfig(kubeConf)
 
-	kc, _ := conf.Create(nil, "busybox", "", map[string]string{}, false)
+	kc, _ := conf.Create(nil, "busybox", "", map[string]set.Set{}, false)
 	entry := &CacheEntry{}
 	kc.cache["host_1"] = entry
 	assert.False(t, kc.HasCacheBeenUsed("host_1"))

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -5,8 +5,9 @@ import (
 	"math"
 	"strings"
 
+	set "github.com/deckarep/golang-set"
 	"github.com/golang/glog"
-	"github.com/turbonomic/kubeturbo/test/integration/framework"
+	. "github.com/onsi/ginkgo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
@@ -16,7 +17,6 @@ import (
 	kubeclientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 
-	. "github.com/onsi/ginkgo"
 	"github.com/turbonomic/kubeturbo/cmd/kubeturbo/app"
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery"
@@ -28,6 +28,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
 	kubeletclient "github.com/turbonomic/kubeturbo/pkg/kubeclient"
 	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
+	"github.com/turbonomic/kubeturbo/test/integration/framework"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
@@ -80,7 +81,7 @@ var _ = Describe("Discover Cluster", func() {
 			}
 
 			s := app.NewVMTServer()
-			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "", "busybox", map[string]string{}, true)
+			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "", "busybox", map[string]set.Set{}, true)
 
 			apiExtClient, err := apiextclient.NewForConfig(kubeConfig)
 			if err != nil {


### PR DESCRIPTION
## Intention

This PR supports running CPU frequency job on Power linux. The following changes/enhancements are made:

* `kubeturbo` will discover the OS and Arch of each node based on the [well known](https://kubernetes.io/docs/reference/labels-annotations-taints/) labels on that node.
* `kubeturbo` will log the OS and Arch info of each node during each full discovery.
* If `kubeturbo` needs to get CPU frequency by job, it will only run the job on a whitelist OS and Arch combinations.
* The `DefaultCpufreqJobExcludeNodeLabels` is removed.
* The `--cpufreq-job-exclude-node-labels` option has been enhanced to support multiple labels with the same key but different values.
* Implement interface, abstract type, and concrete types to handle job command and job output parsing of different os/arch.

## Implementation
* Implement interface `iNodeCpuFrequencyGetter`, abstract type `NodeCpuFrequencyGetter`, and concrete types `LinuxPpc64leNodeCpuFrequencyGetter` and `LinuxAmd64NodeCpuFrequencyGetter`. It is easy to extend and support other os/arch implementations in the future when needed.
* Implement the `GetNodeOSArch` method to parse os/arch from node label.
* Implement the helper function `KubeletClient.GetCpuFrequencyFromJob` which instantiates proper cpu frequency getter of a node based on os/arch of that node.
* Implement the utility function `LabelMapFromNodeSelectorString` to support exclusion labels with the same key but different values. For example, if user specifies 
`--cpufreq-job-exclude-node-labels="kubernetes.io/arch=s390x,kubernetes.io/arch=arm64"`, then both `s390x` and `arm64` node can be excluded (this is just an example, in practice this is not necessary as we only support two os/arch by default: `linux/amd64` and `linux/ppc64le`).

## Test
* Implement proper unit tests
* Build and deploy `kubeturbo` in an IBM Power Linux OCP cluster.
*  Check the log: 
```
I0811 18:10:14.523226       1 kubelet_client.go:306] Node rdr-instana-2-mon01-master-1 is running with linux/ppc64le.
...
I0811 18:10:14.523444       1 kubelet_client.go:306] Node rdr-instana-2-mon01-worker-0 is running with linux/ppc64le.
I0811 18:10:14.523517       1 kubelet_client.go:306] Node rdr-instana-2-mon01-master-0 is running with linux/ppc64le.
I0811 18:10:14.523576       1 kubelet_client.go:306] Node rdr-instana-2-mon01-master-2 is running with linux/ppc64le.
W0811 18:10:14.589974       1 kubelet_client.go:325] Failed to get CPU frequency for node rdr-instana-2-mon01-master-1 from kubelet: "https://192.168.26.12:10250/spec" was not found. Will try job based getter.
W0811 18:10:14.590079       1 kubelet_client.go:325] Failed to get CPU frequency for node rdr-instana-2-mon01-master-2 from kubelet: "https://192.168.26.108:10250/spec" was not found. Will try job based getter.
W0811 18:10:14.590479       1 kubelet_client.go:325] Failed to get CPU frequency for node rdr-instana-2-mon01-master-0 from kubelet: "https://192.168.26.127:10250/spec" was not found. Will try job based getter.
W0811 18:10:14.594946       1 kubelet_client.go:325] Failed to get CPU frequency for node rdr-instana-2-mon01-worker-0 from kubelet: "https://192.168.26.52:10250/spec" was not found. Will try job based getter.
I0811 18:10:20.674302       1 kubelet_client.go:388] CPU frequency of node rdr-instana-2-mon01-master-0: 2500 MHz
...
I0811 18:10:21.576702       1 kubelet_client.go:306] Node rdr-instana-2-mon01-worker-1 is running with linux/ppc64le.
W0811 18:10:21.579763       1 kubelet_client.go:325] Failed to get CPU frequency for node rdr-instana-2-mon01-worker-1 from kubelet: "https://192.168.26.207:10250/spec" was not found. Will try job based getter.
I0811 18:10:21.679130       1 kubelet_client.go:388] CPU frequency of node rdr-instana-2-mon01-master-1: 2500 MHz
I0811 18:10:21.685770       1 kubelet_client.go:388] CPU frequency of node rdr-instana-2-mon01-master-2: 2500 MHz
...
I0811 18:10:24.702581       1 kubelet_client.go:388] CPU frequency of node rdr-instana-2-mon01-worker-0: 2500 MHz
...
I0811 18:10:27.787162       1 kubelet_client.go:388] CPU frequency of node rdr-instana-2-mon01-worker-1: 2500 MHz
```
* **Before** the change, default `2000 MHz` is used 

  ![image](https://user-images.githubusercontent.com/10012486/129093883-2b9e9d3a-b0b0-4e4f-81bb-fa43f5880fa8.png)

* **After** the change, real `2500 MHz` is discovered

  ![image](https://user-images.githubusercontent.com/10012486/129094341-9418fb9d-a335-46f9-be8f-cc222d951a58.png)
