### PR TITLE
Improve logging

### DIFF
--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -349,7 +349,7 @@ func (s *ClusterScraper) UpdatePodControllerCache(
 		controller, exists := controllers[ownerInfo.Uid]
 		if !exists {
 			// Could be custom controller. We do not bulk process custom controller.
-			glog.V(2).Infof("Skip updating controller %v/%v for pod %v/%v: controller not cached.",
+			glog.V(3).Infof("Skip updating controller %v/%v for pod %v/%v: controller not cached.",
 				ownerInfo.Kind, ownerInfo.Name, pod.Namespace, pod.Name)
 			custom++
 			continue

--- a/pkg/discovery/dtofactory/container_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_dto_builder.go
@@ -95,7 +95,7 @@ func (builder *containerDTOBuilder) BuildEntityDTOs(pods []*api.Pod) []*proto.En
 			// Get controllerUID only if Pod is deployed by a K8s controller.
 			controllerUID, err = util.GetControllerUID(pod, builder.metricsSink)
 			if err != nil {
-				glog.Errorf("Error getting controller UID from pod %s, %v", pod.Name, err)
+				glog.V(3).Infof("Cannot find controller UID for pod %s/%s, %v", pod.Namespace, pod.Name, err)
 				continue
 			}
 		}

--- a/pkg/discovery/processor/business_app_processor.go
+++ b/pkg/discovery/processor/business_app_processor.go
@@ -45,7 +45,7 @@ func (p *BusinessAppProcessor) ProcessBusinessApps() {
 
 	apps, err := dynClient.Resource(res).Namespace("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		glog.Warningf("Error while processing application entities: %v", err)
+		glog.Warningf("Failed to list %v from %v/%v: %v", res.Resource, res.Group, res.Version, err)
 		return
 	}
 

--- a/pkg/discovery/processor/service_processor.go
+++ b/pkg/discovery/processor/service_processor.go
@@ -62,7 +62,7 @@ func (p *ServiceProcessor) ProcessServices() {
 		}
 		podClusterIDs := findPodEndpoints(service, serviceEndpoint)
 		if len(podClusterIDs) < 1 {
-			glog.V(2).Infof("Service %s does not have any endpoint pod", serviceClusterID)
+			glog.V(3).Infof("Service %s does not have any endpoint pod", serviceClusterID)
 			continue
 		}
 		glog.V(3).Infof("Service %s with pod endpoints %v", serviceClusterID, podClusterIDs)
@@ -94,8 +94,12 @@ func findPodEndpoints(service *v1.Service, serviceEndpoint *v1.Endpoints) []stri
 			}
 
 			if !strings.EqualFold(target.Kind, "Pod") {
-				glog.Warningf("service: %v depends on non-Pod entity with kind %v and name %v",
-					serviceClusterID, target.Kind, target.Name)
+				// No need to log warning message if service endpoint is a node, as it is a valid case, for example:
+				// kube-system/kubelet service
+				if !strings.EqualFold(target.Kind, "Node") {
+					glog.Warningf("service: %v depends on non-Pod entity with kind %v and name %v",
+						serviceClusterID, target.Kind, target.Name)
+				}
 				continue
 			}
 			podName := target.Name

--- a/pkg/discovery/util/owner_util.go
+++ b/pkg/discovery/util/owner_util.go
@@ -13,7 +13,7 @@ type OwnerInfo struct {
 	Uid  string
 }
 
-// Get owner info by parsing the ownerReference of an object
+// GetOwnerInfo get owner info by parsing the ownerReference of an object
 // A valid owner must be a managing controller, and have non-empty Kind, Name and Uid
 // If there are multiple valid owners, pick the first one
 func GetOwnerInfo(owners []metav1.OwnerReference) (OwnerInfo, bool) {
@@ -41,7 +41,7 @@ func GetOwnerInfo(owners []metav1.OwnerReference) (OwnerInfo, bool) {
 	return ownerInfo, ownerSet
 }
 
-// Check if the input ownerInfo is empty
+// IsOwnerInfoEmpty check if the input ownerInfo is empty
 func IsOwnerInfoEmpty(ownerInfo OwnerInfo) bool {
 	return ownerInfo.Kind == "" || ownerInfo.Name == "" || ownerInfo.Uid == ""
 }

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -283,18 +283,18 @@ func GetPodParentInfo(pod *api.Pod) (OwnerInfo, error) {
 	return OwnerInfo{}, nil
 }
 
-// Get controller UID from the given pod and metrics sink.
+// GetControllerUID get controller UID from the given pod and metrics sink.
 func GetControllerUID(pod *api.Pod, metricsSink *metrics.EntityMetricSink) (string, error) {
 	podKey := PodKeyFunc(pod)
 	ownerUIDMetricId := metrics.GenerateEntityStateMetricUID(metrics.PodType, podKey, metrics.OwnerUID)
 	ownerUIDMetric, err := metricsSink.GetMetric(ownerUIDMetricId)
 	if err != nil {
-		return "", fmt.Errorf("error getting owner UID for pod %s --> %v", podKey, err)
+		return "", err
 	}
 	ownerUID := ownerUIDMetric.GetValue()
 	controllerUID, ok := ownerUID.(string)
 	if !ok {
-		return "", fmt.Errorf("error getting owner UID for pod %s", podKey)
+		return "", fmt.Errorf("owner UID %v is not a string", ownerUID)
 	}
 	return controllerUID, nil
 }

--- a/pkg/discovery/worker/container_spec_metrics_collector.go
+++ b/pkg/discovery/worker/container_spec_metrics_collector.go
@@ -48,7 +48,7 @@ func (collector *ContainerSpecMetricsCollector) CollectContainerSpecMetrics() []
 		if util.HasController(pod) {
 			controllerUID, err := util.GetControllerUID(pod, collector.metricsSink)
 			if err != nil {
-				glog.Errorf("Error getting controller UID from pod %s, %v", pod.Name, err)
+				glog.V(3).Infof("Cannot find controller UID for pod %s/%s, %v", pod.Namespace, pod.Name, err)
 				continue
 			}
 

--- a/pkg/kubeclient/kubelet_client.go
+++ b/pkg/kubeclient/kubelet_client.go
@@ -133,8 +133,8 @@ func (client *KubeletClient) ExecuteRequest(ip, nodeName, path string) ([]byte, 
 			return body, err
 		}
 		if err != nil && client.kubeClient != nil {
-			glog.V(2).Infof("The kubelet endpoint query for path %s to node: %s/%s did not work."+
-				"Trying proxy endpoint.", path, nodeName, ip)
+			glog.V(2).Infof("Failed to query kubelet endpoint %s on node %s/%s: %v. "+
+				"Trying proxy endpoint.", path, nodeName, ip, err)
 			body, err = client.callAPIServerProxyEndpoint(nodeName, path)
 			if err != nil {
 				return body, err


### PR DESCRIPTION
While working and testing #622, I observed a lot of noise in the log. 

I propose the following:

#### Raise log level for the following error or warning messages:
* Service does not have pod endpoints
This could be a valid case. For example, certain services have node as the endpoint. Raise the log level from V(2) to V(3).
* Cannot get controller UID for pod
This could also be valid. Raise the log level from Error to V(3).

#### Log the error when querying `kubelet` endpoint fails

#### Remove certain duplicated loggings