### PR TITLE
Add csi based volumes support for stitching

### DIFF
--- a/pkg/discovery/stitching/volume_stitching_manager_test.go
+++ b/pkg/discovery/stitching/volume_stitching_manager_test.go
@@ -1,0 +1,128 @@
+package stitching
+
+import (
+	"strings"
+	"testing"
+
+	api "k8s.io/api/core/v1"
+)
+
+func mockAWSVolume(volID string) *api.PersistentVolume {
+	vol := &api.PersistentVolume{}
+	vol.Spec.AWSElasticBlockStore = &api.AWSElasticBlockStoreVolumeSource{
+		VolumeID: volID,
+	}
+	return vol
+}
+
+func mockAzureVolume(volID string) *api.PersistentVolume {
+	vol := &api.PersistentVolume{}
+	vol.Spec.AzureDisk = &api.AzureDiskVolumeSource{
+		DataDiskURI: volID,
+	}
+	return vol
+}
+
+func mockCSIAWSVolume(volID string) *api.PersistentVolume {
+	vol := &api.PersistentVolume{}
+	vol.Spec.CSI = &api.CSIPersistentVolumeSource{
+		Driver:       "disk.csi.aws.com",
+		VolumeHandle: volID,
+	}
+	return vol
+}
+
+func mockCSIAzureVolume(volID string) *api.PersistentVolume {
+	vol := &api.PersistentVolume{}
+	vol.Spec.CSI = &api.CSIPersistentVolumeSource{
+		Driver:       "disk.csi.azure.com",
+		VolumeHandle: volID,
+	}
+	return vol
+}
+
+func TestAWSVolumeUUIDGetter_GetUUID(t *testing.T) {
+	tests := [][]string{
+		{
+			"aws://us-east-2c/vol-0e4eaa3ef79bcb5a9",
+			"aws::us-east-2::VL::vol-0e4eaa3ef79bcb5a9",
+		},
+	}
+
+	getter := &awsVolumeUUIDGetter{}
+
+	for _, pair := range tests {
+		vol := mockAWSVolume(pair[0])
+		result, err := getter.GetVolumeUUID(vol)
+
+		if err != nil {
+			t.Errorf("Failed to get AWS node UUID: %v", err)
+			continue
+		}
+
+		if strings.Compare(result, pair[1]) != 0 {
+			t.Errorf("Wrong volume stitching UUID %v Vs. %v", result, pair[1])
+		}
+	}
+}
+
+func TestAzureVolumeUUIDGetter_GetUUID(t *testing.T) {
+	tests := [][]string{
+		{
+			"/subscriptions/6a5d73a4-e446-4c75-8f18-073b2f60d851/resourceGroups/mc_adveng_aks-virtual_westus/providers/Microsoft.Compute/disks/kubernetes-dynamic-pvc-0a2016c8-095c-481e-800d-684e277234e4",
+			"::subscriptions::6a5d73a4-e446-4c75-8f18-073b2f60d851::resourcegroups::mc_adveng_aks-virtual_westus::providers::microsoft.compute::disks::kubernetes-dynamic-pvc-0a2016c8-095c-481e-800d-684e277234e4",
+		},
+	}
+
+	getter := &azureVolumeUUIDGetter{}
+
+	for _, pair := range tests {
+		vol := mockAzureVolume(pair[0])
+		result, err := getter.GetVolumeUUID(vol)
+
+		if err != nil {
+			t.Errorf("Failed to get Azure node UUID: %v", err)
+			continue
+		}
+
+		if strings.Compare(result, pair[1]) != 0 {
+			t.Errorf("Wrong volume stitching UUID %v Vs. %v", result, pair[1])
+		}
+	}
+}
+
+func TestCSIVolumeUUIDGetter_GetUUID(t *testing.T) {
+	tests := [][]string{
+		{
+			"aws",
+			"aws://us-east-2c/vol-0e4eaa3ef79bcb5a9",
+			"aws::us-east-2::VL::vol-0e4eaa3ef79bcb5a9",
+		},
+		{
+			"azure",
+			"/subscriptions/6a5d73a4-e446-4c75-8f18-073b2f60d851/resourceGroups/mc_adveng_aks-virtual_westus/providers/Microsoft.Compute/disks/kubernetes-dynamic-pvc-0a2016c8-095c-481e-800d-684e277234e4",
+			"::subscriptions::6a5d73a4-e446-4c75-8f18-073b2f60d851::resourcegroups::mc_adveng_aks-virtual_westus::providers::microsoft.compute::disks::kubernetes-dynamic-pvc-0a2016c8-095c-481e-800d-684e277234e4",
+		},
+	}
+
+	getter := &csiVolumeUUIDGetter{}
+
+	for _, pair := range tests {
+		var vol *api.PersistentVolume
+		if pair[0] == "aws" {
+			vol = mockCSIAWSVolume(pair[1])
+		} else if pair[0] == "azure" {
+			vol = mockCSIAzureVolume(pair[1])
+		}
+		result, err := getter.GetVolumeUUID(vol)
+
+		if err != nil {
+			t.Errorf("Failed to get csi based %s node UUID: %v", pair[0], err)
+			continue
+		}
+
+		if strings.Compare(result, pair[2]) != 0 {
+			t.Errorf("Wrong volume stitching UUID %v Vs. %v", result, pair[2])
+		}
+	}
+}


### PR DESCRIPTION
**Background**
We have a volume stitching support in place which deciphers the needed mechanism to stitch based on the provider specific fields in the volume resource. This does not include the CSI based volume provisioners and lacked the code specific to determine the stitching property if the volume resource has the csi based fields instead.

**Implementation**
Introduce a csi based uuid getter, which deciphers and uses the provider specific stitching info based on the strings in the provisioner driver fields.

This PR fixes https://vmturbo.atlassian.net/browse/OM-74800

**Testing**
Introduced unit test to verify the stitching uuid generation.

After the fix the volumes on the k8s cluster provisioned by csi driver are stitched
```
Irfans-MacBook-Pro:kubeturbo irfanurrehman$ kakspt describe pv pvc-c3db2637-965a-49fe-9fb1-945ef37507bb
Name:              pvc-c3db2637-965a-49fe-9fb1-945ef37507bb
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: disk.csi.azure.com
Finalizers:        [kubernetes.io/pv-protection external-attacher/disk-csi-azure-com]
StorageClass:      default
Status:            Bound
Claim:             default/volume-auto-testing-claim
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          10Gi
Node Affinity:
  Required Terms:
    Term 0:        topology.disk.csi.azure.com/zone in []
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            disk.csi.azure.com
    FSType:
    VolumeHandle:      /subscriptions/758ad253-cbf5-4b18-8863-3eed0825bf07/resourceGroups/mc_pt_group_pt_westus3/providers/Microsoft.Compute/disks/pvc-c3db2637-965a-49fe-9fb1-945ef37507bb
    ReadOnly:          false
    VolumeAttributes:      csi.storage.k8s.io/pv/name=pvc-c3db2637-965a-49fe-9fb1-945ef37507bb
                           csi.storage.k8s.io/pvc/name=volume-auto-testing-claim
                           csi.storage.k8s.io/pvc/namespace=default
                           requestedsizegib=10
                           skuname=StandardSSD_LRS
                           storage.kubernetes.io/csiProvisionerIdentity=1636960314516-8081-disk.csi.azure.com
Events:                <none>
```
![image](https://user-images.githubusercontent.com/10027921/144422730-8fd1c8a2-db2a-43b3-9e36-34f65b248fec.png)
