### PR TITLE
Reliably get and set kubeturbo version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   global:
     - DOCKER_IMAGE_NAME=$TRAVIS_REPO_SLUG
     - PLATFORM_OS_ARCH_LIST="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
+    - KUBETURBO_VERSION=$TRAVIS_TAG
 
 services:
   - docker
@@ -46,10 +47,10 @@ after_success:
         cd build
         if [ -n "$TRAVIS_TAG" ]; then
             # Push a release image triggered by a git tag
-            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME:$TRAVIS_TAG .
+            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME:$TRAVIS_TAG .
         else
             # Push the latest image built from master branch
-            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME .
+            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME .
         fi
       fi
     fi

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,16 @@ REMOTE=github.com
 USER=turbonomic
 PROJECT=kubeturbo
 BINARY=kubeturbo
+DEFAULT_VERSION=latest
 
 GIT_COMMIT=$(shell git rev-parse HEAD)
 BUILD_TIME=$(shell date -R)
 PROJECT_PATH=$(REMOTE)/$(USER)/$(PROJECT)
-KUBETURBO_VERSION?=latest
+VERSION=$(or $(KUBETURBO_VERSION), $(DEFAULT_VERSION))
 LDFLAGS='\
  -X "$(PROJECT_PATH)/version.GitCommit=$(GIT_COMMIT)" \
  -X "$(PROJECT_PATH)/version.BuildTime=$(BUILD_TIME)" \
- -X "$(PROJECT_PATH)/version.Version=$(KUBETURBO_VERSION)"'
+ -X "$(PROJECT_PATH)/version.Version=$(VERSION)"'
 
 LINUX_ARCH=amd64 arm64 ppc64le s390x
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,5 @@
 FROM registry.access.redhat.com/ubi8
 MAINTAINER Enlin Xu <enlin.xu@turbonomic.com>
-ARG GIT_COMMIT
-ENV GIT_COMMIT ${GIT_COMMIT}
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 

--- a/cmd/kubeturbo/kubeturbo.go
+++ b/cmd/kubeturbo/kubeturbo.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	goflag "flag"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -26,6 +25,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	"github.com/turbonomic/kubeturbo/cmd/kubeturbo/app"
+	"github.com/turbonomic/kubeturbo/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 )
@@ -111,7 +111,8 @@ func main() {
 	defer klog.Flush()
 	defer glog.Flush()
 
-	glog.Infof("Run Kubeturbo service (GIT_COMMIT: %s)", os.Getenv("GIT_COMMIT"))
+	glog.Infof("Running kubeturbo VERSION: %s, GIT_COMMIT: %s, BUILD_TIME: %s",
+		version.Version, version.GitCommit, version.BuildTime)
 
 	s.Run()
 }

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master"
 	"github.com/turbonomic/kubeturbo/pkg/features"
 	"github.com/turbonomic/kubeturbo/pkg/registration"
+	"github.com/turbonomic/kubeturbo/version"
 	"github.com/turbonomic/turbo-go-sdk/pkg/probe"
 	"github.com/turbonomic/turbo-go-sdk/pkg/service"
 )
@@ -178,7 +179,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	// Kubernetes Probe Action Execution Client
 	actionHandler := action.NewActionHandler(actionHandlerConfig)
 
-	probeVersion := extractTagFromImage(config.tapSpec.ProbeContainerImage)
+	probeVersion := version.Version
 	probeDisplayName := getProbeDisplayName(config.tapSpec.TargetType, config.tapSpec.TargetIdentifier)
 
 	probeBuilder := probe.NewProbeBuilder(config.tapSpec.TargetType,
@@ -217,16 +218,6 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	}
 
 	return &K8sTAPService{tapService}, nil
-}
-
-// extractTagFromImage extracts the tag out of the given image string.
-func extractTagFromImage(image string) string {
-	splitsByColon := strings.Split(image, ":")
-	if len(splitsByColon) != 2 {
-		glog.Warningf("Cannot extract a version from the image string %v; return the whole string", image)
-		return image
-	}
-	return splitsByColon[1]
 }
 
 // getProbeDisplayName constructs a display name for the probe based on the input probe type and target id

--- a/pkg/k8s_tap_service_test.go
+++ b/pkg/k8s_tap_service_test.go
@@ -159,35 +159,6 @@ func checkProbeConfig(t *testing.T, pc *configs.ProbeConfig, stitchingPropertyTy
 	}
 }
 
-func TestExtractTagFromImage(t *testing.T) {
-	tests := []struct {
-		inputImageString  string
-		expectedOutputTag string
-	}{
-		{
-			inputImageString:  "foo/kubeturbo:bar",
-			expectedOutputTag: "bar",
-		},
-		{
-			inputImageString:  "foo/kubeturbo",
-			expectedOutputTag: "foo/kubeturbo",
-		},
-		{
-			inputImageString:  "",
-			expectedOutputTag: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.inputImageString, func(t *testing.T) {
-			actualVersion := extractTagFromImage(tt.inputImageString)
-			if actualVersion != tt.expectedOutputTag {
-				t.Errorf("Expected output version is %v from image %v, but the actual output version is %v",
-					tt.expectedOutputTag, tt.inputImageString, actualVersion)
-			}
-		})
-	}
-}
-
 func TestGetProbeDisplayName(t *testing.T) {
 	tests := []struct {
 		inputProbeType            string

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	Version   = "latest"
+	GitCommit = "undefined"
+	BuildTime = "undefined"
+)

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 var (
-	Version   = "latest"
+	Version   = "undefined"
 	GitCommit = "undefined"
 	BuildTime = "undefined"
 )


### PR DESCRIPTION
We need to reliably get and set `kubeturbo` version, and build that into our CI/CD process.

After some investigation, it seems the best way is to set the version at build time using the `ldflags` with `go build`, as mentioned in [this](https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications) post.

This PR:

* Introduce the `version` package, and set `version.Version`, `version.BuildTime` and `version.GitCommit` at build time
* Modify the `Makefile`, `Dockerfile` and `.travis.yml` to support the above semantics accordingly
* Log `kubeturbo` version, build time and git commit head during startup
* Set probe version to `kubeturbo` version

Test

* Create a release through travis using my own account:

  Travis build log:
```
$ make product
env GOOS=linux GOARCH=amd64 go build -ldflags ' -X "github.com/turbonomic/kubeturbo/version.GitCommit=027b817bd4e8f47df7a7303de4854d7378d35691" -X "github.com/turbonomic/kubeturbo/version.BuildTime=Fri, 29 Oct 2021 20:28:57 +0000" -X "github.com/turbonomic/kubeturbo/version.Version=8.3.6"' -o build/linux/amd64/kubeturbo ./cmd/kubeturbo
env GOOS=linux GOARCH=arm64 go build -ldflags ' -X "github.com/turbonomic/kubeturbo/version.GitCommit=027b817bd4e8f47df7a7303de4854d7378d35691" -X "github.com/turbonomic/kubeturbo/version.BuildTime=Fri, 29 Oct 2021 20:29:10 +0000" -X "github.com/turbonomic/kubeturbo/version.Version=8.3.6"' -o build/linux/arm64/kubeturbo ./cmd/kubeturbo
env GOOS=linux GOARCH=ppc64le go build -ldflags ' -X "github.com/turbonomic/kubeturbo/version.GitCommit=027b817bd4e8f47df7a7303de4854d7378d35691" -X "github.com/turbonomic/kubeturbo/version.BuildTime=Fri, 29 Oct 2021 20:33:23 +0000" -X "github.com/turbonomic/kubeturbo/version.Version=8.3.6"' -o build/linux/ppc64le/kubeturbo ./cmd/kubeturbo
env GOOS=linux GOARCH=s390x go build -ldflags ' -X "github.com/turbonomic/kubeturbo/version.GitCommit=027b817bd4e8f47df7a7303de4854d7378d35691" -X "github.com/turbonomic/kubeturbo/version.BuildTime=Fri, 29 Oct 2021 20:37:40 +0000" -X "github.com/turbonomic/kubeturbo/version.Version=8.3.6"' -o build/linux/s390x/kubeturbo ./cmd/kubeturbo
The command "make product" exited with 0.
```

* `kubeturbo` log:

```
I1029 19:52:49.990820       1 kubeturbo.go:114] Running kubeturbo VERSION: 8.3.6, GIT_COMMIT: 027b817bd4e8f47df7a7303de4854d7378d35691, BUILD_TIME: Fri, 29 Oct 2021 15:42:50 -0400
```
