### PR TITLE
Openshift machinesets as nodepools

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -192,7 +192,9 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.DiscoverySampleIntervalSec, "discovery-sample-interval", DefaultDiscoverySampleIntervalSec, "The discovery interval in seconds to collect additional resource usage data samples from kubelet. This should be no smaller than 10 seconds.")
 	fs.IntVar(&s.GCIntervalMin, "garbage-collection-interval", DefaultGCIntervalMin, "The garbage collection interval in minutes for possible leaked pods from actions failed because of kubeturbo restarts. Default value is 20 mins.")
 	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=* to allow all.")
-	fs.StringVar(&s.ClusterAPINamespace, "cluster-api-namespace", "default", "The Cluster API namespace.")
+	// So far we have noticed cluster api support only in openshift clusters and our implementation works only for openshift
+	// It thus makes sense to have openshifts machine api namespace as our default cluster api namespace
+	fs.StringVar(&s.ClusterAPINamespace, "cluster-api-namespace", "openshift-machine-api", "The Cluster API namespace.")
 	fs.StringVar(&s.BusyboxImage, "busybox-image", "busybox", "The complete image uri used for fallback node cpu frequency getter job.")
 	fs.StringVar(&s.BusyboxImagePullSecret, "busybox-image-pull-secret", "", "The name of the secret that stores the image pull credentials for busybox image.")
 	fs.StringVar(&s.CpufreqJobExcludeNodeLabels, "cpufreq-job-exclude-node-labels", "", "The comma separated list of key=value node label pairs for the nodes (for example windows nodes) to be excluded from running job based cpufrequency getter.")

--- a/pkg/action/action_handler_test.go
+++ b/pkg/action/action_handler_test.go
@@ -115,7 +115,8 @@ func newActionHandlerConfig() *ActionHandlerConfig {
 	config := &ActionHandlerConfig{}
 
 	config.StopEverything = make(chan struct{})
-	config.clusterScraper = cluster.NewClusterScraper(&client.Clientset{}, nil)
+	config.clusterScraper = cluster.NewClusterScraper(&client.Clientset{}, nil,
+		false, nil, "")
 	config.kubeletClient = &kubeclient.KubeletClient{}
 
 	return config

--- a/pkg/discovery/dtofactory/node_pools_group_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_pools_group_dto_builder.go
@@ -62,6 +62,10 @@ func (builder *NodePoolsGroupDTOBuilder) getNodePools() map[string][]string {
 		}
 	}
 
+	for capiMachineSetPoolName, nodeUIDs := range builder.cluster.MachineSetToNodeUIDsMap {
+		nodePools[capiMachineSetPoolName] = nodeUIDs
+	}
+
 	if glog.V(3) {
 		for poolName, nodes := range nodePools {
 			glog.Infof("%s: %s", poolName, nodes)

--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -149,7 +149,8 @@ func TestGenNodeResourceMetrics(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to create clusterMonitor: %v", err)
 	}
-	clusterMonitor.clusterClient = cluster.NewClusterScraper(&client.Clientset{}, nil)
+	clusterMonitor.clusterClient = cluster.NewClusterScraper(&client.Clientset{}, nil,
+		false, nil, "")
 	clusterMonitor.sink = metrics.NewEntityMetricSink()
 	clusterMonitor.nodeList = []*api.Node{node}
 	clusterMonitor.nodePodMap = make(map[string][]*api.Pod)

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -170,7 +170,8 @@ func (p *ClusterProcessor) DiscoverCluster() (*repository.ClusterSummary, error)
 	}
 	glog.V(2).Infof("Discovering cluster with %d nodes and %d pods.", len(nodeList), len(podList))
 	// Create kubeCluster and compute cluster resource
-	kubeCluster := repository.NewKubeCluster(svcID, nodeList).WithPods(podList)
+	kubeCluster := repository.NewKubeCluster(svcID, nodeList).WithPods(podList).
+		WithMachineSetToNodeUIDsMap(p.clusterInfoScraper.GetMachineSetToNodeUIDsMap(nodeList))
 
 	// Discover Namespaces and Quotas
 	NewNamespaceProcessor(p.clusterInfoScraper, kubeCluster).ProcessNamespaces()

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -281,7 +281,8 @@ type MockClusterScrapper struct {
 	mockGetKubernetesServiceID func() (svcID string, err error)
 	mockGetAllPVs              func() ([]*v1.PersistentVolume, error)
 	mockGetAllPVCs             func() ([]*v1.PersistentVolumeClaim, error)
-	mockGetResources           func(schema.GroupVersionResource) (*unstructured.UnstructuredList, error)
+	//mockGetResources               func(schema.GroupVersionResource) (*unstructured.UnstructuredList, error)
+	//mockGetMachineSetToNodeUIDsMap func(nodes []*v1.Node) map[string][]string
 }
 
 func (s *MockClusterScrapper) GetAllNodes() ([]*v1.Node, error) {
@@ -353,6 +354,10 @@ func (s *MockClusterScrapper) GetAllPVCs() ([]*v1.PersistentVolumeClaim, error) 
 
 func (s *MockClusterScrapper) GetResources(schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
 	return &unstructured.UnstructuredList{}, nil
+}
+
+func (s *MockClusterScrapper) GetMachineSetToNodeUIDsMap(nodes []*v1.Node) map[string][]string {
+	return make(map[string][]string)
 }
 
 // Implements the KubeHttpClientInterface

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -36,6 +36,10 @@ type KubeCluster struct {
 	K8sAppToComponentMap map[K8sApp][]K8sAppComponent
 	ComponentToAppMap    map[K8sAppComponent][]K8sApp
 	ControllerMap        map[string]*K8sController
+
+	// Map listing parent machineSet name for each nodename
+	// This will be filled only if openshift clusterapi is enabled
+	MachineSetToNodeUIDsMap map[string][]string
 }
 
 func NewKubeCluster(clusterName string, nodes []*v1.Node) *KubeCluster {
@@ -49,6 +53,11 @@ func NewKubeCluster(clusterName string, nodes []*v1.Node) *KubeCluster {
 
 func (kc *KubeCluster) WithPods(pods []*v1.Pod) *KubeCluster {
 	kc.Pods = pods
+	return kc
+}
+
+func (kc *KubeCluster) WithMachineSetToNodeUIDsMap(machineSetToNodeUIDsMap map[string][]string) *KubeCluster {
+	kc.MachineSetToNodeUIDsMap = machineSetToNodeUIDsMap
 	return kc
 }
 

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -128,7 +128,7 @@ func createProbeConfigOrDie(c *Config) *configs.ProbeConfig {
 	kubeletMonitoringConfig := kubelet.NewKubeletMonitorConfig(c.KubeletClient, c.KubeClient)
 
 	// Create cluster monitoring
-	clusterScraper := cluster.NewClusterScraper(c.KubeClient, c.DynamicClient)
+	clusterScraper := cluster.NewClusterScraper(c.KubeClient, c.DynamicClient, c.clusterAPIEnabled, c.CAClient, c.CAPINamespace)
 	masterMonitoringConfig := master.NewClusterMonitorConfig(clusterScraper)
 
 	// TODO for now kubelet is the only monitoring source. As we have more sources, we should choose what to be added into the slice here.

--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -57,7 +57,7 @@ var _ = Describe("Action Executor ", func() {
 			}
 
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(kubeClient, dynamicClient), []string{"*"}, nil, false, true)
+				cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, ""), []string{"*"}, nil, false, true)
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 		}
 		namespace = f.TestNamespaceName()

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -246,7 +246,7 @@ func assertCommoditySame(commI, commJ *proto.CommodityDTO, entityDTO *proto.Enti
 
 func createProbeConfigOrDie(kubeClient *kubeclientset.Clientset, kubeletClient *kubeletclient.KubeletClient, dynamicClient dynamic.Interface) *configs.ProbeConfig {
 	kubeletMonitoringConfig := kubelet.NewKubeletMonitorConfig(kubeletClient, kubeClient)
-	clusterScraper := cluster.NewClusterScraper(kubeClient, dynamicClient)
+	clusterScraper := cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, "")
 	masterMonitoringConfig := master.NewClusterMonitorConfig(clusterScraper)
 	monitoringConfigs := []monitoring.MonitorWorkerConfig{
 		kubeletMonitoringConfig,

--- a/test/integration/pod_move_with_quota.go
+++ b/test/integration/pod_move_with_quota.go
@@ -76,7 +76,7 @@ spec:
 			}
 
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(kubeClient, dynamicClient), []string{"*"}, nil, false, true)
+				cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, ""), []string{"*"}, nil, false, true)
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 
 			namespace = f.TestNamespaceName()
@@ -115,7 +115,7 @@ spec:
 
 		It("should fail the action if the quota-update is disabled", func() {
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(kubeClient, dynamicClient), []string{"*"}, nil, false, false)
+				cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, ""), []string{"*"}, nil, false, false)
 			actionHandler := action.NewActionHandler(actionHandlerConfig)
 
 			quota := createQuota(kubeClient, namespace, quotaFromYaml(quotaYaml))


### PR DESCRIPTION
~~I have marked this as wip as this is on top of #607.
Once #607 is concluded and merged, I will rebase this, remove the WIP and post the overall testing results.
The last commit here but can certainly be reviewed.~~

This PR implements https://vmturbo.atlassian.net/browse/OM-75818.
The PR detects if the cluster API is enabled and if it is enabled creates nodegroups from discovered machinesets.

Test details from nodepools created on ocp 4.7 cluster:

There is 1 `machineset` with 6 `machines` managed by it.
There are 3 other machines not contolled by a machineset (control plane machines).

```
Irfans-MacBook-Pro:kubeturbo irfanurrehman$ ocp47 get machinesets -n openshift-machine-api
NAME                                DESIRED   CURRENT   READY   AVAILABLE   AGE
ocp47demo-2v5jc-worker-us-east-2a   6         6         6       6           206d
Irfans-MacBook-Pro:kubeturbo irfanurrehman$ ocp47 get machines -n openshift-machine-api
NAME                                      PHASE     TYPE         REGION      ZONE         AGE
ocp47demo-2v5jc-master-0                  Running   m5.xlarge    us-east-2   us-east-2a   206d
ocp47demo-2v5jc-master-1                  Running   m5.xlarge    us-east-2   us-east-2a   206d
ocp47demo-2v5jc-master-2                  Running   m5.xlarge    us-east-2   us-east-2a   206d
ocp47demo-2v5jc-worker-us-east-2a-ctc7p   Running   m5.2xlarge   us-east-2   us-east-2a   25d
ocp47demo-2v5jc-worker-us-east-2a-k9966   Running   m5.2xlarge   us-east-2   us-east-2a   206d
ocp47demo-2v5jc-worker-us-east-2a-lx9sd   Running   m5.2xlarge   us-east-2   us-east-2a   25d
ocp47demo-2v5jc-worker-us-east-2a-rczzr   Running   m5.2xlarge   us-east-2   us-east-2a   206d
ocp47demo-2v5jc-worker-us-east-2a-xnfzn   Running   m5.2xlarge   us-east-2   us-east-2a   206d
ocp47demo-2v5jc-worker-us-east-2a-xq4qz   Running   r5.large     us-east-2   us-east-2a   27d
```
Kubeturbo output
The other 3 nodepools (`node-pool-1`, `node-pool-2`, `node-pool-3`) are created based on the labels from the EKS nodes

```
I1004 09:35:07.303048       1 node_pools_group_dto_builder.go:73] node-pool-1: [92083dbf-287d-4bca-9292-b4b573c9de78]
I1004 09:35:07.303055       1 node_pools_group_dto_builder.go:73] node-pool-2: [bd7dd94e-6368-463c-a688-d588ddcef369]
I1004 09:35:07.303060       1 node_pools_group_dto_builder.go:73] node-pool-3: [ced6f4ad-83eb-479a-bd05-e4e78c80b4e2 33bc2563-c700-4fa5-8738-3d81fb9ec551]
I1004 09:35:07.303066       1 node_pools_group_dto_builder.go:73] kubeturbo.io/machineset/ocp47demo-2v5jc-worker-us-east-2a: [5847475a-4c9f-4fd2-a853-41d12889d2e1 ced6f4ad-83eb-479a-bd05-e4e78c80b4e2 bd7dd94e-6368-463c-a688-d588ddcef369 33f52b31-776c-475f-9d05-e7d75d6b2095 92083dbf-287d-4bca-9292-b4b573c9de78 33bc2563-c700-4fa5-8738-3d81fb9ec551]
I1004 09:35:07.303076       1 node_pools_group_dto_builder.go:39] Creating Node Pool group: NodePool-kubeturbo.io/machineset/ocp47demo-2v5jc-worker-us-east-2a-Kubernetes-ocp47-aws belonging to cluster [22ecf12e-402c-438b-a3ae-d483b2a06b49]
I1004 09:35:07.303085       1 node_pools_group_dto_builder.go:39] Creating Node Pool group: NodePool-node-pool-1-Kubernetes-ocp47-aws belonging to cluster [22ecf12e-402c-438b-a3ae-d483b2a06b49]
I1004 09:35:07.303092       1 node_pools_group_dto_builder.go:39] Creating Node Pool group: NodePool-node-pool-2-Kubernetes-ocp47-aws belonging to cluster [22ecf12e-402c-438b-a3ae-d483b2a06b49]
I1004 09:35:07.303100       1 node_pools_group_dto_builder.go:39] Creating Node Pool group: NodePool-node-pool-3-Kubernetes-ocp47-aws belonging to cluster [22ecf12e-402c-438b-a3ae-d483b2a06b49]
I1004 09:35:07.303112       1 k8s_discovery_client.go:399] There are totally 16 groups DTOs
```
Search nodepools output server side:
![image](https://user-images.githubusercontent.com/10027921/135831472-1226ba15-14e7-4efc-91f3-5166f21cf3db.png)


Scope to nodepool view
![image](https://user-images.githubusercontent.com/10027921/135831882-1268dd2f-66a8-4580-80d7-592b2e6f5790.png)
