### PR TITLE
Update Go version to 1.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 go:
-  - 1.16.6
+  - 1.17
  
 go_import_path: github.com/turbonomic/kubeturbo
 

--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -431,9 +431,8 @@ func (s *VMTServer) startHttp() {
 // handleExit disconnects the tap service from Turbo service when Kubeturbo is shotdown
 func handleExit(disconnectFunc disconnectFromTurboFunc) { // k8sTAPService *kubeturbo.K8sTAPService) {
 	glog.V(4).Infof("*** Handling Kubeturbo Termination ***")
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan,
-		os.Interrupt,
 		syscall.SIGTERM,
 		syscall.SIGINT,
 		syscall.SIGQUIT,

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/deckarep/golang-set v1.7.1
 	github.com/openshift/client-go v0.0.0-20210409155308-a8e62c60e930
 	// openshift cluster api for cluster-api based node provision and suspend
 	// TODO (fix this): There are two observed problems here:

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/service/tap_service.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/service/tap_service.go
@@ -133,10 +133,9 @@ func (builder *TAPServiceBuilder) WithTurboCommunicator(commConfig *TurboCommuni
 		return builder
 	}
 	config := client.NewConfigBuilder(serverAddress).
-		BasicAuthentication(commConfig.OpsManagerUsername, commConfig.OpsManagerPassword).
+		BasicAuthentication(url.QueryEscape(commConfig.OpsManagerUsername), url.QueryEscape(commConfig.OpsManagerPassword)).
 		SetProxy(commConfig.ServerMeta.Proxy).
 		Create()
-	glog.V(4).Infof("The Turbo API client config authentication is: %s, %s", commConfig.OpsManagerUsername, commConfig.OpsManagerPassword)
 	glog.V(4).Infof("The Turbo API client config is create successfully: %v", config)
 	builder.tapService.turboClient, err = client.NewTurboClient(config)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,6 +183,7 @@ github.com/cyphar/filepath-securejoin
 ## explicit
 github.com/davecgh/go-spew/spew
 # github.com/deckarep/golang-set v1.7.1
+## explicit
 github.com/deckarep/golang-set
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go


### PR DESCRIPTION
This PR updates Go version to 1.17 to address security vulnerability [CVE-2021-29923](https://nvd.nist.gov/vuln/detail/CVE-2021-29923):

- Update go version to 1.17
- Update go module and vendor
- Make signal channel buffered to pass `make vet` check

After upgrading to Go 1.17, `make vet` reports:
```bash
$ make vet
# github.com/turbonomic/kubeturbo/cmd/kubeturbo/app
cmd/kubeturbo/app/kubeturbo_builder.go:435:2: misuse of unbuffered os.Signal channel as argument to signal.Notify
Makefile:53: recipe for target 'vet' failed
make: *** [vet] Error 2
The command "make vet" exited with 2.
```

According to the comments of `signal.Notify`, a buffered channel should be used:
```Go
// Package signal will not block sending to c: the caller must ensure
// that c has sufficient buffer space to keep up with the expected
// signal rate. For a channel used for notification of just one signal value,
// a buffer of size 1 is sufficient.
...
func Notify(c chan<- os.Signal, sig ...os.Signal) {
...
}
```

Setting a buffer size of 1 should be good enough for our use case, because we don't need to process multiple signals at the same time. As long as we receive one of the signals, `kubeturbo` will disconnect.

Also remove `os.Interrupt`, as it is the same as  `syscall.SIGINT`.