### PR TITLE
Error backoff for busybox cpufreq job

### DIFF
--- a/pkg/kubeclient/cpufrequency.go
+++ b/pkg/kubeclient/cpufrequency.go
@@ -26,7 +26,7 @@ import (
 const (
 	kubeturboNamespaceEnv = "KUBETURBO_NAMESPACE"
 	defaultNamespace      = "default"
-	defaultCpuFreq        = float64(2000) //MHz
+	defaultCpuFreq        = float64(2600) //MHz
 	// cpufreq job by default is created every 10 mins
 	// if there has been failures, a backoff delay would be added to retrials
 	defaultInitialDelay = 10 * time.Minute

--- a/pkg/kubeclient/cpufrequency.go
+++ b/pkg/kubeclient/cpufrequency.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -26,6 +27,9 @@ const (
 	kubeturboNamespaceEnv = "KUBETURBO_NAMESPACE"
 	defaultNamespace      = "default"
 	defaultCpuFreq        = float64(2000) //MHz
+	// cpufreq job by default is created every 10 mins
+	// if there has been failures, a backoff delay would be added to retrials
+	defaultInitialDelay = 10 * time.Minute
 )
 
 var (
@@ -47,6 +51,39 @@ type NodeCpuFrequencyGetter struct {
 	kubeClient      *kubernetes.Clientset
 	busyboxImage    string
 	imagePullSecret string
+	backoffFailures map[string]*backoffFailure
+}
+
+type backoffFailure struct {
+	// Number of times job failed since last success or since start
+	failedTimes float64
+	// Last failure timestamp
+	lastTimestamp time.Time
+	initialDelay  time.Duration
+}
+
+func newBackoff(delay time.Duration) *backoffFailure {
+	return &backoffFailure{initialDelay: delay}
+}
+
+// Each failure would add a 2 exponent times initialDelay to backoff
+// Any backoff call before that would return true meaning "back off"
+func (b *backoffFailure) backoff() bool {
+	return !b.lastTimestamp.IsZero() &&
+		b.lastTimestamp.Add(time.Duration(math.Pow(2,
+			b.failedTimes))*b.initialDelay).After(time.Now())
+}
+
+func (b *backoffFailure) setFailure() {
+	if b.lastTimestamp.IsZero() {
+		b.lastTimestamp = time.Now()
+	}
+	b.failedTimes++
+}
+
+func (b *backoffFailure) reset() {
+	b.lastTimestamp = time.Time{}
+	b.failedTimes = 0
 }
 
 // LinuxAmd64NodeCpuFrequencyGetter is a concrete type that embeds the NodeCpuFrequencyGetter and implements
@@ -117,6 +154,7 @@ func NewNodeCpuFrequencyGetter(kubeClient *kubernetes.Clientset, busyboxImage, i
 		kubeClient:      kubeClient,
 		busyboxImage:    busyboxImage,
 		imagePullSecret: imagePullSecret,
+		backoffFailures: make(map[string]*backoffFailure),
 	}
 }
 
@@ -125,14 +163,32 @@ func NewNodeCpuFrequencyGetter(kubeClient *kubernetes.Clientset, busyboxImage, i
 func (n *NodeCpuFrequencyGetter) GetFrequency(i iNodeCpuFrequencyGetter, nodeName string) (float64, error) {
 	glog.V(4).Infof("Start query node frequency via pod for %s.", nodeName)
 
+	backoff, exists := n.backoffFailures[nodeName]
+	if !exists {
+		n.backoffFailures[nodeName] = newBackoff(defaultInitialDelay)
+		backoff = n.backoffFailures[nodeName]
+	}
+	if backoff.backoff() {
+		return 0, fmt.Errorf("backoff getting node cpu freq for: %s", nodeName)
+	}
+
 	// TODO: See if retries are needed
 	namespace := os.Getenv(kubeturboNamespaceEnv)
 	if namespace == "" {
 		namespace = defaultNamespace
 	}
 
+	failed := false
+	defer func() {
+		if failed {
+			backoff.setFailure()
+		} else {
+			backoff.reset()
+		}
+	}()
 	job, err := n.createJob(i, namespace, nodeName)
 	if err != nil {
+		failed = true
 		return 0, err
 	}
 
@@ -146,15 +202,22 @@ func (n *NodeCpuFrequencyGetter) GetFrequency(i iNodeCpuFrequencyGetter, nodeNam
 
 	err = n.waitForJob(jobName, namespace)
 	if err != nil {
+		failed = true
 		return 0, fmt.Errorf("wait for job %s/%s failed on node %s: %v", namespace, jobName, nodeName, err)
 	}
 
 	pod, err := n.getJobsPod(jobName, namespace)
 	if err != nil {
+		failed = true
 		return 0, fmt.Errorf("get pod for job %s/%s failed on node %s: %v", namespace, jobName, nodeName, err)
 	}
 
-	return n.getCpuFreqFromPodLog(i, pod)
+	cpufreq, err := n.getCpuFreqFromPodLog(i, pod)
+	if err != nil {
+		failed = true
+		return 0, err
+	}
+	return cpufreq, nil
 }
 
 func (n *NodeCpuFrequencyGetter) getCpuFreqFromPodLog(i iNodeCpuFrequencyGetter, pod *corev1.Pod) (float64, error) {

--- a/pkg/kubeclient/cpufrequency_test.go
+++ b/pkg/kubeclient/cpufrequency_test.go
@@ -1,8 +1,11 @@
 package kubeclient
 
 import (
-	"github.com/stretchr/testify/assert"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLinuxAmd64NodeCpuFrequencyGetter_ParseCpuFrequency(t *testing.T) {
@@ -23,4 +26,56 @@ func TestLinuxPpc64leNodeCpuFrequencyGetter_ParseCpuFrequency(t *testing.T) {
 	cpuFreq, err := getter.ParseCpuFrequency(jobLog)
 	assert.Nil(t, err)
 	assert.Equal(t, 2500.0, cpuFreq)
+}
+
+func TestBackoffFailures(t *testing.T) {
+	type failedTimes int
+	type testCase struct {
+		checkAfter    time.Duration // incremental sleep for each next check
+		shouldBackoff bool
+	}
+	testCaseMap := map[failedTimes][]testCase{
+		0: { // No backoff anytime
+			{checkAfter: 10 * time.Millisecond, shouldBackoff: false},
+			{checkAfter: 100 * time.Millisecond, shouldBackoff: false},
+			{checkAfter: 200 * time.Millisecond, shouldBackoff: false},
+		},
+		1: { // Backoff till 2 exponent 1 times 100ms = 200ms
+			{checkAfter: 0 * time.Millisecond, shouldBackoff: true},
+			{checkAfter: 100 * time.Millisecond, shouldBackoff: true},
+			{checkAfter: 200 * time.Millisecond, shouldBackoff: false},
+		},
+		2: { // Backoff till 2 exponent 2 times 100ms = 400ms
+			{checkAfter: 0 * time.Millisecond, shouldBackoff: true},
+			{checkAfter: 100 * time.Millisecond, shouldBackoff: true},
+			{checkAfter: 200 * time.Millisecond, shouldBackoff: true},
+			{checkAfter: 200 * time.Millisecond, shouldBackoff: false},
+		},
+		4: { // Backoff till 2 exponent 4 times 100ms = 1600ms
+			{checkAfter: 0 * time.Millisecond, shouldBackoff: true},     //t0
+			{checkAfter: 400 * time.Millisecond, shouldBackoff: true},   //t0+400
+			{checkAfter: 800 * time.Millisecond, shouldBackoff: true},   //t0+400+400
+			{checkAfter: 1800 * time.Millisecond, shouldBackoff: false}, //t0+400+400+1000
+		},
+	}
+
+	checkDuration := 100 * time.Millisecond
+	var wg sync.WaitGroup
+	for failures, tests := range testCaseMap {
+		wg.Add(1)
+		go func(failures failedTimes, tests []testCase) {
+			backoff := newBackoff(checkDuration)
+			for i := failures; i > 0; i-- {
+				backoff.setFailure()
+			}
+			for index, test := range tests {
+				time.Sleep(test.checkAfter)
+				b := backoff.backoff()
+				assert.Equal(t, test.shouldBackoff, b,
+					"Failed at index: %d for failure times: %d check at %v\n", index, failures, time.Now())
+			}
+			wg.Done()
+		}(failures, tests)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Implements https://vmturbo.atlassian.net/browse/OM-75517

~~Am running long running tests with an actual kubeturbo run with a failing cpu freq job, will post the results.~~
The backoff works as expected. Kubeturbo logs (filtered) below:

_Please note that the start timeout for backoff is 10 mins, and backoff delay is calculated`(2 exponent failure) * start timeout`.
Although we have kept the backoff initial timeout to be 10 mins, the delays might not exactly sync with the discovery timeout. For example a discovery (1st) was forced from server at t0, starting backoff time, next discovery (2nd) automatically triggerred from server at t0+5 mins, backoff would kick in (assuming the the job did fail at t0 the first time it was tried) at 2nd discovery (so no job would be created), at t0+15 (3rd discovery) the backoff would still kick in (2 exp 1 * 10min = 20 min).. at 4th discovery the job would be created again. (and so on)_

_Some logs in between are missing because of kubeturbo logs rollover_

```
Irfans-MacBook-Pro:build irfanurrehman$ knew logs -f  kubeturbo-7454c99c7b-zxcfl -n irf --tail=100 |grep "backoff getting node cpu freq for"
E0920 03:25:35.054094       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-1: backoff getting node cpu freq for: pt-k8s-master-1.
E0920 03:25:35.054178       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-1: backoff getting node cpu freq for: pt-k8s-node-1.
E0920 03:25:35.054266       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-2: backoff getting node cpu freq for: pt-k8s-master-2.
E0920 03:25:35.058779       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-3: backoff getting node cpu freq for: pt-k8s-master-3.
E0920 03:25:35.578610       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-2: backoff getting node cpu freq for: pt-k8s-node-2.
E0920 03:25:35.593091       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-3: backoff getting node cpu freq for: pt-k8s-node-3.
E0920 03:35:35.005193       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-1: backoff getting node cpu freq for: pt-k8s-node-1.
E0920 03:35:35.006457       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-3: backoff getting node cpu freq for: pt-k8s-master-3.
E0920 03:35:35.006803       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-2: backoff getting node cpu freq for: pt-k8s-master-2.
E0920 03:35:35.007142       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-1: backoff getting node cpu freq for: pt-k8s-master-1.
E0920 03:35:35.415159       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-2: backoff getting node cpu freq for: pt-k8s-node-2.
E0920 03:35:35.495575       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-3: backoff getting node cpu freq for: pt-k8s-node-3.
....
....
....
E0920 03:55:35.264773       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-1: backoff getting node cpu freq for: pt-k8s-master-1.
E0920 03:55:35.265672       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-1: backoff getting node cpu freq for: pt-k8s-node-1.
E0920 03:55:35.265851       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-3: backoff getting node cpu freq for: pt-k8s-master-3.
E0920 03:55:35.266453       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-2: backoff getting node cpu freq for: pt-k8s-master-2.
E0920 03:55:36.288965       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-2: backoff getting node cpu freq for: pt-k8s-node-2.
E0920 03:55:36.293243       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-3: backoff getting node cpu freq for: pt-k8s-node-3.
E0920 04:15:35.059584       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-2: backoff getting node cpu freq for: pt-k8s-master-2.
E0920 04:15:35.059611       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-1: backoff getting node cpu freq for: pt-k8s-node-1.
E0920 04:15:35.059725       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-3: backoff getting node cpu freq for: pt-k8s-master-3.
E0920 04:15:35.059918       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-1: backoff getting node cpu freq for: pt-k8s-master-1.
E0920 04:15:35.492718       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-2: backoff getting node cpu freq for: pt-k8s-node-2.
E0920 04:15:35.605262       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-3: backoff getting node cpu freq for: pt-k8s-node-3.
E0920 04:25:35.045004       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-1: backoff getting node cpu freq for: pt-k8s-node-1.
E0920 04:25:35.045320       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-1: backoff getting node cpu freq for: pt-k8s-master-1.
E0920 04:25:35.049848       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-3: backoff getting node cpu freq for: pt-k8s-master-3.
E0920 04:25:35.053939       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-2: backoff getting node cpu freq for: pt-k8s-master-2.
E0920 04:25:35.478694       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-2: backoff getting node cpu freq for: pt-k8s-node-2.
E0920 04:25:35.510993       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-3: backoff getting node cpu freq for: pt-k8s-node-3.
E0920 04:35:34.944198       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-2: backoff getting node cpu freq for: pt-k8s-master-2.
E0920 04:35:34.944592       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-1: backoff getting node cpu freq for: pt-k8s-master-1.
E0920 04:35:34.945226       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-1: backoff getting node cpu freq for: pt-k8s-node-1.
E0920 04:35:34.945328       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-3: backoff getting node cpu freq for: pt-k8s-master-3.
E0920 04:35:35.375627       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-2: backoff getting node cpu freq for: pt-k8s-node-2.
E0920 04:35:35.382899       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-3: backoff getting node cpu freq for: pt-k8s-node-3.
...
...
...
E0920 05:05:34.929819       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-1: backoff getting node cpu freq for: pt-k8s-node-1.
E0920 05:05:34.931330       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-2: backoff getting node cpu freq for: pt-k8s-master-2.
E0920 05:05:34.931505       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-3: backoff getting node cpu freq for: pt-k8s-master-3.
E0920 05:05:34.931386       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-1: backoff getting node cpu freq for: pt-k8s-master-1.
E0920 05:05:35.413885       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-2: backoff getting node cpu freq for: pt-k8s-node-2.
E0920 05:05:35.417520       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-3: backoff getting node cpu freq for: pt-k8s-node-3.
E0920 05:15:35.036661       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-2: backoff getting node cpu freq for: pt-k8s-master-2.
E0920 05:15:35.036679       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-1: backoff getting node cpu freq for: pt-k8s-node-1.
E0920 05:15:35.036867       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-3: backoff getting node cpu freq for: pt-k8s-master-3.
E0920 05:15:35.037037       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-1: backoff getting node cpu freq for: pt-k8s-master-1.
E0920 05:15:35.541940       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-2: backoff getting node cpu freq for: pt-k8s-node-2.
E0920 05:15:35.563133       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-3: backoff getting node cpu freq for: pt-k8s-node-3.
E0920 05:25:34.949724       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-3: backoff getting node cpu freq for: pt-k8s-master-3.
E0920 05:25:34.950326       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-1: backoff getting node cpu freq for: pt-k8s-master-1.
E0920 05:25:34.950460       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-1: backoff getting node cpu freq for: pt-k8s-node-1.
E0920 05:25:34.951783       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-2: backoff getting node cpu freq for: pt-k8s-master-2.
E0920 05:25:35.500569       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-2: backoff getting node cpu freq for: pt-k8s-node-2.
E0920 05:25:35.578428       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-3: backoff getting node cpu freq for: pt-k8s-node-3.
E0920 05:35:35.002711       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-3: backoff getting node cpu freq for: pt-k8s-master-3.
E0920 05:35:35.003163       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-1: backoff getting node cpu freq for: pt-k8s-node-1.
E0920 05:35:35.014996       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-1: backoff getting node cpu freq for: pt-k8s-master-1.
E0920 05:35:35.016095       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-master-2: backoff getting node cpu freq for: pt-k8s-master-2.
E0920 05:35:35.415165       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-2: backoff getting node cpu freq for: pt-k8s-node-2.
E0920 05:35:35.433298       1 kubelet_client.go:393] Failed to get CPU frequency from job on node pt-k8s-node-3: backoff getting node cpu freq for: pt-k8s-node-3.
``` 