### PR TITLE
Support executing resizing actions on StatefulSet

### DIFF
--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -98,6 +98,11 @@ func GetSupportedResUsingKind(kind, namespace, name string) (schema.GroupVersion
 			Group:    util.K8sAPIDaemonsetGV.Group,
 			Version:  util.K8sAPIDaemonsetGV.Version,
 			Resource: util.DaemonSetResName}
+	case util.KindStatefulSet:
+		res = schema.GroupVersionResource{
+			Group:    util.K8sAPIStatefulsetGV.Group,
+			Version:  util.K8sAPIStatefulsetGV.Version,
+			Resource: util.StatefulSetResName}
 	default:
 		err = fmt.Errorf("unsupport controller type %s for %s/%s", kind, namespace, name)
 	}

--- a/pkg/action/executor/k8s_controller_updater_test.go
+++ b/pkg/action/executor/k8s_controller_updater_test.go
@@ -1,0 +1,108 @@
+package executor
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/turbonomic/kubeturbo/pkg/util"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGetSupportedResUsingKind(t *testing.T) {
+	testCases := []struct {
+		testName  string
+		kind      string
+		namespace string
+		name      string
+		res       schema.GroupVersionResource
+		wantErr   bool
+	}{
+		{
+			testName:  "test ReplicationController kind",
+			kind:      util.KindReplicationController,
+			namespace: "namesapce",
+			name:      "name",
+			res: schema.GroupVersionResource{
+				Group:    util.K8sAPIReplicationControllerGV.Group,
+				Version:  util.K8sAPIReplicationControllerGV.Version,
+				Resource: util.ReplicationControllerResName},
+			wantErr: false,
+		},
+		{
+			testName:  "test ReplicaSet kind",
+			kind:      util.KindReplicaSet,
+			namespace: "namesapce",
+			name:      "name",
+			res: schema.GroupVersionResource{
+				Group:    util.K8sAPIReplicasetGV.Group,
+				Version:  util.K8sAPIReplicasetGV.Version,
+				Resource: util.ReplicaSetResName},
+			wantErr: false,
+		},
+		{
+			testName:  "test Deployment kind",
+			kind:      util.KindDeployment,
+			namespace: "namesapce",
+			name:      "name",
+			res: schema.GroupVersionResource{
+				Group:    util.K8sAPIDeploymentGV.Group,
+				Version:  util.K8sAPIDeploymentGV.Version,
+				Resource: util.DeploymentResName},
+			wantErr: false,
+		},
+		{
+			testName:  "test DeploymentConfig kind",
+			kind:      util.KindDeploymentConfig,
+			namespace: "namesapce",
+			name:      "name",
+			res: schema.GroupVersionResource{
+				Group:    util.OpenShiftAPIDeploymentConfigGV.Group,
+				Version:  util.OpenShiftAPIDeploymentConfigGV.Version,
+				Resource: util.DeploymentConfigResName},
+			wantErr: false,
+		},
+		{
+			testName:  "test DaemonSet kind",
+			kind:      util.KindDaemonSet,
+			namespace: "namesapce",
+			name:      "name",
+			res: schema.GroupVersionResource{
+				Group:    util.K8sAPIDaemonsetGV.Group,
+				Version:  util.K8sAPIDaemonsetGV.Version,
+				Resource: util.DaemonSetResName},
+			wantErr: false,
+		},
+		{
+			testName:  "test StatefulSet kind",
+			kind:      util.KindStatefulSet,
+			namespace: "namesapce",
+			name:      "name",
+			res: schema.GroupVersionResource{
+				Group:    util.K8sAPIStatefulsetGV.Group,
+				Version:  util.K8sAPIStatefulsetGV.Version,
+				Resource: util.StatefulSetResName},
+			wantErr: false,
+		},
+		{
+			testName:  "test Job kind",
+			kind:      util.KindJob,
+			namespace: "namesapce",
+			name:      "name",
+			res:       schema.GroupVersionResource{},
+			wantErr:   true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			res, err := GetSupportedResUsingKind(testCase.kind, testCase.namespace, testCase.name)
+			if (err != nil) != testCase.wantErr {
+				t.Errorf("GetSupportedResUsingKind() error = %v, wantError %v", err, testCase.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(res, testCase.res) {
+				t.Errorf("GetSupportedResUsingKind() got = %v, want %v", res, testCase.res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Intent
The intent is to support executing resizing actions on StatefulSet. When executing resizing actions on controller, we have a function to check if corresponding K8s controller is supported to execute the action. StatefulSet is not included in supported controller. There's no special requirement to allow executing resizing actions on StatefulSet, so the change here is to support StatefulSet as well.

# Background
One important background is that there are 2 types of `updateStrategies` : `OnDelete` and `RollingUpdate` (https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies), where
> OnDelete
> When a StatefulSet's .spec.updateStrategy.type is set to OnDelete, the StatefulSet controller will not automatically update the Pods in a StatefulSet. Users must manually delete Pods to cause the controller to create new Pods that reflect modifications made to a StatefulSet's .spec.template.
> 
> RollingUpdate
> The RollingUpdate update strategy implements automated, rolling update for the Pods in a StatefulSet. This is the default update strategy.


So we need additional document to mention the expectation when executing actions on StatefulSet.

# Testing Done
## Environment
Tested action execution on cassandra StatefulSet in our twitter demoapp. By default, the `updateStrategies` is set to `OnDelete`.

Executed following action:
<img width="1696" alt="Screen Shot 2021-10-15 at 5 35 37 PM" src="https://user-images.githubusercontent.com/23689754/137562799-f2e1dbc0-5d9b-43fe-8e3d-cc95c100be91.png">

## Testing Results
And action execution was successful with such log message:
```
I1015 21:36:42.772343       1 action_handler.go:356] Received an action RIGHT_SIZE for entity WORKLOAD_CONTROLLER [cassandra]
I1015 21:36:42.933790       1 workload_controller_resizer.go:165] Begin to resize workload controller demoapp/cassandra.
I1015 21:36:42.938435       1 resize_container_util.go:69] Try to update container cassandra resource limit from map[cpu:{i:{value:300 scale:-3} d:{Dec:<nil>} s:300m Format:DecimalSI}] to map[cpu:{{1100 -3} {<nil>} 1100m DecimalSI}]
I1015 21:36:43.011336       1 k8s_controller_updater.go:147] Successfully updated StatefulSet demoapp/cassandra
```

The value of CPU limit was correctly updated in the StatefulSet. The cassandra pod wasn't automatically restarted which is as expected.

Then after restarting cassandra pod, CPU limit was correctly updated in the newly scheduled pod. And cassandra itself was still working properly by checking the twitter app:
<img width="1782" alt="Screen Shot 2021-10-15 at 7 03 26 PM" src="https://user-images.githubusercontent.com/23689754/137562960-81e44336-4306-499c-8775-1f9a0fc04a15.png">

Furthermore, after updating the `updateStrategies` to `RollingUpdate` in cassandra StatefulSet and re-executing the action, cassandra pod was able to automatically restart.
