### PR TITLE
Discover argocd app

### DIFF
--- a/pkg/discovery/dtofactory/property/pod_properties.go
+++ b/pkg/discovery/dtofactory/property/pod_properties.go
@@ -2,20 +2,10 @@ package property
 
 import (
 	"fmt"
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-	api "k8s.io/api/core/v1"
-)
 
-const (
-	// TODO currently in the server side only properties in "DEFAULT" namespaces are respected. Ideally we should use "Kubernetes-Pod".
-	k8sPropertyNamespace         = "DEFAULT"
-	VCTagsPropertyNamespace      = "VCTAGS"
-	k8sNamespace                 = "KubernetesNamespace"
-	k8sPodName                   = "KubernetesPodName"
-	k8sNodeName                  = "KubernetesNodeName"
-	k8sContainerIndex            = "Kubernetes-Container-Index"
-	TolerationPropertyNamePrefix = "[k8s toleration]"
-	LabelPropertyNamePrefix      = "[k8s label]"
+	api "k8s.io/api/core/v1"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
 // BuildPodProperties builds entity properties of a pod. The properties are consisted of name and namespace of a pod.

--- a/pkg/discovery/dtofactory/property/property_common.go
+++ b/pkg/discovery/dtofactory/property/property_common.go
@@ -4,6 +4,23 @@ import (
 	"regexp"
 
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+)
+
+const (
+	// TODO currently in the server side only properties in "DEFAULT" namespaces are respected. Ideally we should use "Kubernetes-Pod".
+	k8sPropertyNamespace         = "DEFAULT"
+	VCTagsPropertyNamespace      = "VCTAGS"
+	k8sNamespace                 = "KubernetesNamespace"
+	k8sPodName                   = "KubernetesPodName"
+	k8sNodeName                  = "KubernetesNodeName"
+	k8sContainerIndex            = "Kubernetes-Container-Index"
+	k8sAppNamespace              = "KubernetesAppNamespace"
+	k8sAppName                   = "KubernetesAppName"
+	k8sAppType                   = "KubernetesAppType"
+	TolerationPropertyNamePrefix = "[k8s toleration]"
+	LabelPropertyNamePrefix      = "[k8s label]"
 )
 
 func BuildTagProperty(namespace string, name string, value string) *proto.EntityDTO_EntityProperty {
@@ -38,6 +55,38 @@ func BuildLabelAnnotationProperties(labelMap map[string]string, annotationMap ma
 			}
 		}
 	}
+
+	return properties
+}
+
+// Creates the properties identifying mapped application namespace, name and type
+func BuildBusinessAppRelatedProperties(app repository.K8sApp) []*proto.EntityDTO_EntityProperty {
+	var properties []*proto.EntityDTO_EntityProperty
+	propertyNamespace := k8sPropertyNamespace
+
+	appPropertyNamespaceKey := k8sAppNamespace
+	appPropertyNamespaceValue := app.Namespace
+	properties = append(properties, &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &appPropertyNamespaceKey,
+		Value:     &appPropertyNamespaceValue,
+	})
+
+	appPropertyNameKey := k8sAppName
+	appPropertyNameValue := app.Name
+	properties = append(properties, &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &appPropertyNameKey,
+		Value:     &appPropertyNameValue,
+	})
+
+	appPropertyTypeKey := k8sAppType
+	appPropertyTypeValue := app.Type
+	properties = append(properties, &proto.EntityDTO_EntityProperty{
+		Namespace: &propertyNamespace,
+		Name:      &appPropertyTypeKey,
+		Value:     &appPropertyTypeValue,
+	})
 
 	return properties
 }

--- a/pkg/discovery/processor/business_app_processor.go
+++ b/pkg/discovery/processor/business_app_processor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,70 +32,135 @@ func NewBusinessAppProcessor(clusterScraper cluster.ClusterScraperInterface,
 }
 
 func (p *BusinessAppProcessor) ProcessBusinessApps() {
-	res := schema.GroupVersionResource{
-		Group:    util.K8sApplicationGV.Group,
-		Version:  util.K8sApplicationGV.Version,
-		Resource: util.ApplicationResName}
+	resources := []schema.GroupVersionResource{
+		{
+			Group:    util.K8sApplicationGV.Group,
+			Version:  util.K8sApplicationGV.Version,
+			Resource: util.ApplicationResName,
+		},
+		{
+			Group:    util.ArgoCDApplicationGV.Group,
+			Version:  util.ArgoCDApplicationGV.Version,
+			Resource: util.ApplicationResName,
+		},
+	}
 
+	for _, res := range resources {
+		appToComponentMap := p.ProcessAppsOfType(res)
+		if p.KubeCluster.K8sAppToComponentMap == nil {
+			p.KubeCluster.K8sAppToComponentMap = appToComponentMap
+		} else {
+			for key, val := range appToComponentMap {
+				p.KubeCluster.K8sAppToComponentMap[key] = val
+			}
+		}
+	}
+	p.KubeCluster.ComponentToAppMap = inverseAppToComponentMap(p.KubeCluster.K8sAppToComponentMap)
+
+}
+
+func (p *BusinessAppProcessor) ProcessAppsOfType(res schema.GroupVersionResource) map[repository.K8sApp][]repository.K8sAppComponent {
+	appToComponentMap := make(map[repository.K8sApp][]repository.K8sAppComponent)
 	typedClusterScraper, isClusterScraper := p.ClusterScraper.(*cluster.ClusterScraper)
 	if !isClusterScraper {
 		// This is probably a test run
-		return
+		return appToComponentMap
 	}
 	dynClient := typedClusterScraper.DynamicClient
 
 	apps, err := dynClient.Resource(res).Namespace("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		glog.Warningf("Failed to list %v from %v/%v: %v", res.Resource, res.Group, res.Version, err)
-		return
+		return appToComponentMap
 	}
 
-	appToComponentMap := make(map[repository.K8sApp][]repository.K8sAppComponent)
 	for _, item := range apps.Items {
-		app := appv1beta1.Application{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, &app); err != nil {
-			glog.Warningf("Error converting unstructured app to typed app %v", err)
-			continue
-		}
-
-		selectors := app.Spec.Selector
-		allEntities := []repository.K8sAppComponent{}
-		qualifiedAppName := fmt.Sprintf("%s/%s", app.Namespace, app.Name)
-		for _, gk := range app.Spec.ComponentGroupKinds {
-			entities, err := p.getEntities(selectors, gk, app.Namespace)
+		var allEntities []repository.K8sAppComponent
+		switch res.Group {
+		case util.K8sApplicationGV.Group:
+			allEntities = p.getK8sAppEntities(item)
+		case util.ArgoCDApplicationGV.Group:
+			allEntities, err = p.getArgoCDAppEntities(item)
 			if err != nil {
-				glog.Warningf("Error processing entities for application %s, %v", qualifiedAppName, err)
-				continue
+				glog.Warningf("Failed to get app entities for %v from %v/%v: %v", res.Resource, res.Group, res.Version, err)
+				return appToComponentMap
 			}
-			allEntities = append(allEntities, entities...)
 		}
 
 		application := repository.K8sApp{
-			Uid:       string(app.UID),
-			Namespace: app.Namespace,
-			Name:      app.Name,
+			Uid:       string(item.GetUID()),
+			Namespace: item.GetNamespace(),
+			Name:      item.GetName(),
 		}
 		if len(allEntities) > 0 {
 			appToComponentMap[application] = allEntities
-			glog.V(4).Infof("Discovered %d entities for app:%s, entities: %v", len(allEntities), qualifiedAppName, allEntities)
+			glog.V(4).Infof("Discovered %d entities for app:%s/%s, entities: %v", len(allEntities), item.GetNamespace(), item.GetName(), allEntities)
 		} else {
 			// nil indicates no entities discovered for this applicaiton
 			appToComponentMap[application] = nil
 		}
 	}
 
-	p.KubeCluster.K8sAppToComponentMap = appToComponentMap
-	p.KubeCluster.ComponentToAppMap = inverseAppToComponentMap(appToComponentMap)
+	return appToComponentMap
 }
 
-func (p *BusinessAppProcessor) getEntities(selector *metav1.LabelSelector, gk metav1.GroupKind, namespace string) ([]repository.K8sAppComponent, error) {
-	res := schema.GroupVersionResource{}
-	var err error
+func (p *BusinessAppProcessor) getK8sAppEntities(unstructuredApp unstructured.Unstructured) []repository.K8sAppComponent {
+	app := appv1beta1.Application{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredApp.Object, &app); err != nil {
+		glog.Warningf("Error converting unstructured app to typed app %v", err)
+		return nil
+	}
+
+	selectors := app.Spec.Selector
+	allEntities := []repository.K8sAppComponent{}
+	for _, gk := range app.Spec.ComponentGroupKinds {
+		entities, err := p.getEntitiesViaSelector(selectors, gk, app.Namespace)
+		if err != nil {
+			glog.Warningf("Error processing entities for application %s/%s, %v", app.Namespace, app.Name, err)
+			continue
+		}
+		allEntities = append(allEntities, entities...)
+	}
+
+	return allEntities
+}
+
+func (p *BusinessAppProcessor) getArgoCDAppEntities(unstructuredApp unstructured.Unstructured) ([]repository.K8sAppComponent, error) {
+	allEntities := []repository.K8sAppComponent{}
+	resources, found, err := unstructured.NestedSlice(unstructuredApp.Object, "status", "resources")
+	if err != nil || !found {
+		return allEntities, fmt.Errorf("error retrieving resources from argocd app %s/%s: %v",
+			unstructuredApp.GetNamespace(), unstructuredApp.GetName(), err)
+	}
+
+	for _, res := range resources {
+		typedResource, ok := res.(map[string]interface{})
+		if !ok {
+			glog.Warningf("Decoded wrong resource detail from argocd app %s/%s: %T: %v",
+				unstructuredApp.GetNamespace(), unstructuredApp.GetName(), res, res)
+			continue
+		}
+		gk := metav1.GroupKind{
+			Group: typedResource["group"].(string),
+			Kind:  typedResource["kind"].(string),
+		}
+		entity, err := p.getEntity(gk, typedResource["name"].(string), typedResource["namespace"].(string))
+		if err != nil {
+			glog.Warningf("Error processing entities for argocd app %s/%s entity %v/%v, %v",
+				unstructuredApp.GetNamespace(), unstructuredApp.GetName(), typedResource["group"], typedResource["group"], err)
+			continue
+		}
+		allEntities = append(allEntities, *entity)
+	}
+
+	return allEntities, nil
+}
+
+func renderTypeInfo(gk metav1.GroupKind) (schema.GroupVersionResource, proto.EntityDTO_EntityType, error) {
+	var res schema.GroupVersionResource
 	var entityType proto.EntityDTO_EntityType
 	switch gk.String() {
-	// TODO: standardise this, find a better way,
-	// for example move to using controller-runtime and the need for explicitly
-	// mapping each type might not be there.
+	// TODO: standardise this, or find a better way,
 	// In case we continue to keep these values for gvr make them constants.
 	case "StatefulSet.apps":
 		res = schema.GroupVersionResource{
@@ -132,7 +198,6 @@ func (p *BusinessAppProcessor) getEntities(selector *metav1.LabelSelector, gk me
 			Version:  "v1",
 			Resource: "jobs"}
 		entityType = proto.EntityDTO_WORKLOAD_CONTROLLER
-	// TODO: not sure why service gk returns "Service.v1"
 	case "Service.v1":
 		res = schema.GroupVersionResource{
 			Group:    "",
@@ -146,9 +211,17 @@ func (p *BusinessAppProcessor) getEntities(selector *metav1.LabelSelector, gk me
 			Resource: "pods"}
 		entityType = proto.EntityDTO_CONTAINER_POD
 	default:
-		return nil, fmt.Errorf("unsupport group kind type %s", gk.String())
+		return res, entityType, fmt.Errorf("unsupport group kind type %s", gk.String())
 	}
 
+	return res, entityType, nil
+}
+
+func (p *BusinessAppProcessor) getEntitiesViaSelector(selector *metav1.LabelSelector, gk metav1.GroupKind, namespace string) ([]repository.K8sAppComponent, error) {
+	res, entityType, err := renderTypeInfo(gk)
+	if err != nil {
+		return nil, err
+	}
 	dynClient := p.ClusterScraper.(*cluster.ClusterScraper).DynamicClient
 	resourceList, err := dynClient.Resource(res).Namespace(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Set(selector.MatchLabels).String()})
 	if err != nil {
@@ -168,6 +241,26 @@ func (p *BusinessAppProcessor) getEntities(selector *metav1.LabelSelector, gk me
 	}
 
 	return entities, nil
+}
+
+func (p *BusinessAppProcessor) getEntity(gk metav1.GroupKind, name, namespace string) (*repository.K8sAppComponent, error) {
+	res, entityType, err := renderTypeInfo(gk)
+	if err != nil {
+		return nil, err
+	}
+	dynClient := p.ClusterScraper.(*cluster.ClusterScraper).DynamicClient
+	object, err := dynClient.Resource(res).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &repository.K8sAppComponent{
+		EntityType: entityType,
+		Uid:        string(object.GetUID()),
+		Namespace:  object.GetNamespace(),
+		Name:       object.GetName(),
+	}, nil
+
 }
 
 func inverseAppToComponentMap(appToComponents map[repository.K8sApp][]repository.K8sAppComponent) map[repository.K8sAppComponent][]repository.K8sApp {

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -273,6 +273,11 @@ func parseResourceValue(computeResourceType metrics.ResourceType, resourceList v
 	return DEFAULT_METRIC_VALUE
 }
 
+const (
+	AppTypeK8s    = "k8s"
+	AppTypeArgoCD = "argocd"
+)
+
 type K8sApp struct {
 	Uid       string
 	Namespace string

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -277,6 +277,7 @@ type K8sApp struct {
 	Uid       string
 	Namespace string
 	Name      string
+	Type      string
 }
 
 type K8sAppComponent struct {

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -13,11 +13,12 @@ const (
 	KindReplicationController = "ReplicationController"
 	KindStatefulSet           = "StatefulSet"
 
-	K8sExtensionsGroupName  = "extensions"
-	K8sAppsGroupName        = "apps"
-	K8sApplicationGroupName = "app.k8s.io"
-	OpenShiftAppsGroupName  = "apps.openshift.io"
-	K8sBatchGroupName       = "batch"
+	K8sExtensionsGroupName     = "extensions"
+	K8sAppsGroupName           = "apps"
+	K8sApplicationGroupName    = "app.k8s.io"
+	ArgoCDApplicationGroupName = "argoproj.io"
+	OpenShiftAppsGroupName     = "apps.openshift.io"
+	K8sBatchGroupName          = "batch"
 
 	ReplicationControllerResName = "replicationcontrollers"
 	ReplicaSetResName            = "replicasets"
@@ -44,6 +45,8 @@ var (
 	OpenShiftAPIDeploymentConfigGV = schema.GroupVersion{Group: OpenShiftAppsGroupName, Version: "v1"}
 	// The API group under which application crd resource is installed on the server
 	K8sApplicationGV = schema.GroupVersion{Group: K8sApplicationGroupName, Version: "v1beta1"}
+	// The API group under which ArgoCD application crd resource is installed on the server
+	ArgoCDApplicationGV = schema.GroupVersion{Group: ArgoCDApplicationGroupName, Version: "v1alpha1"}
 	// The API group under which statefulsets are exposed by the k8s cluster
 	K8sAPIStatefulsetGV = schema.GroupVersion{Group: K8sAppsGroupName, Version: "v1"}
 	// The API group under which daemonsets are exposed by the k8s cluster


### PR DESCRIPTION
**Intent**
This PR implements discovering argoCD `applications` as turbo `business apps` and creates a supply chain relation to the  mapped resources if they already exist in the same cluster.

**Background**
As part of the implementation of gitops support in turbo, we chose argoCD as the tool for which we implement support for first. Being able to support the actions which understand the argoCD managed resources we need to discover as much information as possible from the argoCD itself. The information that we need to discover is available as the `argoCD application` (a custom resource akin to k8s upstream `application` resource).

**Implementation**
`ArgoCD application` is discovered as a `business app`, irrespective of the resources which it manages exist in the cluster yet or not. If the resources are found, a supply chain relation is created between the `business app` and the relevant `resources`. This code is intermixed with the upstream application code. The applications are generically discovered information on resources is retrieved based on the `gv (group version)` of the `application`.
Currently there is no direct information (eg suffix in the name) of the application which can identify the business app as the upstream application or the argoCD application.

**Testing**
An argoCD application in the cluster is discovered as business app and correctly mapped to the created resources

```
irf@Irfans-MacBook-Pro kubeturbo % k get applications -n argocd test-app -o yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  creationTimestamp: "2022-01-05T05:38:09Z"
  generation: 506
  name: test-app
  namespace: argocd
  resourceVersion: "539230"
  uid: f653e10d-a261-43de-b808-6b763c5af789
spec:
  destination:
    namespace: default
    server: https://kubernetes.default.svc
  project: default
  source:
    path: gitops-demo
    repoURL: https://github.com/irfanurrehman/Turbo-ScenarioAsCode.git
    targetRevision: HEAD
status:
  health:
    status: Healthy
  history:
  - deployStartedAt: "2022-01-06T11:33:36Z"
    deployedAt: "2022-01-06T11:33:36Z"
    id: 0
    revision: d5dbac473128e23c64a5993747a93b9743b5b111
    source:
      path: gitops-demo
      repoURL: https://github.com/irfanurrehman/Turbo-ScenarioAsCode.git
      targetRevision: HEAD
  operationState:
    finishedAt: "2022-01-06T11:33:36Z"
    message: successfully synced (all tasks run)
    operation:
      initiatedBy:
        username: admin
      retry: {}
      sync:
        revision: d5dbac473128e23c64a5993747a93b9743b5b111
        syncStrategy:
          hook: {}
    phase: Succeeded
    startedAt: "2022-01-06T11:33:36Z"
    syncResult:
      resources:
      - group: apps
        hookPhase: Running
        kind: Deployment
        message: deployment.apps/beekman-gitops created
        name: beekman-gitops
        namespace: default
        status: Synced
        syncPhase: Sync
        version: v1
      revision: d5dbac473128e23c64a5993747a93b9743b5b111
      source:
        path: gitops-demo
        repoURL: https://github.com/irfanurrehman/Turbo-ScenarioAsCode.git
        targetRevision: HEAD
  reconciledAt: "2022-01-06T12:47:10Z"
  resources:
  - group: apps
    health:
      status: Healthy
    kind: Deployment
    name: beekman-gitops
    namespace: default
    status: Synced
    version: v1
  sourceType: Directory
  summary:
    images:
    - beekman9527/cpumemload:latest
  sync:
    comparedTo:
      destination:
        namespace: default
        server: https://kubernetes.default.svc
      source:
        path: gitops-demo
        repoURL: https://github.com/irfanurrehman/Turbo-ScenarioAsCode.git
        targetRevision: HEAD
    revision: d5dbac473128e23c64a5993747a93b9743b5b111
    status: Synced
```

![image](https://user-images.githubusercontent.com/10027921/148385691-8c6f4bd9-d25d-4dd0-a79a-0658daa26921.png)
