### PR TITLE
Remove the unnecessary go-md2man package

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -31,13 +31,6 @@ COPY licenses /licenses
 
 COPY Dockerfile /Dockerfile
 
-### Add md2man package
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    dnf install -y --setopt=tsflags=nodocs golang-github-cpuguy83-go-md2man && \
-    dnf clean all && \
-
-### help file markdown to man conversion
-    go-md2man -in /tmp/help.md -out /help.1
 
 ### Setup user for build execution and application runtime
 ENV APP_ROOT=/opt/turbonomic \


### PR DESCRIPTION
At Customer site, we see High Vulnerability reported over the binary go-md2man.
The binary itself is opened early on to comply with the openshift certificate, which I don't think it's critical.

Performed the regression test already and make sure everything works