### PR TITLE
Support skipOperator label to directly resize k8s controller regardless of Operator

### DIFF
--- a/pkg/action/executor/k8s_controller.go
+++ b/pkg/action/executor/k8s_controller.go
@@ -3,7 +3,9 @@ package executor
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
 
 	apicorev1 "k8s.io/api/core/v1"
@@ -12,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 
+	actionutil "github.com/turbonomic/kubeturbo/pkg/action/util"
 	"github.com/turbonomic/kubeturbo/pkg/util"
 )
 
@@ -98,8 +101,9 @@ func (c *parentController) update(updatedSpec *k8sControllerSpec) error {
 		return fmt.Errorf("error setting podSpec into unstructured %s %s: %v", kind, objName, err)
 	}
 	controllerOwnerReferences := c.obj.GetOwnerReferences()
-	if controllerOwnerReferences != nil && len(controllerOwnerReferences) == 1 && *controllerOwnerReferences[0].Controller {
+	if !c.shouldSkipOperator(c.obj) && len(controllerOwnerReferences) == 1 && *controllerOwnerReferences[0].Controller {
 		// If k8s controller is controlled by custom controller, update the CR using OperatorResourceMapping
+		// if SkipOperatorLabel is not set or not true.
 		if c.ormClient == nil {
 			return fmt.Errorf("failed to execute action with nil ORMClient")
 		}
@@ -108,6 +112,19 @@ func (c *parentController) update(updatedSpec *k8sControllerSpec) error {
 		_, err = c.dynNamespacedClient.Update(context.TODO(), c.obj, metav1.UpdateOptions{})
 	}
 	return err
+}
+
+// Whether Operator controller should be skipped when executing a resize action on a K8s controller
+// based on the label. If the SkipOperatorLabel is set to true on a K8s controller, resize action
+// will directly update this controller regardless of upper Operator controller.
+func (c *parentController) shouldSkipOperator(controller *unstructured.Unstructured) bool {
+	labelVal, exists := controller.GetLabels()[actionutil.SkipOperatorLabel]
+	if exists && strings.EqualFold(labelVal, "true") {
+		glog.Infof("Directly updating '%s %s/%s' regardless of Operator controller because '%s' label is set to true.",
+			controller.GetKind(), controller.GetNamespace(), controller.GetName(), actionutil.SkipOperatorLabel)
+		return true
+	}
+	return false
 }
 
 func (rc *parentController) String() string {

--- a/pkg/action/executor/k8s_controller.go
+++ b/pkg/action/executor/k8s_controller.go
@@ -118,7 +118,11 @@ func (c *parentController) update(updatedSpec *k8sControllerSpec) error {
 // based on the label. If the SkipOperatorLabel is set to true on a K8s controller, resize action
 // will directly update this controller regardless of upper Operator controller.
 func (c *parentController) shouldSkipOperator(controller *unstructured.Unstructured) bool {
-	labelVal, exists := controller.GetLabels()[actionutil.SkipOperatorLabel]
+	labels := controller.GetLabels()
+	if labels == nil {
+		return false
+	}
+	labelVal, exists := labels[actionutil.SkipOperatorLabel]
 	if exists && strings.EqualFold(labelVal, "true") {
 		glog.Infof("Directly updating '%s %s/%s' regardless of Operator controller because '%s' label is set to true.",
 			controller.GetKind(), controller.GetNamespace(), controller.GetName(), actionutil.SkipOperatorLabel)

--- a/pkg/action/util/util.go
+++ b/pkg/action/util/util.go
@@ -20,6 +20,9 @@ import (
 const (
 	osSccAnnotation = "openshift.io/scc"
 	osSccAllowAll   = "*"
+	// The label to identify the controllers where resizing action execution will be directly update
+	// controller itself if the label is "true" regardless of its Opeartor controller.
+	SkipOperatorLabel = "kubeturbo.io/skipOperator"
 )
 
 var (


### PR DESCRIPTION
JIRA: https://vmturbo.atlassian.net/browse/OM-77357

# Background
1. This story is motivated by the cooperation with an IBM team to enhance the IBM Cirrus platform using Kubeturbo. The applications are managed by their own Operator, where resources can be only configured by certain fixed T-shirt sizes in Operator CR instead of any customized values. For example "profile16" template means 2 cores of CPU limits and 16Gi of memory limits. They have updated their Operator so that when a K8s controller has a certain label, resource changes directly made on this controller won't be reverted by the owner Operator.
2. In current action execution logic in Kubeturbo, when resizing a K8s native controller, if the controller has a CustomResource owner which is a "Controller", we assume this controller is managed by Operator, so the changes will be updated on Operator CR via ORM; otherwise, we directly update the values on this controller.

# Solution
To properly support executing resizing actions on Cirrus platform, we decided to support recognizing a certain generic label on these Operator managed controllers so that action execution will bypass ORM logic and directly update values on the controllers. The proposed label is:
```
labels:
   kubeturbo.io/skipOperator: "true"
```

When this label is set and set to true, resizing action will directly update the controller regardless of upper Operator controller.

Note that the implementation here support setting the label value as **case insensitive** ("true" or "True" will be recognized).

# Testing Done
Setting up an Operator managing a deployment with this label is a little complicated. The way I tested the changes was to just deploy a Deployment by setting the label:
```
  labels:
    kubeturbo.io/skipOperator: "True"
```
and executing the corresponding generated resize action to make sure the logic to check the label works correctly.

The action was successful with following log message:
```
I1110 12:25:43.539296   30414 k8s_controller.go:123] Directly updating 'Deployment testns/cpu-resize-up' regardless of
 Operator controller because 'kubeturbo.io/skipOperator' label is set to true
```
