### PR TITLE
Fix permissions in turbo-cluster-reader and turbo-cluster-admin role

### DIFF
--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/serviceaccount.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/serviceaccount.yaml
@@ -12,7 +12,12 @@ rules:
   - apiGroups:
       - ""
       - apps
+      - app.k8s.io
+      - apps.openshift.io
+      - batch
       - extensions
+      - machine.openshift.io
+      - turbonomic.com
     resources:
       - nodes
       - pods
@@ -26,6 +31,15 @@ rules:
       - resourcequotas
       - persistentvolumes
       - persistentvolumeclaims
+      - applications
+      - jobs
+      - cronjobs
+      - statefulsets
+      - daemonsets
+      - deploymentconfigs
+      - machinesets
+      - machines
+      - operatorresourcemappings
     verbs:
       - get
       - watch
@@ -35,6 +49,8 @@ rules:
     resources:
       - nodes/spec
       - nodes/stats
+      - nodes/metrics
+      - nodes/proxy
     verbs:
       - get
 {{- end }}
@@ -47,31 +63,55 @@ metadata:
 rules:
   - apiGroups:
       - ""
-      - apps
-      - extensions
+      - batch
     resources:
-      - nodes
       - pods
-      - deployments
-      - replicasets
-      - replicationcontrollers
+      - jobs
     verbs:
       - '*'
   - apiGroups:
       - ""
       - apps
+      - apps.openshift.io
+      - extensions
+      - machine.openshift.io
+    resources:
+      - deployments
+      - replicasets
+      - replicationcontrollers
+      - statefulsets
+      - daemonsets
+      - deploymentconfigs
+      - machinesets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - ""
+      - apps
+      - batch
       - extensions
       - policy
+      - app.k8s.io
+      - turbonomic.com
+      - machine.openshift.io
     resources:
+      - nodes
+      - machines
       - services
       - endpoints
       - namespaces
       - limitranges
       - resourcequotas
-      - daemonsets
       - persistentvolumes
       - persistentvolumeclaims
       - poddisruptionbudget
+      - cronjobs
+      - applications
+      - operatorresourcemappings
     verbs:
       - get
       - list
@@ -81,6 +121,9 @@ rules:
     resources:
       - nodes/spec
       - nodes/stats
+      - nodes/metrics
+      - nodes/proxy
+      - pods/log
     verbs:
       - get
 {{- end }}

--- a/deploy/kubeturbo/templates/serviceaccount.yaml
+++ b/deploy/kubeturbo/templates/serviceaccount.yaml
@@ -12,7 +12,12 @@ rules:
   - apiGroups:
       - ""
       - apps
+      - app.k8s.io
+      - apps.openshift.io
+      - batch
       - extensions
+      - machine.openshift.io
+      - turbonomic.com
     resources:
       - nodes
       - pods
@@ -26,6 +31,15 @@ rules:
       - resourcequotas
       - persistentvolumes
       - persistentvolumeclaims
+      - applications
+      - jobs
+      - cronjobs
+      - statefulsets
+      - daemonsets
+      - deploymentconfigs
+      - machinesets
+      - machines
+      - operatorresourcemappings
     verbs:
       - get
       - watch
@@ -35,6 +49,8 @@ rules:
     resources:
       - nodes/spec
       - nodes/stats
+      - nodes/metrics
+      - nodes/proxy
     verbs:
       - get
 {{- end }}
@@ -47,31 +63,55 @@ metadata:
 rules:
   - apiGroups:
       - ""
-      - apps
-      - extensions
+      - batch
     resources:
-      - nodes
       - pods
-      - deployments
-      - replicasets
-      - replicationcontrollers
+      - jobs
     verbs:
       - '*'
   - apiGroups:
       - ""
       - apps
+      - apps.openshift.io
+      - extensions
+      - machine.openshift.io
+    resources:
+      - deployments
+      - replicasets
+      - replicationcontrollers
+      - statefulsets
+      - daemonsets
+      - deploymentconfigs
+      - machinesets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - ""
+      - apps
+      - batch
       - extensions
       - policy
+      - app.k8s.io
+      - turbonomic.com
+      - machine.openshift.io
     resources:
+      - nodes
+      - machines
       - services
       - endpoints
       - namespaces
       - limitranges
       - resourcequotas
-      - daemonsets
       - persistentvolumes
       - persistentvolumeclaims
       - poddisruptionbudget
+      - cronjobs
+      - applications
+      - operatorresourcemappings
     verbs:
       - get
       - list
@@ -81,6 +121,9 @@ rules:
     resources:
       - nodes/spec
       - nodes/stats
+      - nodes/metrics
+      - nodes/proxy
+      - pods/log
     verbs:
       - get
 {{- end }}
@@ -94,7 +137,7 @@ metadata:
   name: {{ .Values.roleBinding }}
 subjects:
   - kind: ServiceAccount
-    name: turbo-user
+    name: {{ .Values.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   # User creating this resource must have permissions to add this policy to the SA


### PR DESCRIPTION
### Motivation
The current `turbo-cluster-reader` and `turbo-cluster-admin` roles are outdated. Customers deploying `kubeturbo` using these roles will hit all kinds of permission issues. This PR attempts to update these role definitions with the minimum required privileges. 

This change affects the operator only. There is a separate PR #621 that updates the yamls. We can update that one and also the helm charts after this PR is approved. 

### Implementation
#### For `turbo-cluster-reader` role
* Add the following missing `resources` along with their corresponding `apiGroups`:
  * applications
  * jobs
  * cronjobs
  * statefulsets
  * daemonsets
  * deploymentconfigs
  * machinesets
  * machines
  * operatorresourcemappings

I put `operatorresourcemappings` resource in the `turbo-cluster-reader` just to get rid of the read permission error in the log.

#### For `turbo-cluster-admin` role
* Put `pods` and `jobs` into a separate section with **full** permission. Both `create` and `delete` permissions are needed for pod move and cpu frequency job
* Put the following controller resources into a separate section with `get`, `list`, `watch`, `update` and `patch` permissions
  * deployments
  * replicasets
  * replicationcontrollers
  * statefulsets
  * daemonsets
  * deploymentconfigs
  * machinesets
* Put the rest of the resources into a separate section with read only `get`, `list`, `watch` permissions

For both roles, add `nodes/metrics` and `nodes/proxy` resources to allow querying of throttling and threshold metrics.
 
For `turbo-cluster-admin` role, add `pods/log` resource to allow getting pods output for cpu frequency job.

Questions for reviewers:

Should I add the following resource to the `turbo-cluster-admin` role? I personally don't think this is needed, as customer who execute turbo-on-turbo actions through ORM most likely won't change the `kubeturbo` role, and will just use the default `cluster-admin` role that comes with the xl installer.
* `apiGroups`: `charts.helm.k8s.io`  
* `resources`: `xls`

Also, with `turbo-cluster-reader` and `turbo-cluster-admin` roles, any custom controller resources not listed in the  resources list cannot be discovered.

### Tests
* Deploy `kubeturbo` with `turbo-cluster-reader` role, observe there is no permission errors accessing read-only resources. The job based CPU frequency getter will fail as expected:
```
E1119 18:55:31.061723       1 kubelet_client.go:393] Failed to get CPU frequency from job on node ip-10-0-254-170.us-east-2.compute.internal: error creating cpufreq job for node: ip-10-0-254-170.us-east-2.compute.internal: jobs.batch is forbidden: User "system:serviceaccount:turbo:kubeturbo-meng-lab2" cannot create resource "jobs" in API group "batch" in the namespace "turbo".
```
* Deploy `kubeturbo` with `turbo-cluster-admin` role, observe there is no permission errors accessing any resources, and the job based CPU frequency getter works fine:
```
W1119 19:06:08.952211       1 kubelet_client.go:329] Failed to get CPU frequency for node ip-10-0-146-14.us-east-2.compute.internal from kubelet: "https://10.0.146.14:10250/spec" was not found. Will try job based getter.
...
...
I1119 19:06:15.361575       1 kubelet_client.go:397] CPU frequency of node ip-10-0-146-14.us-east-2.compute.internal: 3099.747 MHz.
```
* Execute a resize action with `turbo-cluster-admin` role:
```
I1119 19:47:31.385906       1 action_handler.go:356] Received an action RIGHT_SIZE for entity WORKLOAD_CONTROLLER [catalogue]
I1119 19:47:31.395784       1 workload_controller_resizer.go:165] Begin to resize workload controller robotshop/catalogue.
I1119 19:47:31.405129       1 resize_container_util.go:69] Try to update container catalogue resource limit from map[cpu:{i:{value:200 scale:-3} d:{Dec:<nil>} s:200m Format:DecimalSI} memory:{i:{value:104857600 scale:0} d:{Dec:<nil>} s:100Mi Format:BinarySI}] to map[cpu:{{300 -3} {<nil>} 300m DecimalSI} memory:{{104857600 0} {<nil>} 100Mi BinarySI}]
I1119 19:47:31.405162       1 resize_container_util.go:69] Try to update container catalogue resource limit from map[cpu:{i:{value:300 scale:-3} d:{Dec:<nil>} s:300m Format:DecimalSI} memory:{i:{value:104857600 scale:0} d:{Dec:<nil>} s:100Mi Format:BinarySI}] to map[cpu:{{300 -3} {<nil>} 300m DecimalSI} memory:{{239075328 0} {<nil>}  BinarySI}]
I1119 19:47:31.427183       1 k8s_controller_updater.go:147] Successfully updated Deployment robotshop/catalogue

```
