### PR TITLE
Exclude the unschedulable node taint from taints processor handling

### DIFF
--- a/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
@@ -77,7 +77,7 @@ func TestProcess(t *testing.T) {
 	entityDTOs := []*proto.EntityDTO{&dto1, &dto2, &dto3, &dto4, &dto5, &dto6, &dto7}
 	taintTolerationProcessor.Process(entityDTOs)
 
-	// Check entity DTOs for access commodities created from tatins and tolerations
+	// Check entity DTOs for access commodities created from taints and tolerations
 	checkPodEntity(t, &dto1, "node-1")
 	checkPodEntity(t, &dto2, "node-2")
 	checkPodEntity(t, &dto3, "node-3")
@@ -118,8 +118,14 @@ func (m *mockNodeAndPodGetter) GetAllPods() ([]*api.Pod, error) {
 }
 
 func TestGetTaintCollection(t *testing.T) {
-	taintCollection := getTaintCollection(nodes)
+	// The unschedulable taint with any effect should be skipped from the taints collection
+	// effectively resulting in no access commodity created for the same.
+	unschedulableNodeTaint1 := newTaint(unschedulableNodeTaintKey, "", api.TaintEffectNoSchedule)
+	unschedulableNodeTaint2 := newTaint(unschedulableNodeTaintKey, "", api.TaintEffectNoExecute)
+	nodes[string(n1.UID)].Spec.Taints = append(nodes[string(n1.UID)].Spec.Taints,
+		unschedulableNodeTaint1, unschedulableNodeTaint2)
 
+	taintCollection := getTaintCollection(nodes)
 	fmt.Printf("taintCollection: %++v", taintCollection)
 
 	if len(taintCollection) != 2 {


### PR DESCRIPTION
Fixes https://vmturbo.atlassian.net/browse/OM-74036

As part of the unschedulable node handling refactor in https://github.com/turbonomic/kubeturbo/pull/557 we removed the logic which earlier would use VMPM_ACCESS commodities named `schedulable` to ensure the pods on unschedulable nodes don't get moved out. We used flag `AvailableForPlacement` in place.
Post that change, if a node is marked unschedulable via a taint using key `node.kubernetes.io/unschedulable`, the taint processor treats it as any regular taint and still handles it the way it handles other taints, leading to the pods on the unschedulable node being moved out. This PR excludes this specific taint from be handled by taints processor.

Please note that there are couple of other taints k8s uses to mark similar conditions especially [use these to evict pods](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-based-evictions):
node.kubernetes.io/not-ready
node.kubernetes.io/unreachable
node.kubernetes.io/memory-pressure
node.kubernetes.io/disk-pressure
node.kubernetes.io/pid-pressure
node.kubernetes.io/network-unavailable
node.kubernetes.io/unschedulable
node.cloudprovider.kubernetes.io/uninitialized

We don't skip others the same way we skip `node.kubernetes.io/unschedulable` because:
1. All others except `node.kubernetes.io/unschedulable` are applied by k8s in situations which are problematic to the node and will mostly be used with effect `NoExecute` forcing eviction anyways.
2. If the evictions are not configured or a user or a user managed subsystem applies these with the effect  `NoSchedule`, its still beneficial for turbo to recommend the pod move out like any other normal taint applied on a node not tolerated by a pod on it.

*Tests performed*:
No pod move out generated with a node marked unschedulable
```
Irfans-MacBook-Pro:kubeturbo irfanurrehman$ ae2 get nodes
NAME                                STATUS                     ROLES    AGE    VERSION
ae-cluster2-master-gro-e0bce0d0b3   Ready                      master   437d   v1.16.3
ae-cluster2-node-group-6b6dc365c4   Ready                      <none>   437d   v1.16.3
ae-cluster2-node-group-8f961899c6   Ready,SchedulingDisabled   <none>   437d   v1.16.3
ae-cluster2-node-group-d37ee354b9   Ready                      <none>   437d   v1.16.3
ae-cluster2-node-group-d618c2418b   Ready                      <none>   437d   v1.16.3
```

![image](https://user-images.githubusercontent.com/10027921/129341931-a1e55705-75e4-45e9-8dba-0bef217de18b.png)
![image](https://user-images.githubusercontent.com/10027921/129341986-711240b9-d80f-4fb8-bd8b-d9c349783115.png)
