### PR TITLE
Send probe version as one of the target account values

### DIFF
--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -5,12 +5,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
-
 	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/configs"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/processor"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/worker"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/worker/compliance"
@@ -18,6 +17,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/features"
 	"github.com/turbonomic/kubeturbo/pkg/registration"
 	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
+	kubeturboversion "github.com/turbonomic/kubeturbo/version"
 	sdkprobe "github.com/turbonomic/turbo-go-sdk/pkg/probe"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 
@@ -177,6 +177,13 @@ func (dc *K8sDiscoveryClient) GetAccountValues() *sdkprobe.TurboTargetInfo {
 		accVal = &proto.AccountValue{
 			Key:         &imageID,
 			StringValue: &targetConf.ProbeContainerImageID,
+		}
+		accountValues = append(accountValues, accVal)
+
+		probeVersion := registration.ProbeVersion
+		accVal = &proto.AccountValue{
+			Key:         &probeVersion,
+			StringValue: &kubeturboversion.Version,
 		}
 		accountValues = append(accountValues, accVal)
 	}

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -14,6 +14,7 @@ const (
 	ServerVersion         string = "serverVersion"
 	Image                 string = "image"
 	ImageID               string = "imageID"
+	ProbeVersion          string = "probeVersion"
 	propertyId            string = "id"
 )
 
@@ -87,7 +88,11 @@ func (rClient *K8sRegistrationClient) GetAccountDefinition() (acctDefProps []*pr
 	imageID := builder.NewAccountDefEntryBuilder(ImageID, "Kubeturbo Image ID",
 		"Container Image ID of Kubeturbo Probe", ".*", false, false).Create()
 	acctDefProps = append(acctDefProps, imageID)
-
+	// Probe Version
+	// TODO: Find a good verification regex for probe version
+	probeVersion := builder.NewAccountDefEntryBuilder(ProbeVersion, "Kubeturbo Version",
+		"Release Version of Kubeturbo Probe", ".*", false, false).Create()
+	acctDefProps = append(acctDefProps, probeVersion)
 	return
 }
 


### PR DESCRIPTION
This PR sends `kubeturbo` probe version as one of the target account values, so it can be displayed on the target page, for example:

![image](https://user-images.githubusercontent.com/10012486/144651788-e98ec905-365d-418b-ac60-fc40c033d4d6.png)
