### PR TITLE
Update get pod by uid

### DIFF
--- a/pkg/action/action_handler_test.go
+++ b/pkg/action/action_handler_test.go
@@ -4,22 +4,19 @@ import (
 	"context"
 	"testing"
 
+	api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
 	"github.com/turbonomic/kubeturbo/pkg/action/executor"
 	"github.com/turbonomic/kubeturbo/pkg/action/util"
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	discoveryutil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	"github.com/turbonomic/kubeturbo/pkg/kubeclient"
 	"github.com/turbonomic/kubeturbo/pkg/turbostore"
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-	api "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
-	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
-	client "k8s.io/client-go/kubernetes"
-	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	restclient "k8s.io/client-go/rest"
 )
 
 const (
@@ -168,17 +165,21 @@ func (p *mockProgressTrack) UpdateProgress(actionState proto.ActionResponseState
 type mockPodsGetter struct{}
 
 func (p *mockPodsGetter) Pods(namespace string) v1.PodInterface {
-	return &mockPodInterface{namespace}
+	return &mockPodInterface{
+		discoveryutil.MockPodInterface{
+			Namespace: namespace,
+		},
+	}
 }
 
 type mockPodInterface struct {
-	namespace string
+	discoveryutil.MockPodInterface
 }
 
 func (p *mockPodInterface) Get(ctx context.Context, name string, opts metav1.GetOptions) (*api.Pod, error) {
 	pod := &api.Pod{}
 	pod.Name = name
-	pod.Namespace = p.namespace
+	pod.Namespace = p.Namespace
 	pod.UID = mockPodId
 	pod.Status.Phase = api.PodRunning
 
@@ -186,70 +187,4 @@ func (p *mockPodInterface) Get(ctx context.Context, name string, opts metav1.Get
 	pod.Spec.Containers = []api.Container{c}
 
 	return pod, nil
-}
-
-func (p *mockPodInterface) List(ctx context.Context, opts metav1.ListOptions) (*api.PodList, error) {
-	return nil, nil
-}
-
-func (p *mockPodInterface) Create(ctx context.Context, pod *api.Pod, opts metav1.CreateOptions) (*api.Pod, error) {
-	return nil, nil
-}
-
-func (p *mockPodInterface) Update(ctx context.Context, pod *api.Pod, opts metav1.UpdateOptions) (*api.Pod, error) {
-	return nil, nil
-}
-
-func (p *mockPodInterface) UpdateStatus(ctx context.Context, pod *api.Pod, opts metav1.UpdateOptions) (*api.Pod, error) {
-	return nil, nil
-}
-
-func (p *mockPodInterface) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
-	return nil
-}
-
-func (p *mockPodInterface) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
-	return nil
-}
-
-func (p *mockPodInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-	return nil, nil
-}
-
-func (p *mockPodInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *api.Pod, err error) {
-	return nil, nil
-}
-
-func (p *mockPodInterface) Bind(ctx context.Context, binding *api.Binding, co metav1.CreateOptions) error {
-	return nil
-}
-
-func (p *mockPodInterface) Evict(ctx context.Context, eviction *policyv1beta1.Eviction) error {
-	return nil
-}
-
-func (p *mockPodInterface) EvictV1(ctx context.Context, eviction *policyv1.Eviction) error {
-	return nil
-}
-
-func (p *mockPodInterface) EvictV1beta1(ctx context.Context, eviction *policyv1beta1.Eviction) error {
-	return nil
-}
-
-func (p *mockPodInterface) GetLogs(name string, opts *api.PodLogOptions) *restclient.Request {
-	return nil
-}
-
-func (p *mockPodInterface) ProxyGet(scheme, name, port, path string, params map[string]string) restclient.ResponseWrapper {
-	return nil
-}
-func (p *mockPodInterface) Apply(ctx context.Context, pod *corev1.PodApplyConfiguration, opts metav1.ApplyOptions) (result *api.Pod, err error) {
-	return nil, nil
-}
-func (p *mockPodInterface) ApplyStatus(ctx context.Context, pod *corev1.PodApplyConfiguration, opts metav1.ApplyOptions) (result *api.Pod, err error) {
-	return nil, nil
-}
-
-func (p *mockPodInterface) UpdateEphemeralContainers(ctx context.Context, podName string, pod *api.Pod, opts metav1.UpdateOptions) (*api.Pod, error) {
-	return nil, nil
 }

--- a/pkg/discovery/util/pod_util_test.go
+++ b/pkg/discovery/util/pod_util_test.go
@@ -1,17 +1,18 @@
 package util
 
 import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/golang/glog"
+	"github.com/stretchr/testify/assert"
+
 	k8sapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
-
-	"encoding/json"
-	"fmt"
-	"github.com/golang/glog"
-	"reflect"
-	"testing"
 )
 
 func createPod() *k8sapi.Pod {
@@ -250,5 +251,23 @@ func newPod(name string, podConds ...k8sapi.PodCondition) *k8sapi.Pod {
 		Status: k8sapi.PodStatus{
 			Conditions: podConds,
 		},
+	}
+}
+
+func TestGetPodInPhaseByUid(t *testing.T) {
+	podInterface := &MockPodInterface{}
+
+	// An existing pod should return no error
+	pod, err := GetPodInPhaseByUid(podInterface, testPodUID1, k8sapi.PodRunning)
+	if err != nil {
+		t.Errorf("Failed GetPodInPhaseByUid: %v,", err)
+	}
+	// Found pod should match the UID
+	assert.Equal(t, string(pod.UID), testPodUID1)
+
+	// A non existing pod should return an error
+	_, err = GetPodInPhaseByUid(podInterface, testPodUID3, k8sapi.PodRunning)
+	if err == nil {
+		t.Errorf("GetPodInPhaseByUid should have returned an error.")
 	}
 }

--- a/pkg/discovery/util/test_util.go
+++ b/pkg/discovery/util/test_util.go
@@ -1,0 +1,116 @@
+package util
+
+import (
+	"context"
+
+	api "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	restclient "k8s.io/client-go/rest"
+)
+
+const (
+	testPodName1 string = "pod1"
+	testPodName2 string = "pod2"
+	testPodUID1  string = "pod-UID1"
+	testPodUID2  string = "pod-UID2"
+	testPodUID3  string = "pod-UID3"
+)
+
+// MockPodInterface is used to mock podInterface for testing.
+type MockPodInterface struct {
+	Namespace string
+}
+
+func (p *MockPodInterface) Get(ctx context.Context, name string, opts metav1.GetOptions) (*api.Pod, error) {
+	return nil, nil
+}
+
+func (p *MockPodInterface) List(ctx context.Context, opts metav1.ListOptions) (*api.PodList, error) {
+	pod1 := api.Pod{}
+	pod1.Name = testPodName1
+	pod1.Namespace = p.Namespace
+	pod1.UID = types.UID(testPodUID1)
+	pod1.Status.Phase = api.PodRunning
+
+	pod2 := api.Pod{}
+	pod2.Name = testPodName1
+	pod2.Namespace = p.Namespace
+	pod2.UID = types.UID(testPodUID1)
+	pod2.Status.Phase = api.PodRunning
+
+	podList := api.PodList{
+		Items: []api.Pod{
+			pod1,
+			pod2,
+		},
+	}
+
+	return &podList, nil
+}
+
+func (p *MockPodInterface) Create(ctx context.Context, pod *api.Pod, opts metav1.CreateOptions) (*api.Pod, error) {
+	return nil, nil
+}
+
+func (p *MockPodInterface) Update(ctx context.Context, pod *api.Pod, opts metav1.UpdateOptions) (*api.Pod, error) {
+	return nil, nil
+}
+
+func (p *MockPodInterface) UpdateStatus(ctx context.Context, pod *api.Pod, opts metav1.UpdateOptions) (*api.Pod, error) {
+	return nil, nil
+}
+
+func (p *MockPodInterface) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return nil
+}
+
+func (p *MockPodInterface) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	return nil
+}
+
+func (p *MockPodInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, nil
+}
+
+func (p *MockPodInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *api.Pod, err error) {
+	return nil, nil
+}
+
+func (p *MockPodInterface) Bind(ctx context.Context, binding *api.Binding, co metav1.CreateOptions) error {
+	return nil
+}
+
+func (p *MockPodInterface) Evict(ctx context.Context, eviction *policyv1beta1.Eviction) error {
+	return nil
+}
+
+func (p *MockPodInterface) EvictV1(ctx context.Context, eviction *policyv1.Eviction) error {
+	return nil
+}
+
+func (p *MockPodInterface) EvictV1beta1(ctx context.Context, eviction *policyv1beta1.Eviction) error {
+	return nil
+}
+
+func (p *MockPodInterface) GetLogs(name string, opts *api.PodLogOptions) *restclient.Request {
+	return nil
+}
+
+func (p *MockPodInterface) ProxyGet(scheme, name, port, path string, params map[string]string) restclient.ResponseWrapper {
+	return nil
+}
+func (p *MockPodInterface) Apply(ctx context.Context, pod *corev1.PodApplyConfiguration, opts metav1.ApplyOptions) (result *api.Pod, err error) {
+	return nil, nil
+}
+func (p *MockPodInterface) ApplyStatus(ctx context.Context, pod *corev1.PodApplyConfiguration, opts metav1.ApplyOptions) (result *api.Pod, err error) {
+	return nil, nil
+}
+
+func (p *MockPodInterface) UpdateEphemeralContainers(ctx context.Context, podName string, pod *api.Pod, opts metav1.UpdateOptions) (*api.Pod, error) {
+	return nil, nil
+}


### PR DESCRIPTION
**Motivation**
While executing pod move actions we have sometimes observed the following error:
```
Error executing action Failed to get Pod by padre-stage/prepay-inventory-detection-11-9gmcg: Error to get pod with uid c37341ba-7518-4e60-b197-7b76f25bdd8d: field label not supported: metadata.uid 
```
We use `metadata.uid` as the filter in the pod list api, which does not seem to be supported as of now.  It probably worked when this piece of code was implemented but at some point (in some subsequent release of k8s) has been removed from default field selectors.

**Implementation**
This PR updates the code to use a list search by comparing the UID of each retrieved pod individually instead. It fixes https://vmturbo.atlassian.net/browse/OM-74949.

**Test**
Implemented a simple unit test to verify the updated function.
