### PR TITLE
Fix the uuid parser for GKE

### DIFF
--- a/pkg/discovery/stitching/node_uuid.go
+++ b/pkg/discovery/stitching/node_uuid.go
@@ -164,7 +164,7 @@ Input GCE.k8s.Node info:
   spec:
     providerID: gce://turbonomic-eng/us-central1-a/gke-enlin-cluster-1-default-pool-b0f2516c-mrl0
 
- Output:  gcp::us-central1::VM::8108478110475488564
+ Output:  gcp::us-central1-a::VM::8108478110475488564
 */
 
 type gceNodeUUIDGetter struct {
@@ -197,16 +197,7 @@ func (gce *gceNodeUUIDGetter) GetUUID(node *api.Node) (string, error) {
 		return "", fmt.Errorf("Invalid")
 	}
 
-	//3. get region by remove the zone suffix
-	if len(parts[1]) < 2 {
-		glog.Errorf("Invalid zone Id: %v", providerId)
-		return "", fmt.Errorf("Invalid")
-	}
-
-	end := len(parts[1]) - 2
-	region := parts[1][0:end]
-
-	result := fmt.Sprintf(gceFormat, region, instanceId)
+	result := fmt.Sprintf(gceFormat, parts[1], instanceId)
 	return result, nil
 }
 


### PR DESCRIPTION
Intent:
New GCP Project probe has a different VM id format. When GCP Beta probe is retired and GCP Project is in use, K8s side should also be updated with the new VM id format(eg: "gcp::us-central1::VM::6482254384813016492" -> "gcp::us-central1-a::VM::6482254384813016492"). I looked at gceNodeUUIDGetter at node_uuid.go, and seems to me change might be - update concatenation for GCP VM id to use zone instead of region. 

Added unit test and confirmed on an appliance:
![Screen Shot 2021-09-08 at 3 10 58 PM](https://user-images.githubusercontent.com/4391815/132577354-be75d506-1f37-4ed8-8d9e-5a2940a4b9e4.png)

