### PR TITLE
Add support for gitops based action executor

### DIFF
--- a/pkg/action/executor/change_request_controller.go
+++ b/pkg/action/executor/change_request_controller.go
@@ -1,0 +1,124 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	CRGroup        = "turbonomic.kubeturbo.io"
+	CRVersion      = "v1alpha1"
+	CRResourceName = "changerequests"
+	CRKind         = "ChangeRequest"
+
+	// We currently use the source of truth path as an annotation on the
+	// given workload controller. At some point we will need to move this
+	// to a more structured place, for example a CR.
+	GitopsSourceAnnotationKey = "turbonomic.kubeturbo.io/gitops-source"
+)
+
+type cRController interface {
+	// Update will create a ChangeRequest resource with
+	// path from the obj annotation and payload as the
+	// json representation of the obj
+	// The creation of ChangeRequest will be observed by the
+	// change reconciler which will update the source path
+	// with the new object
+	Update(sourcePath string, workloadObj *unstructured.Unstructured) error
+}
+
+type cRControllerImpl struct {
+	dynClient dynamic.Interface
+	name      string
+}
+
+func newCRController(dynClient dynamic.Interface) cRController {
+	return &cRControllerImpl{
+		dynClient: dynClient,
+		name:      "ChangeRequestController",
+	}
+}
+
+func (c *cRControllerImpl) Update(sourcePath string, workloadObj *unstructured.Unstructured) error {
+	objJSON, err := workloadObj.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("Error encoding unstructured object to yaml: %v", err)
+	}
+
+	data, err := yaml.JSONToYAML(objJSON)
+	if err != nil {
+		return fmt.Errorf("Error encoding json object to yaml: %v", err)
+	}
+
+	cR := newCRResource(workloadObj.GetName(), workloadObj.GetNamespace())
+	err = unstructured.SetNestedField(cR.Object, sourcePath, "spec", "pathname")
+	if err != nil {
+		return err
+	}
+	err = unstructured.SetNestedField(cR.Object, string(data), "spec", "payload")
+	if err != nil {
+		return err
+	}
+	err = unstructured.SetNestedField(cR.Object, "GitHub", "spec", "type")
+	if err != nil {
+		return err
+	}
+
+	res := schema.GroupVersionResource{
+		Group:    CRGroup,
+		Version:  CRVersion,
+		Resource: CRResourceName,
+	}
+	namespacedClient := c.dynClient.Resource(res).Namespace(workloadObj.GetNamespace())
+
+	// We try to create a new CR resource with the update info.
+	// It might be that this action has been executed once and we are trying it
+	// again in which case we try to only update the existing resource
+	// Also we create the ChangeRequest resource with same name as workload obj
+	_, outerErr := namespacedClient.Create(context.Background(), cR, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(outerErr) {
+		cRSpec, found, err := unstructured.NestedMap(cR.Object, "spec")
+		if err != nil || !found {
+			return fmt.Errorf("could not retrieve spec fields from ChangeRequest: %s: %v", cR.GetName(), err)
+		}
+
+		existing, err := namespacedClient.Get(context.Background(), cR.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		err = unstructured.SetNestedMap(existing.Object, cRSpec, "spec")
+		if err != nil {
+			return err
+		}
+
+		_, err = namespacedClient.Update(context.Background(), cR, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return outerErr
+}
+
+func (c *cRControllerImpl) String() string {
+	return c.name
+}
+
+func newCRResource(name, namespace string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetKind(CRKind)
+	gv := schema.GroupVersion{Group: CRGroup, Version: CRVersion}
+	obj.SetAPIVersion(gv.String())
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+
+	return obj
+}

--- a/pkg/action/executor/k8s_controller.go
+++ b/pkg/action/executor/k8s_controller.go
@@ -104,11 +104,12 @@ func (c *parentController) update(updatedSpec *k8sControllerSpec) error {
 
 	annotations := c.obj.GetAnnotations()
 	gitopsSource, exists := annotations[GitopsSourceAnnotationKey]
+	// We will extract other annotations in update
 	if exists {
 		// The workload is managed by a pipeline controller which replicates
 		// it from a source of truth
-		cRC := newCRController(c.dynClient)
-		err := cRC.Update(gitopsSource, c.obj)
+		cRC := newCRController(c.dynClient, c.obj)
+		err := cRC.Update(gitopsSource, int64(*updatedSpec.replicas), podSpecUnstructured)
 		if err != nil {
 			return fmt.Errorf("failed to create a ChangeRequest: %v", err)
 		}

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -14,6 +14,7 @@ import (
 	kclient "k8s.io/client-go/kubernetes"
 
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	discoveryutil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
 	"github.com/turbonomic/kubeturbo/pkg/util"
@@ -47,11 +48,18 @@ func newK8sControllerUpdaterViaPod(clusterScraper *cluster.ClusterScraper, pod *
 	if discoveryutil.IsOwnerInfoEmpty(ownerInfo) {
 		return nil, fmt.Errorf("pod %s/%s does not have controller", pod.Namespace, pod.Name)
 	}
-	return newK8sControllerUpdater(clusterScraper, ormClient, ownerInfo.Kind, ownerInfo.Name, pod.Name, pod.Namespace)
+	// TODO: For an action on a parent workload controller of this pod managed by gitops (argoCD) we will need
+	// Some information to be available on the entity we get in the action (pod here).
+	// We currently put the info about the argoCD manager app on the workload controller it manages.
+	// Copy that data on to the pod also to ensure we can rightly identify if this pods parent is managed
+	// by a specific argoCD app. (or find a better way of doing this)
+	// As of now scale up and down actions wont work with argoCD.
+	return newK8sControllerUpdater(clusterScraper, ormClient, ownerInfo.Kind, ownerInfo.Name, pod.Name, pod.Namespace, nil)
 }
 
 // newK8sControllerUpdater returns a k8sControllerUpdater based on the controller kind
-func newK8sControllerUpdater(clusterScraper *cluster.ClusterScraper, ormClient *resourcemapping.ORMClient, kind, controllerName, podName, namespace string) (*k8sControllerUpdater, error) {
+func newK8sControllerUpdater(clusterScraper *cluster.ClusterScraper, ormClient *resourcemapping.ORMClient, kind,
+	controllerName, podName, namespace string, managerApp *repository.K8sApp) (*k8sControllerUpdater, error) {
 	res, err := GetSupportedResUsingKind(kind, namespace, controllerName)
 	if err != nil {
 		return nil, err
@@ -62,6 +70,7 @@ func newK8sControllerUpdater(clusterScraper *cluster.ClusterScraper, ormClient *
 			dynNamespacedClient: clusterScraper.DynamicClient.Resource(res).Namespace(namespace),
 			name:                kind,
 			ormClient:           ormClient,
+			managerApp:          managerApp,
 		},
 		client:    clusterScraper.Clientset,
 		name:      controllerName,

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -58,6 +58,7 @@ func newK8sControllerUpdater(clusterScraper *cluster.ClusterScraper, ormClient *
 	}
 	return &k8sControllerUpdater{
 		controller: &parentController{
+			dynClient:           clusterScraper.DynamicClient,
 			dynNamespacedClient: clusterScraper.DynamicClient.Resource(res).Namespace(namespace),
 			name:                kind,
 			ormClient:           ormClient,

--- a/pkg/discovery/dtofactory/property/pod_properties.go
+++ b/pkg/discovery/dtofactory/property/pod_properties.go
@@ -4,17 +4,8 @@ import (
 	api "k8s.io/api/core/v1"
 
 	"fmt"
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-)
 
-const (
-	// TODO currently in the server side only properties in "DEFAULT" namespaces are respected. Ideally we should use "Kubernetes-Pod".
-	k8sPropertyNamespace    = "DEFAULT"
-	VCTagsPropertyNamespace = "VCTAGS"
-	k8sNamespace            = "KubernetesNamespace"
-	k8sPodName              = "KubernetesPodName"
-	k8sNodeName             = "KubernetesNodeName"
-	k8sContainerIndex       = "Kubernetes-Container-Index"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
 // Build entity properties of a pod. The properties are consisted of name and namespace of a pod.

--- a/pkg/discovery/dtofactory/property/property_common.go
+++ b/pkg/discovery/dtofactory/property/property_common.go
@@ -1,6 +1,23 @@
 package property
 
-import "github.com/turbonomic/turbo-go-sdk/pkg/proto"
+import (
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+)
+
+const (
+	// TODO currently in the server side only properties in "DEFAULT" namespaces are respected. Ideally we should use "Kubernetes-Pod".
+	k8sPropertyNamespace    = "DEFAULT"
+	VCTagsPropertyNamespace = "VCTAGS"
+	k8sNamespace            = "KubernetesNamespace"
+	k8sPodName              = "KubernetesPodName"
+	k8sNodeName             = "KubernetesNodeName"
+	k8sContainerIndex       = "Kubernetes-Container-Index"
+	k8sAppNamespace         = "KubernetesAppNamespace"
+	k8sAppName              = "KubernetesAppName"
+	k8sAppType              = "KubernetesAppType"
+)
 
 // Add label and annotation
 func BuildLabelAnnotationProperties(tagMaps []map[string]string) []*proto.EntityDTO_EntityProperty {
@@ -19,6 +36,38 @@ func BuildLabelAnnotationProperties(tagMaps []map[string]string) []*proto.Entity
 			properties = append(properties, tagProperty)
 		}
 	}
+
+	return properties
+}
+
+// Creates the properties identifying mapped application namespace, name and type
+func BuildBusinessAppRelatedProperties(app repository.K8sApp) []*proto.EntityDTO_EntityProperty {
+	var properties []*proto.EntityDTO_EntityProperty
+	propertyNamespace := k8sPropertyNamespace
+
+	appPropertyNamespaceKey := k8sAppNamespace
+	appPropertyNamespaceValue := app.Namespace
+	properties = append(properties, &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &appPropertyNamespaceKey,
+		Value:     &appPropertyNamespaceValue,
+	})
+
+	appPropertyNameKey := k8sAppName
+	appPropertyNameValue := app.Name
+	properties = append(properties, &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &appPropertyNameKey,
+		Value:     &appPropertyNameValue,
+	})
+
+	appPropertyTypeKey := k8sAppType
+	appPropertyTypeValue := app.Type
+	properties = append(properties, &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &appPropertyTypeKey,
+		Value:     &appPropertyTypeValue,
+	})
 
 	return properties
 }

--- a/pkg/discovery/dtofactory/property/property_common.go
+++ b/pkg/discovery/dtofactory/property/property_common.go
@@ -71,3 +71,43 @@ func BuildBusinessAppRelatedProperties(app repository.K8sApp) []*proto.EntityDTO
 
 	return properties
 }
+
+// Creates the properties identifying mapped application namespace, name and type
+func GetManagerAppFromProperties(properties []*proto.EntityDTO_EntityProperty) *repository.K8sApp {
+	managerApp := &repository.K8sApp{}
+	if properties == nil {
+		return nil
+	}
+
+	for _, property := range properties {
+		if property.GetNamespace() != k8sPropertyNamespace {
+			continue
+		}
+		if (property.GetName() != k8sAppNamespace) &&
+			(property.GetName() != k8sAppName) &&
+			(property.GetName() != k8sAppType) {
+			continue
+		}
+
+		if property.GetName() == k8sAppType {
+			if property.GetValue() != repository.AppTypeArgoCD {
+				// We return a valid app only for app type argoCD as of now
+				continue
+			}
+			managerApp.Type = property.GetValue()
+		}
+
+		if property.GetName() == k8sAppName {
+			managerApp.Name = property.GetValue()
+		}
+
+		if property.GetName() == k8sAppNamespace {
+			managerApp.Namespace = property.GetValue()
+		}
+	}
+
+	if managerApp.Type == "" {
+		return nil
+	}
+	return managerApp
+}

--- a/pkg/discovery/processor/business_app_processor.go
+++ b/pkg/discovery/processor/business_app_processor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,70 +32,135 @@ func NewBusinessAppProcessor(clusterScraper cluster.ClusterScraperInterface,
 }
 
 func (p *BusinessAppProcessor) ProcessBusinessApps() {
-	res := schema.GroupVersionResource{
-		Group:    util.K8sApplicationGV.Group,
-		Version:  util.K8sApplicationGV.Version,
-		Resource: util.ApplicationResName}
+	resources := []schema.GroupVersionResource{
+		{
+			Group:    util.K8sApplicationGV.Group,
+			Version:  util.K8sApplicationGV.Version,
+			Resource: util.ApplicationResName,
+		},
+		{
+			Group:    util.ArgoCDApplicationGV.Group,
+			Version:  util.ArgoCDApplicationGV.Version,
+			Resource: util.ApplicationResName,
+		},
+	}
 
+	for _, res := range resources {
+		appToComponentMap := p.ProcessAppsOfType(res)
+		if p.KubeCluster.K8sAppToComponentMap == nil {
+			p.KubeCluster.K8sAppToComponentMap = appToComponentMap
+		} else {
+			for key, val := range appToComponentMap {
+				p.KubeCluster.K8sAppToComponentMap[key] = val
+			}
+		}
+	}
+	p.KubeCluster.ComponentToAppMap = inverseAppToComponentMap(p.KubeCluster.K8sAppToComponentMap)
+
+}
+
+func (p *BusinessAppProcessor) ProcessAppsOfType(res schema.GroupVersionResource) map[repository.K8sApp][]repository.K8sAppComponent {
+	appToComponentMap := make(map[repository.K8sApp][]repository.K8sAppComponent)
 	typedClusterScraper, isClusterScraper := p.ClusterScraper.(*cluster.ClusterScraper)
 	if !isClusterScraper {
 		// This is probably a test run
-		return
+		return appToComponentMap
 	}
 	dynClient := typedClusterScraper.DynamicClient
 
 	apps, err := dynClient.Resource(res).Namespace("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		glog.Warningf("Failed to list %v from %v/%v: %v", res.Resource, res.Group, res.Version, err)
-		return
+		return appToComponentMap
 	}
 
-	appToComponentMap := make(map[repository.K8sApp][]repository.K8sAppComponent)
 	for _, item := range apps.Items {
-		app := appv1beta1.Application{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, &app); err != nil {
-			glog.Warningf("Error converting unstructured app to typed app %v", err)
-			continue
-		}
-
-		selectors := app.Spec.Selector
-		allEntities := []repository.K8sAppComponent{}
-		qualifiedAppName := fmt.Sprintf("%s/%s", app.Namespace, app.Name)
-		for _, gk := range app.Spec.ComponentGroupKinds {
-			entities, err := p.getEntities(selectors, gk, app.Namespace)
+		var allEntities []repository.K8sAppComponent
+		switch res.Group {
+		case util.K8sApplicationGV.Group:
+			allEntities = p.getK8sAppEntities(item)
+		case util.ArgoCDApplicationGV.Group:
+			allEntities, err = p.getArgoCDAppEntities(item)
 			if err != nil {
-				glog.Warningf("Error processing entities for application %s, %v", qualifiedAppName, err)
-				continue
+				glog.Warningf("Failed to get app entities for %v from %v/%v: %v", res.Resource, res.Group, res.Version, err)
+				return appToComponentMap
 			}
-			allEntities = append(allEntities, entities...)
 		}
 
 		application := repository.K8sApp{
-			Uid:       string(app.UID),
-			Namespace: app.Namespace,
-			Name:      app.Name,
+			Uid:       string(item.GetUID()),
+			Namespace: item.GetNamespace(),
+			Name:      item.GetName(),
 		}
 		if len(allEntities) > 0 {
 			appToComponentMap[application] = allEntities
-			glog.V(4).Infof("Discovered %d entities for app:%s, entities: %v", len(allEntities), qualifiedAppName, allEntities)
+			glog.V(4).Infof("Discovered %d entities for app:%s/%s, entities: %v", len(allEntities), item.GetNamespace(), item.GetName(), allEntities)
 		} else {
 			// nil indicates no entities discovered for this applicaiton
 			appToComponentMap[application] = nil
 		}
 	}
 
-	p.KubeCluster.K8sAppToComponentMap = appToComponentMap
-	p.KubeCluster.ComponentToAppMap = inverseAppToComponentMap(appToComponentMap)
+	return appToComponentMap
 }
 
-func (p *BusinessAppProcessor) getEntities(selector *metav1.LabelSelector, gk metav1.GroupKind, namespace string) ([]repository.K8sAppComponent, error) {
-	res := schema.GroupVersionResource{}
-	var err error
+func (p *BusinessAppProcessor) getK8sAppEntities(unstructuredApp unstructured.Unstructured) []repository.K8sAppComponent {
+	app := appv1beta1.Application{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredApp.Object, &app); err != nil {
+		glog.Warningf("Error converting unstructured app to typed app %v", err)
+		return nil
+	}
+
+	selectors := app.Spec.Selector
+	allEntities := []repository.K8sAppComponent{}
+	for _, gk := range app.Spec.ComponentGroupKinds {
+		entities, err := p.getEntitiesViaSelector(selectors, gk, app.Namespace)
+		if err != nil {
+			glog.Warningf("Error processing entities for application %s/%s, %v", app.Namespace, app.Name, err)
+			continue
+		}
+		allEntities = append(allEntities, entities...)
+	}
+
+	return allEntities
+}
+
+func (p *BusinessAppProcessor) getArgoCDAppEntities(unstructuredApp unstructured.Unstructured) ([]repository.K8sAppComponent, error) {
+	allEntities := []repository.K8sAppComponent{}
+	resources, found, err := unstructured.NestedSlice(unstructuredApp.Object, "status", "resources")
+	if err != nil || !found {
+		return allEntities, fmt.Errorf("error retrieving resources from argocd app %s/%s: %v",
+			unstructuredApp.GetNamespace(), unstructuredApp.GetName(), err)
+	}
+
+	for _, res := range resources {
+		typedResource, ok := res.(map[string]interface{})
+		if !ok {
+			glog.Warningf("Decoded wrong resource detail from argocd app %s/%s: %T: %v",
+				unstructuredApp.GetNamespace(), unstructuredApp.GetName(), res, res)
+			continue
+		}
+		gk := metav1.GroupKind{
+			Group: typedResource["group"].(string),
+			Kind:  typedResource["kind"].(string),
+		}
+		entity, err := p.getEntity(gk, typedResource["name"].(string), typedResource["namespace"].(string))
+		if err != nil {
+			glog.Warningf("Error processing entities for argocd app %s/%s entity %v/%v, %v",
+				unstructuredApp.GetNamespace(), unstructuredApp.GetName(), typedResource["group"], typedResource["group"], err)
+			continue
+		}
+		allEntities = append(allEntities, *entity)
+	}
+
+	return allEntities, nil
+}
+
+func renderTypeInfo(gk metav1.GroupKind) (schema.GroupVersionResource, proto.EntityDTO_EntityType, error) {
+	var res schema.GroupVersionResource
 	var entityType proto.EntityDTO_EntityType
 	switch gk.String() {
-	// TODO: standardise this, find a better way,
-	// for example move to using controller-runtime and the need for explicitly
-	// mapping each type might not be there.
+	// TODO: standardise this, or find a better way,
 	// In case we continue to keep these values for gvr make them constants.
 	case "StatefulSet.apps":
 		res = schema.GroupVersionResource{
@@ -132,7 +198,6 @@ func (p *BusinessAppProcessor) getEntities(selector *metav1.LabelSelector, gk me
 			Version:  "v1",
 			Resource: "jobs"}
 		entityType = proto.EntityDTO_WORKLOAD_CONTROLLER
-	// TODO: not sure why service gk returns "Service.v1"
 	case "Service.v1":
 		res = schema.GroupVersionResource{
 			Group:    "",
@@ -146,9 +211,17 @@ func (p *BusinessAppProcessor) getEntities(selector *metav1.LabelSelector, gk me
 			Resource: "pods"}
 		entityType = proto.EntityDTO_CONTAINER_POD
 	default:
-		return nil, fmt.Errorf("unsupport group kind type %s", gk.String())
+		return res, entityType, fmt.Errorf("unsupport group kind type %s", gk.String())
 	}
 
+	return res, entityType, nil
+}
+
+func (p *BusinessAppProcessor) getEntitiesViaSelector(selector *metav1.LabelSelector, gk metav1.GroupKind, namespace string) ([]repository.K8sAppComponent, error) {
+	res, entityType, err := renderTypeInfo(gk)
+	if err != nil {
+		return nil, err
+	}
 	dynClient := p.ClusterScraper.(*cluster.ClusterScraper).DynamicClient
 	resourceList, err := dynClient.Resource(res).Namespace(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Set(selector.MatchLabels).String()})
 	if err != nil {
@@ -168,6 +241,26 @@ func (p *BusinessAppProcessor) getEntities(selector *metav1.LabelSelector, gk me
 	}
 
 	return entities, nil
+}
+
+func (p *BusinessAppProcessor) getEntity(gk metav1.GroupKind, name, namespace string) (*repository.K8sAppComponent, error) {
+	res, entityType, err := renderTypeInfo(gk)
+	if err != nil {
+		return nil, err
+	}
+	dynClient := p.ClusterScraper.(*cluster.ClusterScraper).DynamicClient
+	object, err := dynClient.Resource(res).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &repository.K8sAppComponent{
+		EntityType: entityType,
+		Uid:        string(object.GetUID()),
+		Namespace:  object.GetNamespace(),
+		Name:       object.GetName(),
+	}, nil
+
 }
 
 func inverseAppToComponentMap(appToComponents map[repository.K8sApp][]repository.K8sAppComponent) map[repository.K8sAppComponent][]repository.K8sApp {

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -273,6 +273,11 @@ func parseResourceValue(computeResourceType metrics.ResourceType, resourceList v
 	return DEFAULT_METRIC_VALUE
 }
 
+const (
+	AppTypeK8s    = "k8s"
+	AppTypeArgoCD = "argocd"
+)
+
 type K8sApp struct {
 	Uid       string
 	Namespace string

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -277,6 +277,7 @@ type K8sApp struct {
 	Uid       string
 	Namespace string
 	Name      string
+	Type      string
 }
 
 type K8sAppComponent struct {

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -13,11 +13,12 @@ const (
 	KindReplicationController = "ReplicationController"
 	KindStatefulSet           = "StatefulSet"
 
-	K8sExtensionsGroupName  = "extensions"
-	K8sAppsGroupName        = "apps"
-	K8sApplicationGroupName = "app.k8s.io"
-	OpenShiftAppsGroupName  = "apps.openshift.io"
-	K8sBatchGroupName       = "batch"
+	K8sExtensionsGroupName     = "extensions"
+	K8sAppsGroupName           = "apps"
+	K8sApplicationGroupName    = "app.k8s.io"
+	ArgoCDApplicationGroupName = "argoproj.io"
+	OpenShiftAppsGroupName     = "apps.openshift.io"
+	K8sBatchGroupName          = "batch"
 
 	ReplicationControllerResName = "replicationcontrollers"
 	ReplicaSetResName            = "replicasets"
@@ -44,6 +45,8 @@ var (
 	OpenShiftAPIDeploymentConfigGV = schema.GroupVersion{Group: OpenShiftAppsGroupName, Version: "v1"}
 	// The API group under which application crd resource is installed on the server
 	K8sApplicationGV = schema.GroupVersion{Group: K8sApplicationGroupName, Version: "v1beta1"}
+	// The API group under which ArgoCD application crd resource is installed on the server
+	ArgoCDApplicationGV = schema.GroupVersion{Group: ArgoCDApplicationGroupName, Version: "v1alpha1"}
 	// The API group under which statefulsets are exposed by the k8s cluster
 	K8sAPIStatefulsetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
 	// The API group under which daemonsets are exposed by the k8s cluster

--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -191,7 +191,7 @@ var _ = Describe("Action Executor ", func() {
 	// CRD definition is finalised.
 	Describe("executing action resize pod on a gitops updated workload", func() {
 		It("should result in new pod on target node", func() {
-			dep, err := createDeployResource(kubeClient, depSingleContainerWithGitopsAnnotation(namespace, 1))
+			dep, err := createDeployResource(kubeClient, depSingleContainerWithGitopsAnnotations(namespace, 1))
 			framework.ExpectNoError(err, "Error creating test resources")
 
 			pod, err := getDeploymentsPod(kubeClient, dep.Name, namespace, "")
@@ -231,12 +231,15 @@ func createDeployResource(client *kubeclientset.Clientset, dep *appsv1.Deploymen
 	return waitForDeployment(client, newDep.Name, newDep.Namespace)
 }
 
-func depSingleContainerWithGitopsAnnotation(namespace string, replicas int32) *appsv1.Deployment {
+func depSingleContainerWithGitopsAnnotations(namespace string, replicas int32) *appsv1.Deployment {
 	dep := depSingleContainerWithResources(namespace, "", replicas, false, false, false)
 	if dep.Annotations == nil {
 		dep.Annotations = make(map[string]string)
 	}
-	dep.Annotations[executor.GitopsSourceAnnotationKey] = "dummy-path"
+	dep.Annotations[executor.GitopsSourceAnnotationKey] = "dummy-source"
+	dep.Annotations[executor.GitopsFilePathAnnotationKey] = "dummy-path"
+	dep.Annotations[executor.GitopsBranchAnnotationKey] = "dummy-branch"
+	dep.Annotations[executor.GitopsSecretNameAnnotationKey] = "dummy-secret-name"
 	return dep
 }
 


### PR DESCRIPTION
**Intent**

This PR implements kubeturbo part of the prototype level implementation of being able to update github repos for actions which update the workload controllers.

**Background**

There is a considerable number of users which rely on the gitops based controllers and a source of truth, eg a git repo to manage the statue of resources in their clusters. Turbo as of now cannot execute resource resize and horizontal scale actions on such environments. Turbo can (and does) apply the changes spec on the workload controller resource  that exists in the cluster, but as its managed by a gitops based controller, its immediately synced with the source of truth and reverted back to the original. This PR implements basic support using which the actions result will be updated by pushing a PR to the source of truth. This PR assumes that as of now only supported types will be a git repo with yaml files stored in it.

**Implementation**

If the workload controller under question (for example parent of the container specs which are resized) has an annotation with key `turbonomic.kubeturbo.io/gitops-source`, a ChangeRequest resource with the information from action wil be created. A separate work will implement a `change-reconciler` which will watch this `ChangeRequest` resource and will create a PR against the git repo using the details in the `CR`.
This does not wait for the status of the ChangeReqest to be updated, which will be implemented in future.

**Testing done**
The PR implements an integration test using which creation of the CR with appropriate content, when executing a resize action,  is validated.

Test output
```
Starting: /Users/irfanurrehman/bin/dlv-dap dap --check-go-version=false --listen=127.0.0.1:51750 --log-dest=3 from /Users/irfanurrehman/src/github.com/turbonomic/kubeturbo/test/integration
DAP server listening at: 127.0.0.1:51750
I1025 21:09:14.503134    8668 test_context.go:78] FLAG: --add_dir_header="false"
I1025 21:09:14.503615    8668 test_context.go:78] FLAG: --alsologtostderr="true"
I1025 21:09:14.503626    8668 test_context.go:78] FLAG: --cloud-provider-gce-l7lb-src-cidrs="130.211.0.0/22,35.191.0.0/16"
I1025 21:09:14.503636    8668 test_context.go:78] FLAG: --cloud-provider-gce-lb-src-cidrs="130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16"
I1025 21:09:14.503643    8668 test_context.go:78] FLAG: --ginkgo.debug="false"
I1025 21:09:14.503647    8668 test_context.go:78] FLAG: --ginkgo.dryRun="false"
I1025 21:09:14.503650    8668 test_context.go:78] FLAG: --ginkgo.failFast="false"
I1025 21:09:14.503654    8668 test_context.go:78] FLAG: --ginkgo.failOnPending="false"
I1025 21:09:14.503657    8668 test_context.go:78] FLAG: --ginkgo.flakeAttempts="1"
I1025 21:09:14.503663    8668 test_context.go:78] FLAG: --ginkgo.focus=""
I1025 21:09:14.503668    8668 test_context.go:78] FLAG: --ginkgo.noColor="false"
I1025 21:09:14.503672    8668 test_context.go:78] FLAG: --ginkgo.noisyPendings="true"
I1025 21:09:14.503676    8668 test_context.go:78] FLAG: --ginkgo.noisySkippings="true"
I1025 21:09:14.503680    8668 test_context.go:78] FLAG: --ginkgo.parallel.node="1"
I1025 21:09:14.503684    8668 test_context.go:78] FLAG: --ginkgo.parallel.streamhost=""
I1025 21:09:14.503688    8668 test_context.go:78] FLAG: --ginkgo.parallel.synchost=""
I1025 21:09:14.503691    8668 test_context.go:78] FLAG: --ginkgo.parallel.total="1"
I1025 21:09:14.503695    8668 test_context.go:78] FLAG: --ginkgo.progress="false"
I1025 21:09:14.503698    8668 test_context.go:78] FLAG: --ginkgo.randomizeAllSpecs="false"
I1025 21:09:14.503702    8668 test_context.go:78] FLAG: --ginkgo.regexScansFilePath="false"
I1025 21:09:14.503705    8668 test_context.go:78] FLAG: --ginkgo.reportFile=""
I1025 21:09:14.503709    8668 test_context.go:78] FLAG: --ginkgo.reportPassed="false"
I1025 21:09:14.503712    8668 test_context.go:78] FLAG: --ginkgo.seed="1635156554"
I1025 21:09:14.503717    8668 test_context.go:78] FLAG: --ginkgo.skip=""
I1025 21:09:14.503721    8668 test_context.go:78] FLAG: --ginkgo.skipMeasurements="false"
I1025 21:09:14.503724    8668 test_context.go:78] FLAG: --ginkgo.slowSpecThreshold="5"
I1025 21:09:14.503732    8668 test_context.go:78] FLAG: --ginkgo.succinct="false"
I1025 21:09:14.503735    8668 test_context.go:78] FLAG: --ginkgo.trace="false"
I1025 21:09:14.503739    8668 test_context.go:78] FLAG: --ginkgo.v="false"
I1025 21:09:14.503743    8668 test_context.go:78] FLAG: --k8s-context="kind-kind"
I1025 21:09:14.503747    8668 test_context.go:78] FLAG: --k8s-kubeconfig="/Users/irfanurrehman/.kube/config"
I1025 21:09:14.503751    8668 test_context.go:78] FLAG: --kubeconfig=""
I1025 21:09:14.503754    8668 test_context.go:78] FLAG: --log-flush-frequency="5s"
I1025 21:09:14.503759    8668 test_context.go:78] FLAG: --log_backtrace_at=":0"
I1025 21:09:14.503767    8668 test_context.go:78] FLAG: --log_dir=""
I1025 21:09:14.503771    8668 test_context.go:78] FLAG: --log_file=""
I1025 21:09:14.503774    8668 test_context.go:78] FLAG: --log_file_max_size="1800"
I1025 21:09:14.503779    8668 test_context.go:78] FLAG: --logtostderr="false"
I1025 21:09:14.503783    8668 test_context.go:78] FLAG: --min-replica-count="0"
I1025 21:09:14.503786    8668 test_context.go:78] FLAG: --single-call-timeout="2m0s"
I1025 21:09:14.503790    8668 test_context.go:78] FLAG: --skip-nodes-with-local-storage="true"
I1025 21:09:14.503794    8668 test_context.go:78] FLAG: --skip-nodes-with-system-pods="true"
I1025 21:09:14.503797    8668 test_context.go:78] FLAG: --skip_headers="false"
I1025 21:09:14.503801    8668 test_context.go:78] FLAG: --skip_log_headers="false"
I1025 21:09:14.503804    8668 test_context.go:78] FLAG: --stderrthreshold="2"
I1025 21:09:14.503809    8668 test_context.go:78] FLAG: --test-namespace="kubeturbo-test"
I1025 21:09:14.503814    8668 test_context.go:78] FLAG: --test.bench=""
I1025 21:09:14.503817    8668 test_context.go:78] FLAG: --test.benchmem="false"
I1025 21:09:14.503820    8668 test_context.go:78] FLAG: --test.benchtime="1s"
I1025 21:09:14.503828    8668 test_context.go:78] FLAG: --test.blockprofile=""
I1025 21:09:14.503832    8668 test_context.go:78] FLAG: --test.blockprofilerate="1"
I1025 21:09:14.503835    8668 test_context.go:78] FLAG: --test.count="1"
I1025 21:09:14.503840    8668 test_context.go:78] FLAG: --test.coverprofile=""
I1025 21:09:14.503844    8668 test_context.go:78] FLAG: --test.cpu=""
I1025 21:09:14.503847    8668 test_context.go:78] FLAG: --test.cpuprofile=""
I1025 21:09:14.503851    8668 test_context.go:78] FLAG: --test.failfast="false"
I1025 21:09:14.503855    8668 test_context.go:78] FLAG: --test.list=""
I1025 21:09:14.503858    8668 test_context.go:78] FLAG: --test.memprofile=""
I1025 21:09:14.503861    8668 test_context.go:78] FLAG: --test.memprofilerate="0"
I1025 21:09:14.503864    8668 test_context.go:78] FLAG: --test.mutexprofile=""
I1025 21:09:14.503868    8668 test_context.go:78] FLAG: --test.mutexprofilefraction="1"
I1025 21:09:14.503872    8668 test_context.go:78] FLAG: --test.outputdir=""
I1025 21:09:14.503875    8668 test_context.go:78] FLAG: --test.paniconexit0="false"
I1025 21:09:14.503879    8668 test_context.go:78] FLAG: --test.parallel="12"
I1025 21:09:14.503882    8668 test_context.go:78] FLAG: --test.run=""
I1025 21:09:14.503885    8668 test_context.go:78] FLAG: --test.short="false"
I1025 21:09:14.503889    8668 test_context.go:78] FLAG: --test.testlogfile=""
I1025 21:09:14.503892    8668 test_context.go:78] FLAG: --test.timeout="0s"
I1025 21:09:14.503896    8668 test_context.go:78] FLAG: --test.trace=""
I1025 21:09:14.503899    8668 test_context.go:78] FLAG: --test.v="true"
I1025 21:09:14.503903    8668 test_context.go:78] FLAG: --v="7"
I1025 21:09:14.503908    8668 test_context.go:78] FLAG: --vmodule=""
=== RUN   TestIntegration
I1025 21:09:14.503970    8668 integration_test.go:52] Starting integration run on Ginkgo node 1
Running Suite: Kubeturbo integration suite
==========================================
Random Seed: 1635156554
Will run 1 of 16 specs
SSSSSSSSSSSSSS
I1025 21:09:14.520828    8668 action_handler.go:64] SCC's allowed: map[*:{}]
I1025 21:09:14.520876    8668 action_handler.go:150] the Cluster API is unavailable
I1025 21:09:21.542921    8668 action_handler.go:356] Received an action RIGHT_SIZE for entity WORKLOAD_CONTROLLER [test-nh7jr]
I1025 21:09:21.543935    8668 action_handler.go:173] Now wait for action result
I1025 21:09:23.028027    8668 resize_container.go:133] Resize test-nh7jr VCPU Capacity to 200
I1025 21:09:24.206547    8668 workload_controller_resizer.go:165] Begin to resize workload controller kubeturbo-test-action-executor-8bprr/test-nh7jr.
I1025 21:09:24.206588    8668 k8s_controller_updater.go:130] Begin to update Deployment kubeturbo-test-action-executor-8bprr/test-nh7jr
I1025 21:09:24.212539    8668 k8s_controller_updater.go:180] Try to update resources for container indexes: 0, in pod template spec of Deployment kubeturbo-test-action-executor-8bprr/test-nh7jr .
I1025 21:09:24.212563    8668 resize_container_util.go:50] Begin to update Capacity.
I1025 21:09:24.212572    8668 resize_container_util.go:69] Try to update container test-cont resource limit from map[cpu:{i:{value:100 scale:-3} d:{Dec:<nil>} s:100m Format:DecimalSI} memory:{i:{value:209715200 scale:0} d:{Dec:<nil>} s: Format:BinarySI}] to map[cpu:{{200 -3} {<nil>} 200m DecimalSI} memory:{{209715200 0} {<nil>}  BinarySI}]
I1025 21:09:24.212610    8668 resize_container_util.go:130] Container test-cont resources changed.
I1025 22:28:59.216584    8668 k8s_controller_updater.go:148] Successfully updated Deployment kubeturbo-test-action-executor-8bprr/test-nh7jr
I1025 22:28:59.235292    8668 go_util.go:65] [retry-1/3] success
I1025 22:28:59.235379    8668 action_handler.go:333] action keepAlive goroutine exit.

------------------------------
• [SLOW TEST:4784.297 seconds]
Action Executor 
/Users/irfanurrehman/src/github.com/turbonomic/kubeturbo/test/integration/action_execution.go:35
  executing action resize pod on a gitops updated workload
  /Users/irfanurrehman/src/github.com/turbonomic/kubeturbo/test/integration/action_execution.go:186
    should result in new pod on target node
    /Users/irfanurrehman/src/github.com/turbonomic/kubeturbo/test/integration/action_execution.go:187
------------------------------
S
Ran 1 of 16 Specs in 4784.297 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 15 Skipped
--- PASS: TestIntegration (4784.30s)
PASS
```

Created CR resource for the test deployment (It currently lists the whole of updated deployment resource spec in payload)
```
Irfans-MacBook-Pro:kubeturbo irfanurrehman$ k get changerequest -n kubeturbo-test-action-executor-xlq9l -o yaml
apiVersion: v1
items:
- apiVersion: turbonomic.kubeturbo.io/v1alpha1
  kind: ChangeRequest
  metadata:
    creationTimestamp: "2021-10-25T12:35:53Z"
    generation: 1
    managedFields:
    - apiVersion: turbonomic.kubeturbo.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        f:spec:
          .: {}
          f:pathname: {}
          f:payload: {}
          f:type: {}
      manager: __debug_bin
      operation: Update
      time: "2021-10-25T12:35:53Z"
    name: test-rhvw5
    namespace: kubeturbo-test-action-executor-xlq9l
    resourceVersion: "1005010"
    uid: 8a2e021e-fe4f-4cee-bbdc-a7ae9cf5f9bf
  spec:
    pathname: dummy-path
    payload: |
      apiVersion: apps/v1
      kind: Deployment
      metadata:
        annotations:
          deployment.kubernetes.io/revision: "1"
          turbonomic.kubeturbo.io/gitops-source: dummy-path
        creationTimestamp: "2021-10-25T12:35:22Z"
        generateName: test-
        generation: 1
        managedFields:
        - apiVersion: apps/v1
          fieldsType: FieldsV1
          fieldsV1:
            f:metadata:
              f:annotations:
                .: {}
                f:turbonomic.kubeturbo.io/gitops-source: {}
              f:generateName: {}
            f:spec:
              f:progressDeadlineSeconds: {}
              f:replicas: {}
              f:revisionHistoryLimit: {}
              f:selector: {}
              f:strategy:
                f:rollingUpdate:
                  .: {}
                  f:maxSurge: {}
                  f:maxUnavailable: {}
                f:type: {}
              f:template:
                f:metadata:
                  f:labels:
                    .: {}
                    f:app: {}
                f:spec:
                  f:containers:
                    k:{"name":"test-cont"}:
                      .: {}
                      f:args: {}
                      f:command: {}
                      f:image: {}
                      f:imagePullPolicy: {}
                      f:name: {}
                      f:resources:
                        .: {}
                        f:limits:
                          .: {}
                          f:cpu: {}
                          f:memory: {}
                        f:requests:
                          .: {}
                          f:cpu: {}
                          f:memory: {}
                      f:terminationMessagePath: {}
                      f:terminationMessagePolicy: {}
                  f:dnsPolicy: {}
                  f:restartPolicy: {}
                  f:schedulerName: {}
                  f:securityContext: {}
                  f:terminationGracePeriodSeconds: {}
          manager: __debug_bin
          operation: Update
          time: "2021-10-25T12:35:22Z"
        - apiVersion: apps/v1
          fieldsType: FieldsV1
          fieldsV1:
            f:metadata:
              f:annotations:
                f:deployment.kubernetes.io/revision: {}
            f:status:
              f:availableReplicas: {}
              f:conditions:
                .: {}
                k:{"type":"Available"}:
                  .: {}
                  f:lastTransitionTime: {}
                  f:lastUpdateTime: {}
                  f:message: {}
                  f:reason: {}
                  f:status: {}
                  f:type: {}
                k:{"type":"Progressing"}:
                  .: {}
                  f:lastTransitionTime: {}
                  f:lastUpdateTime: {}
                  f:message: {}
                  f:reason: {}
                  f:status: {}
                  f:type: {}
              f:observedGeneration: {}
              f:readyReplicas: {}
              f:replicas: {}
              f:updatedReplicas: {}
          manager: kube-controller-manager
          operation: Update
          time: "2021-10-25T12:35:29Z"
        name: test-rhvw5
        namespace: kubeturbo-test-action-executor-xlq9l
        resourceVersion: "1004968"
        uid: 9ec5fbe9-e782-41bf-84e8-92e21160e55c
      spec:
        progressDeadlineSeconds: 600
        replicas: 1
        revisionHistoryLimit: 10
        selector:
          matchLabels:
            app: test-app
        strategy:
          rollingUpdate:
            maxSurge: 25%
            maxUnavailable: 25%
          type: RollingUpdate
        template:
          metadata:
            creationTimestamp: null
            labels:
              app: test-app
          spec:
            containers:
            - args:
              - -c
              - while true; do sleep 30; done;
              command:
              - /bin/sh
              image: busybox
              imagePullPolicy: Always
              name: test-cont
              resources:
                limits:
                  cpu: 200m
                  memory: 200Mi
                requests:
                  cpu: 50m
                  memory: 100Mi
              terminationMessagePath: /dev/termination-log
              terminationMessagePolicy: File
            dnsPolicy: ClusterFirst
            restartPolicy: Always
            schedulerName: default-scheduler
            securityContext: {}
            terminationGracePeriodSeconds: 30
      status:
        availableReplicas: 1
        conditions:
        - lastTransitionTime: "2021-10-25T12:35:29Z"
          lastUpdateTime: "2021-10-25T12:35:29Z"
          message: Deployment has minimum availability.
          reason: MinimumReplicasAvailable
          status: "True"
          type: Available
        - lastTransitionTime: "2021-10-25T12:35:22Z"
          lastUpdateTime: "2021-10-25T12:35:29Z"
          message: ReplicaSet "test-rhvw5-7cdf55c674" has successfully progressed.
          reason: NewReplicaSetAvailable
          status: "True"
          type: Progressing
        observedGeneration: 1
        readyReplicas: 1
        replicas: 1
        updatedReplicas: 1
    type: GitHub
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```