### PR TITLE
Update go sdk dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20210727055052-ae95c7e5f800
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20210820114323-d54aadceaf9e
 )
 
 // k8s and relevant dependencies

--- a/go.sum
+++ b/go.sum
@@ -901,8 +901,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca h1:kWhxdWkGgeMNZQgZ+FQVFW0FEau2fHwraM7OGFug6Tw=
 github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20210727055052-ae95c7e5f800 h1:quw1HUsV9UzAC2ILnZdeSFyMASIixLz8BIkY/T4lHE4=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20210727055052-ae95c7e5f800/go.mod h1:nvHeonNsQf5hpCpfFxa/0SFaTIKjfZIPF9m5avqlI4s=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20210820114323-d54aadceaf9e h1:QNc9S/TUjH4O9Tv5F7aXq9x4QQWJL06WyssBK4A6vaM=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20210820114323-d54aadceaf9e/go.mod h1:nvHeonNsQf5hpCpfFxa/0SFaTIKjfZIPF9m5avqlI4s=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/go.sum
+++ b/go.sum
@@ -903,6 +903,8 @@ github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca h1:kWhxdWkGge
 github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20210727055052-ae95c7e5f800 h1:quw1HUsV9UzAC2ILnZdeSFyMASIixLz8BIkY/T4lHE4=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20210727055052-ae95c7e5f800/go.mod h1:nvHeonNsQf5hpCpfFxa/0SFaTIKjfZIPF9m5avqlI4s=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20210820114323-d54aadceaf9e h1:QNc9S/TUjH4O9Tv5F7aXq9x4QQWJL06WyssBK4A6vaM=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20210820114323-d54aadceaf9e/go.mod h1:nvHeonNsQf5hpCpfFxa/0SFaTIKjfZIPF9m5avqlI4s=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -604,7 +604,7 @@ github.com/thecodeteam/goscaleio/types/v1
 # github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
-# github.com/turbonomic/turbo-go-sdk v0.0.0-20210727055052-ae95c7e5f800
+# github.com/turbonomic/turbo-go-sdk v0.0.0-20210820114323-d54aadceaf9e
 ## explicit
 github.com/turbonomic/turbo-go-sdk/pkg
 github.com/turbonomic/turbo-go-sdk/pkg/builder


### PR DESCRIPTION
Update the go sdk dependency for https://github.com/turbonomic/turbo-go-sdk/pull/125