### PR TITLE
Filter out container CPU throttling samples when corresponding CPU limits do not match container spec VCPU capacity

### DIFF
--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -100,15 +100,23 @@ func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpecMetrics 
 		}
 		commSoldBuilder := sdkbuilder.NewCommodityDTOBuilder(commodityType)
 
-		// Aggregate container replicas utilization data.
-		// Note that the returned dataIntervalMs is not the real sampling interval because there could be multiple data
-		// points from container replicas discovered at the same time in one set of data samples. This is just a calculated
-		// equivalent interval between 2 data points to be fed into percentile based algorithm in Turbo server side.
-		// We don't need utilization data for VCPU Throttling and average aggregation strategies are not applicable.
 		if resourceType == metrics.VCPUThrottling {
+			// We don't need utilization data for VCPU Throttling and average aggregation strategies are not applicable.
 			typedUsed, ok := resourceMetrics.Used.([][]metrics.ThrottlingCumulative)
 			if ok {
-				aggregatedCap, aggregatedUsed, aggregatedPeak := aggregateThrottlingSamples(containerSpecMetrics.ContainerSpecId, typedUsed)
+				containerCPUMetrics, exists := containerSpecMetrics.ContainerMetrics[metrics.CPU]
+				if !exists {
+					glog.Errorf("CPU metrics do not exist in resource metrics for ContainerSpec %s", containerSpecMetrics.ContainerSpecId)
+					continue
+				}
+				// Get max container CPU value as containerSpec VCPU capacity which matches the logic in
+				// container_usage_data_aggregator#Aggregate
+				containerSpecVCPUCapacity := float64(0)
+				for _, containerVCPUCapacity := range containerCPUMetrics.Capacity {
+					containerSpecVCPUCapacity = math.Max(containerSpecVCPUCapacity, containerVCPUCapacity)
+				}
+				aggregatedCap, aggregatedUsed, aggregatedPeak :=
+					aggregateThrottlingSamples(containerSpecMetrics.ContainerSpecId, containerSpecVCPUCapacity, typedUsed)
 				commSoldBuilder.Capacity(aggregatedCap)
 				commSoldBuilder.Peak(aggregatedPeak)
 				commSoldBuilder.Used(aggregatedUsed)
@@ -117,6 +125,10 @@ func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpecMetrics 
 				glog.Warningf("Invalid throttling metrics type: expected: [][]metrics.ThrottlingCumulative, got: %T.", resourceMetrics.Used)
 			}
 		} else {
+			// Aggregate container replicas utilization data.
+			// Note that the returned dataIntervalMs is not the real sampling interval because there could be multiple data
+			// points from container replicas discovered at the same time in one set of data samples. This is just a calculated
+			// equivalent interval between 2 data points to be fed into percentile based algorithm in Turbo server side.
 			utilizationDataPoints, lastPointTimestamp, dataIntervalMs, err := builder.containerUtilizationDataAggregator.Aggregate(resourceMetrics)
 			if err != nil {
 				glog.Errorf("Error aggregating %s utilization data for ContainerSpec %s, %v",
@@ -161,10 +173,12 @@ func (builder *containerSpecDTOBuilder) getCommoditiesSold(containerSpecMetrics 
 // Throttled values is the percentage of overall throttled counter sum wrt the overall total counter sum
 // across all containers. Peak is the peak of peaks, ie. the peak of individual container peaks calculated
 // from diff of subsequent samples per container.
-func aggregateThrottlingSamples(containerSpecId string, samples [][]metrics.ThrottlingCumulative) (float64, float64, float64) {
+func aggregateThrottlingSamples(containerSpecId string, containerSpecVCPUCapacity float64, samples [][]metrics.ThrottlingCumulative) (float64, float64, float64) {
 	var throttledOverall, totalOverall, peakOverall float64
 	for _, singleContainerSamples := range samples {
-		containerThrottled, containerTotal, containerPeak, ok := aggregateContainerThrottlingSamples("", singleContainerSamples)
+		// Include container samples only if corresponding CPU limit is same as containerSpec VCPU capacity.
+		filteredContainerSamples := filterContainerThrottlingSamples(containerSpecId, singleContainerSamples, containerSpecVCPUCapacity)
+		containerThrottled, containerTotal, containerPeak, ok := aggregateContainerThrottlingSamples("", filteredContainerSamples)
 		if !ok {
 			// We don't have enough samples to calculate this value.
 			continue
@@ -185,4 +199,21 @@ func aggregateThrottlingSamples(containerSpecId string, samples [][]metrics.Thro
 	}
 
 	return 100, avgThrottledOverall, peakOverall
+}
+
+func filterContainerThrottlingSamples(containerSpecId string, singleContainerSamples []metrics.ThrottlingCumulative, containerSpecVCPUCapacity float64) []metrics.ThrottlingCumulative {
+	var filteredSamples []metrics.ThrottlingCumulative
+	for _, sample := range singleContainerSamples {
+		if int(math.Round(sample.CPULimits)) == int(math.Round(containerSpecVCPUCapacity)) {
+			filteredSamples = append(filteredSamples, sample)
+		} else if sample.CPULimits != 0 {
+			// Log a message only when CPU limit of container sample is not 0, which means CPU limit is defined for corresponding
+			// container.
+			// When CPU limit is not defined on a container, VCPU capacity is node VCPU capacity. We don't need to log
+			// such valid case.
+			glog.V(3).Infof("Container data sample with CPU limits %v collected at timestamp %v doesn't match VCPU capacity %v for ContainerSpec %s. Skip this data sample.",
+				sample.CPULimits, sample.Timestamp, containerSpecVCPUCapacity, containerSpecId)
+		}
+	}
+	return filteredSamples
 }

--- a/pkg/discovery/metrics/metric.go
+++ b/pkg/discovery/metrics/metric.go
@@ -212,6 +212,8 @@ type ThrottlingCumulative struct {
 	Throttled float64
 	// Cumulative total number of runnable periods for the resource
 	Total float64
+	// Container CPU limits when collecting this set of throttling metrics
+	CPULimits float64
 	// Time at which the metric value is collected
 	Timestamp int64
 }

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -162,33 +162,51 @@ func (m *KubeletMonitor) generateThrottlingMetrics(metricFamilies map[string]*dt
 	parsedMetrics := parseMetricFamilies(metricFamilies)
 	for metricID, tm := range parsedMetrics {
 		if tm != nil {
-			glog.V(4).Infof("Throttling Metrics for container: %s, cpuThrottled: %.3f, cpuTotal: %.3f.", metricID, tm.cpuThrottled, tm.cpuTotal)
-			m.genThrottlingMetrics(metrics.ContainerType, metricID, tm.cpuThrottled, tm.cpuTotal, timestamp)
+			glog.V(4).Infof("Throttling Metrics for container: %s, cpuThrottled: %.3f, cpuTotal: %.3f, cpuQuota: %.3f, cpuPeriod: %.3f",
+				metricID, tm.cpuThrottled, tm.cpuTotal, tm.cpuQuota, tm.cpuPeriod)
+			m.genThrottlingMetrics(metrics.ContainerType, metricID, tm, timestamp)
 		}
 	}
 }
 
 type throttlingMetric struct {
+	// container_cpu_cfs_throttled_periods_total
 	cpuThrottled float64
-	cpuTotal     float64
+	// container_cpu_cfs_periods_total
+	cpuTotal float64
+	// container_spec_cpu_quota
+	cpuQuota float64
+	// container_spec_cpu_period
+	cpuPeriod float64
 }
 
-// parseMetricFamilies parses the incoming prometheus format metric from two metric families
-// "container_cpu_cfs_throttled_periods_total" and "container_cpu_cfs_periods_total".
-// It deciphers the container id from the labels on the metric and merges the two for
+// parseMetricFamilies parses the incoming prometheus format metric from four metric families
+// "container_cpu_cfs_throttled_periods_total", "container_cpu_cfs_periods_total", "container_spec_cpu_quota"
+// and "container_spec_cpu_period".
+// It deciphers the container id from the labels on the metric and merges the four for
 // each container into "type throttlingMetric struct".
 // Example:
 // in:
+// # HELP container_cpu_cfs_periods_total Number of elapsed enforcement period intervals.
 // # TYPE container_cpu_cfs_periods_total counter
 // container_cpu_cfs_periods_total{container="metallb-speaker",id="/kubepods/pod8266a379-dd56-42f8-8af0-19fc0d8ea3af/8e1a2ff0f116c9d086af53cbd7430dced0e70fed104aea79e3891870564aed38",image="sha256:8c49f7de2c13b87026d7afb04f35494e5d9ce6b5eeeb7f8983d38e601d0ac910",name="k8s_metallb-speaker_metallb-speaker-m29mf_ccp_8266a379-dd56-42f8-8af0-19fc0d8ea3af_16",namespace="ccp",pod="metallb-speaker-m29mf"} 10 1616975907597
+// # HELP container_cpu_cfs_throttled_periods_total Number of throttled period intervals.
 // # TYPE container_cpu_cfs_throttled_periods_total counter
 // container_cpu_cfs_throttled_periods_total{container="metallb-speaker",id="/kubepods/pod8266a379-dd56-42f8-8af0-19fc0d8ea3af/8e1a2ff0f116c9d086af53cbd7430dced0e70fed104aea79e3891870564aed38",image="sha256:8c49f7de2c13b87026d7afb04f35494e5d9ce6b5eeeb7f8983d38e601d0ac910",name="k8s_metallb-speaker_metallb-speaker-m29mf_ccp_8266a379-dd56-42f8-8af0-19fc0d8ea3af_16",namespace="ccp",pod="metallb-speaker-m29mf"} 5 1616976197080
+// # HELP container_spec_cpu_quota CPU quota of the container.
+// # TYPE container_spec_cpu_quota gauge
+// container_spec_cpu_quota{container="metallb-speaker",id="/kubepods/pod8266a379-dd56-42f8-8af0-19fc0d8ea3af/8e1a2ff0f116c9d086af53cbd7430dced0e70fed104aea79e3891870564aed38",image="sha256:8c49f7de2c13b87026d7afb04f35494e5d9ce6b5eeeb7f8983d38e601d0ac910",name="k8s_metallb-speaker_metallb-speaker-m29mf_ccp_8266a379-dd56-42f8-8af0-19fc0d8ea3af_16",namespace="ccp",pod="metallb-speaker-m29mf"} 10000 1629775344665
+// # HELP container_spec_cpu_period CPU period of the container.
+// # TYPE container_spec_cpu_period gauge
+// container_spec_cpu_period{container="metallb-speaker",id="/kubepods/pod8266a379-dd56-42f8-8af0-19fc0d8ea3af/8e1a2ff0f116c9d086af53cbd7430dced0e70fed104aea79e3891870564aed38",image="sha256:8c49f7de2c13b87026d7afb04f35494e5d9ce6b5eeeb7f8983d38e601d0ac910",name="k8s_metallb-speaker_metallb-speaker-m29mf_ccp_8266a379-dd56-42f8-8af0-19fc0d8ea3af_16",namespace="ccp",pod="metallb-speaker-m29mf"} 100000 1629775404902
 //
 //out:
 // map[string]*throttlingMetric{
 //		"ccp/metallb-speaker-m29mf/metallb-speaker": {
 //			cpuThrottled: 5,
 //			cpuTotal:     10,
+//          cpuQuota:     10000,
+//          cpuPeriod:    100000,
 //		},
 //	}
 //
@@ -196,10 +214,10 @@ type throttlingMetric struct {
 func parseMetricFamilies(metricFamilies map[string]*dto.MetricFamily) map[string]*throttlingMetric {
 	parsed := make(map[string]*throttlingMetric)
 	for metricName, metricFamily := range metricFamilies {
-		if metricFamily.GetType() != dto.MetricType_COUNTER {
+		if metricFamily.GetType() != dto.MetricType_COUNTER && metricFamily.GetType() != dto.MetricType_GAUGE {
 			// We ideally should not land into this situation
-			glog.Warningf("Expected metrics type: %v, but received type: %v"+
-				"while parsing throttling metrics.", dto.MetricType_COUNTER, metricFamily.GetType())
+			glog.Warningf("Expected metrics type: %v or %v, but received type: %v"+
+				"while parsing throttling metrics.", dto.MetricType_COUNTER, dto.MetricType_GAUGE, metricFamily.GetType())
 			return parsed
 		}
 		for _, metric := range metricFamily.GetMetric() {
@@ -218,8 +236,9 @@ func parseMetricFamilies(metricFamilies map[string]*dto.MetricFamily) map[string
 				default:
 				}
 			}
-			if name == "" {
-				// This metric is for pod not container
+			if name == "" || name == "POD" {
+				// A metric with name as "" are for pod not container and a metric with name as "POD" is parent cgroup
+				// for this container and tracks stats for all the containers in the pod. Skip these metrics.
 				continue
 			}
 			metricID := fmt.Sprintf("%s/%s/%s", namespace, podName, name)
@@ -227,10 +246,18 @@ func parseMetricFamilies(metricFamilies map[string]*dto.MetricFamily) map[string
 			if !exists {
 				tm = &throttlingMetric{}
 			}
-			if metricName == kubeclient.ContainerCPUTotal {
-				tm.cpuTotal = metric.Counter.GetValue()
-			} else {
-				tm.cpuThrottled = metric.Counter.GetValue()
+			if metricFamily.GetType() == dto.MetricType_COUNTER {
+				if metricName == kubeclient.ContainerCPUTotal {
+					tm.cpuTotal = metric.Counter.GetValue()
+				} else {
+					tm.cpuThrottled = metric.Counter.GetValue()
+				}
+			} else if metricFamily.GetType() == dto.MetricType_GAUGE {
+				if metricName == kubeclient.ContainerCPUQuota {
+					tm.cpuQuota = metric.Gauge.GetValue()
+				} else {
+					tm.cpuPeriod = metric.Gauge.GetValue()
+				}
 			}
 			parsed[metricID] = tm
 		}
@@ -466,11 +493,16 @@ func (m *KubeletMonitor) parseContainerStats(pod *stats.PodStats, timestamp int6
 	return totalUsedCPU, totalUsedMem, allMetricsMissing
 }
 
-func (m *KubeletMonitor) genThrottlingMetrics(etype metrics.DiscoveredEntityType, key string, throttled, total float64, timestamp int64) {
+func (m *KubeletMonitor) genThrottlingMetrics(etype metrics.DiscoveredEntityType, key string, tm *throttlingMetric, timestamp int64) {
+	cpuLimits := float64(0)
+	if tm.cpuQuota != 0 && tm.cpuPeriod != 0 {
+		cpuLimits = tm.cpuQuota * 1000 / tm.cpuPeriod
+	}
 	metric := metrics.NewEntityResourceMetric(etype, key, metrics.VCPUThrottling, metrics.Used,
 		[]metrics.ThrottlingCumulative{{
-			Throttled: throttled,
-			Total:     total,
+			Throttled: tm.cpuThrottled,
+			Total:     tm.cpuTotal,
+			CPULimits: cpuLimits,
 			Timestamp: timestamp,
 		}})
 	m.metricSink.AddNewMetricEntries(metric)

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
@@ -284,6 +286,34 @@ func TestParseStats(t *testing.T) {
 	}
 }
 
+func TestGenThrottlingMetrics(t *testing.T) {
+	kubeletMonitorConf := &KubeletMonitorConfig{}
+	kubeletMonitor, _ := NewKubeletMonitor(kubeletMonitorConf, true)
+
+	throttlingMetric := &throttlingMetric{
+		cpuThrottled: 2,
+		cpuTotal:     10,
+		cpuQuota:     2000,
+		cpuPeriod:    10000,
+	}
+	metricID := "cpu_throttling_metric"
+	kubeletMonitor.genThrottlingMetrics(metrics.ContainerType, metricID, throttlingMetric, timestamp)
+	key := metrics.GenerateEntityResourceMetricUID(metrics.ContainerType, metricID, metrics.VCPUThrottling, metrics.Used)
+	metric, _ := kubeletMonitor.metricSink.GetMetric(key)
+	throttlingMetricValue, ok := metric.GetValue().([]metrics.ThrottlingCumulative)
+
+	assert.True(t, ok)
+	expectedThrottlingMetricValue := []metrics.ThrottlingCumulative{{
+		Throttled: 2,
+		Total:     10,
+		CPULimits: 200,
+		Timestamp: timestamp,
+	}}
+	if !reflect.DeepEqual(expectedThrottlingMetricValue, throttlingMetricValue) {
+		t.Errorf("genThrottlingMetrics() expected: %v, actual: %v", expectedThrottlingMetricValue, throttlingMetricValue)
+	}
+}
+
 func TestParseMetricFamilies(t *testing.T) {
 	// This sample is an actual metric copied from a live cluster to also document
 	// how an actual metric retrieved from kubelet would look like.
@@ -301,6 +331,18 @@ container_cpu_cfs_throttled_periods_total{container="",id="/kubepods/burstable/p
 container_cpu_cfs_throttled_periods_total{container="",id="/kubepods/pod8266a379-dd56-42f8-8af0-19fc0d8ea3af",image="",name="",namespace="ccp",pod="metallb-speaker-m29mf"} 38909 1616976189755
 container_cpu_cfs_throttled_periods_total{container="metallb-speaker",id="/kubepods/pod8266a379-dd56-42f8-8af0-19fc0d8ea3af/8e1a2ff0f116c9d086af53cbd7430dced0e70fed104aea79e3891870564aed38",image="sha256:8c49f7de2c13b87026d7afb04f35494e5d9ce6b5eeeb7f8983d38e601d0ac910",name="k8s_metallb-speaker_metallb-speaker-m29mf_ccp_8266a379-dd56-42f8-8af0-19fc0d8ea3af_16",namespace="ccp",pod="metallb-speaker-m29mf"} 5 1616976197080
 container_cpu_cfs_throttled_periods_total{container="node-exporter",id="/kubepods/burstable/pod278c96f7-c22a-466a-85ae-69f221705a38/6a79a7d41fcfb3347875e6bfa17a7c6daa7911ff42a0177906a2005b1e8ffa12",image="sha256:0e0218889c33b5fbb9e158d45ff6193c7c145b4ce3ec348045626cfa09f8331d",name="k8s_node-exporter_node-exporter-pmngv_lens-metrics_278c96f7-c22a-466a-85ae-69f221705a38_1",namespace="lens-metrics",pod="node-exporter-pmngv"} 15 1616976196348
+# HELP container_spec_cpu_quota CPU quota of the container.
+# TYPE container_spec_cpu_quota gauge
+container_spec_cpu_quota{container="",id="/kubepods/burstable/pod278c96f7-c22a-466a-85ae-69f221705a38",image="",name="",namespace="lens-metrics",pod="node-exporter-pmngv"} 20000 1616975920718
+container_spec_cpu_quota{container="",id="/kubepods/pod8266a379-dd56-42f8-8af0-19fc0d8ea3af",image="",name="",namespace="ccp",pod="metallb-speaker-m29mf"} 10000 1616976289754
+container_spec_cpu_quota{container="metallb-speaker",id="/kubepods/pod8266a379-dd56-42f8-8af0-19fc0d8ea3af/8e1a2ff0f116c9d086af53cbd7430dced0e70fed104aea79e3891870564aed38",image="sha256:8c49f7de2c13b87026d7afb04f35494e5d9ce6b5eeeb7f8983d38e601d0ac910",name="k8s_metallb-speaker_metallb-speaker-m29mf_ccp_8266a379-dd56-42f8-8af0-19fc0d8ea3af_16",namespace="ccp",pod="metallb-speaker-m29mf"} 10000 1629775344665
+container_spec_cpu_quota{container="node-exporter",id="/kubepods/burstable/pod278c96f7-c22a-466a-85ae-69f221705a38/6a79a7d41fcfb3347875e6bfa17a7c6daa7911ff42a0177906a2005b1e8ffa12",image="sha256:0e0218889c33b5fbb9e158d45ff6193c7c145b4ce3ec348045626cfa09f8331d",name="k8s_node-exporter_node-exporter-pmngv_lens-metrics_278c96f7-c22a-466a-85ae-69f221705a38_1",namespace="lens-metrics",pod="node-exporter-pmngv"} 20000 1616975915711
+# HELP container_spec_cpu_period CPU period of the container.
+# TYPE container_spec_cpu_period gauge
+container_spec_cpu_period{container="",id="/kubepods/burstable/pod278c96f7-c22a-466a-85ae-69f221705a38",image="",name="",namespace="lens-metrics",pod="node-exporter-pmngv"} 100000 1616975920718
+container_spec_cpu_period{container="",id="/kubepods/pod8266a379-dd56-42f8-8af0-19fc0d8ea3af",image="",name="",namespace="ccp",pod="metallb-speaker-m29mf"} 100000 1616976289754
+container_spec_cpu_period{container="metallb-speaker",id="/kubepods/pod8266a379-dd56-42f8-8af0-19fc0d8ea3af/8e1a2ff0f116c9d086af53cbd7430dced0e70fed104aea79e3891870564aed38",image="sha256:8c49f7de2c13b87026d7afb04f35494e5d9ce6b5eeeb7f8983d38e601d0ac910",name="k8s_metallb-speaker_metallb-speaker-m29mf_ccp_8266a379-dd56-42f8-8af0-19fc0d8ea3af_16",namespace="ccp",pod="metallb-speaker-m29mf"} 100000 1629775404902
+container_spec_cpu_period{container="node-exporter",id="/kubepods/burstable/pod278c96f7-c22a-466a-85ae-69f221705a38/6a79a7d41fcfb3347875e6bfa17a7c6daa7911ff42a0177906a2005b1e8ffa12",image="sha256:0e0218889c33b5fbb9e158d45ff6193c7c145b4ce3ec348045626cfa09f8331d",name="k8s_node-exporter_node-exporter-pmngv_lens-metrics_278c96f7-c22a-466a-85ae-69f221705a38_1",namespace="lens-metrics",pod="node-exporter-pmngv"} 100000 1616975915711
 `)
 	mfs, err := kubeclient.TextToThrottlingMetricFamilies(metricSample)
 	if err != nil {
@@ -320,20 +362,29 @@ func verifyParsedMetrics(t *testing.T, got map[string]*throttlingMetric) {
 	// type throttlingMetric struct {
 	// cpuThrottled float64
 	// cpuTotal     float64
+	// cpuQuota     float64
+	// cpuPeriod    float64
 	// }
 	// from the two separately reported metrics for each container.
-	// The parsing ignores the metrics with container names = ""
+	// The parsing ignores the metrics with container names = "" or "POD"
 	// These metrics are sum total of all containers for a pod.
 	expected := map[string]*throttlingMetric{
 		"ccp/metallb-speaker-m29mf/metallb-speaker": {
 			cpuThrottled: 5,
 			cpuTotal:     10,
+			cpuQuota:     10000,
+			cpuPeriod:    100000,
 		},
 		"lens-metrics/node-exporter-pmngv/node-exporter": {
 			cpuThrottled: 15,
 			cpuTotal:     20,
+			cpuQuota:     20000,
+			cpuPeriod:    100000,
 		},
 	}
+
+	// Returned throttlingMetrics only include 2 metrics
+	assert.Equal(t, 2, len(got))
 
 	for key, expectedMetrics := range expected {
 		gotMetrics, exists := got[key]

--- a/pkg/kubeclient/kubelet_client.go
+++ b/pkg/kubeclient/kubelet_client.go
@@ -45,6 +45,8 @@ const (
 
 	ContainerCPUThrottledTotal = "container_cpu_cfs_throttled_periods_total"
 	ContainerCPUTotal          = "container_cpu_cfs_periods_total"
+	ContainerCPUQuota          = "container_spec_cpu_quota"
+	ContainerCPUPeriod         = "container_spec_cpu_period"
 )
 
 type KubeHttpClientInterface interface {
@@ -291,6 +293,8 @@ func TextToThrottlingMetricFamilies(data []byte) (map[string]*dto.MetricFamily, 
 	metricFamilies := make(map[string]*dto.MetricFamily)
 	metricFamilies[ContainerCPUThrottledTotal] = parsed[ContainerCPUThrottledTotal]
 	metricFamilies[ContainerCPUTotal] = parsed[ContainerCPUTotal]
+	metricFamilies[ContainerCPUQuota] = parsed[ContainerCPUQuota]
+	metricFamilies[ContainerCPUPeriod] = parsed[ContainerCPUPeriod]
 
 	return metricFamilies, nil
 }


### PR DESCRIPTION
JIRA: https://vmturbo.atlassian.net/browse/OM-74062

# Intent
The intent is to properly collect container CPU throttling data samples on container spec by including only samples with same CPU limits as container spec capacity. This is to make sure the data samples sent to Turbo platform are correctly attached to corresponding CPU capacity, which will help drive proper VCPU resizing action results based on CPU throttling

# Problem
There was a ping-pong issue of VCPU resizing based on CPU throttling moving statistics. Corresponding containers kept resizing up and down between 2 values, which is not good.

A container in low CPU limits (500m) had very high CPU throttling. It was first resized up to 2200m and then resized up to 3000m. Afterwards, it was resized between 2200m and 3000m:
<img width="1721" alt="Screen Shot 2021-08-12 at 1 10 08 PM" src="https://user-images.githubusercontent.com/23689754/130654220-d3e624dc-7e59-42bd-94a8-c43d615ac75f.png">

Here're moving stats records:
```
statistic_records {
  entity_oid: 74083536599111
  throttling_record {
    ...
    capacity_records {
      vcpu_capacity: 2200
      last_sample_timestamp: 1628771698072
      sample_count: 42
      throttling_max_sample: 18.376645291933851
      throttling_fast_moving_average: 3.3498132213017553
      throttling_fast_moving_variance: 55.522075582729961
      throttling_slow_moving_average: 15.936646250332029
      throttling_slow_moving_variance: 39.1511103873128
    }
    capacity_records {
      vcpu_capacity: 3000
      last_sample_timestamp: 1628775297803
      sample_count: 54
      throttling_max_sample: 0.90144230769230771
      throttling_fast_moving_average: 0.021976738282271948
      throttling_fast_moving_variance: 0.016923339719339438
      throttling_slow_moving_average: 0.0036044069183694943
      throttling_slow_moving_variance: 0.0029061986192307908
    }
    active_vcpu_capacity: 3000
```

# Diagnosis
Noticed the moving statistics record when capacity is 2200 is the problem. From grafana dashboard above, there's no very high CPU throttling when capacity became 2200m and the high pike happened when capacity was low (500m). However moving averages are very high when `vcpu_capacity` is 2200.

Each main discover only discovers latest running containers so any changes on the containers within 2 discovery cycle should be fine. This issue could happen when rolling update happens during the main discovery on one replica or multiple replicas. For example container `foo2` (with CPU limits 2200 and low CPU throttling) starts but container `foo1` hasn't terminated yet (still running with CPU limits 500 and high throttling). ContainerSpec VCPU capacity would be 2200m in this case (largest CPU capacity of container replicas). In this case, we'll aggregate high throttling samples from container `foo1` to final CPU throttling usage of this container spec., which leads to high CPU throttling usage of this container spec although CPU throttling is pretty low with CPU limits 2200m.

# Solution
We should filter out the CPU throttling data samples when corresponding CPU limit is different from final ContainerSpec VCPU capacity.

1. In `kubelet_client.go`, collect "container_spec_cpu_quota" and "container_spec_cpu_period" from cadvisor.
2. In `kubelet_monitor.go`, parse, calculate and store CPU limits for each CPU throttling data sample by: `cpu_limits = 1000 * container_spec_cpu_quota / container_spec_cpu_period`
3. In `container_spec_entity_dto_builder.go`, when aggregating CPU throttling data, include only CPU throttling samples if corresponding CPU limit matches ContainerSpec VCPU capacity.
4. Added additional unit tests

# Testing Done
The issue can be easier to reproduce using multiple replicas.

## Environment
1. Kept 2 instances running with same version of Turbo XL server and added same kubeturbo target. One ran kubeturbo with the fix and the other didn't.
2. Set replicas of a ContainerSpec to 8 with low CPU limits (10m) which triggered high CPU throttling.
3. Update CPU limits in deployment to 300m, which resulted in low CPU throttling.
4. During the rolling update of this deployment, some pods were restarted with new CPU limits (300m) and others were still running old CPU limits (10m)
5. Manually triggered rediscovery on this target on both instances during the rolling update to make sure 2 instances collect same set of throttling data in kubeturbo
6. After the discovery, triggered broadcast on both instances and dumped throttling moving statistics data.

## Evidence
1. Moving statistics data without the fix:
```
statistic_records {
  entity_oid: 74101254870497
  throttling_record {
    capacity_records {
      vcpu_capacity: 10
      last_sample_timestamp: 1629775225876
      sample_count: 2
      throttling_max_sample: 85.580182529335076
      throttling_fast_moving_average: 84.265749276427641
      throttling_fast_moving_variance: 0.0060041834107298266
      throttling_slow_moving_average: 84.261577098565411
      throttling_slow_moving_variance: 0.000501141825574166
    }
    capacity_records {
      vcpu_capacity: 300
      last_sample_timestamp: 1629775529419
      sample_count: 1
      throttling_max_sample: 80.918097754293257
      throttling_fast_moving_average: 80.918097754293257
      throttling_fast_moving_variance: 0
      throttling_slow_moving_average: 80.918097754293257
      throttling_slow_moving_variance: 0
    }
    active_vcpu_capacity: 300
  }
}
```
where `moving_averages` are pretty high when `vcpu_capacity` is 300 (where throttling is supposed to be very low)

2. Moving statistics data with the fix:
```
statistic_records {
  entity_oid: 74103952674104
  throttling_record {
    capacity_records {
      vcpu_capacity: 10
      last_sample_timestamp: 1629775285661
      sample_count: 2
      throttling_max_sample: 84.314765694076044
      throttling_fast_moving_average: 84.308177416849389
      throttling_fast_moving_variance: 0.0070013798542989817
      throttling_slow_moving_average: 84.314215104739631
      throttling_slow_moving_variance: 0.00058511276246782091
    }
    capacity_records {
      vcpu_capacity: 300
      last_sample_timestamp: 1629775514734
      sample_count: 1
      throttling_max_sample: 0
      throttling_fast_moving_average: 0
      throttling_fast_moving_variance: 0
      throttling_slow_moving_average: 0
      throttling_slow_moving_variance: 0
    }
    active_vcpu_capacity: 300
  }
}
```
where `moving_averages` are very low when `vcpu_capacity` is 300, which is correct.

Furthermore, such log messages got printed with the fix:
```
I0823 23:25:13.707675   48517 container_spec_entity_dto_builder.go:214] Container data sample with CPU limits 10 collected at timestamp 1629775344665 doesn't match VCPU capacity 300 for ContainerSpec 82344272-0e46-41f5-a1bd-72406e6781fb/resize-up-low-cpu. Skip this data sample.
I0823 23:25:13.707830   48517 container_spec_entity_dto_builder.go:214] Container data sample with CPU limits 10 collected at timestamp 1629775404902 doesn't match VCPU capacity 300 for ContainerSpec 82344272-0e46-41f5-a1bd-72406e6781fb/resize-up-low-cpu. Skip this data sample.
I0823 23:25:13.707858   48517 container_spec_entity_dto_builder.go:214] Container data sample with CPU limits 10 collected at timestamp 1629775464646 doesn't match VCPU capacity 300 for ContainerSpec 82344272-0e46-41f5-a1bd-72406e6781fb/resize-up-low-cpu. Skip this data sample.
```