### PR TITLE
Fix crash when .Status.NodeRef field is reported null in machine api

### DIFF
--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -145,7 +145,7 @@ func (s *ClusterScraper) GetMachineSetToNodeUIDsMap(nodes []*api.Node) map[strin
 		})
 		nodeUIDs := []string{}
 		for _, machine := range machines {
-			if machine.Status.NodeRef.Name != "" {
+			if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name != "" {
 				if uid := findNodeUID(machine.Status.NodeRef.Name, nodes); uid != "" {
 					nodeUIDs = append(nodeUIDs, uid)
 				}


### PR DESCRIPTION
This fixes the issue reported in https://vmturbo.atlassian.net/browse/OM-79307

**Implementation**
Introduce a null check on the field `.Status.NodeRef` in machine api before using it. Skip if null.

**Testing**
Discovery completes successfully after the fix
With this fix the nodepools created based on opneshift machinesets will be missing from such a cluster

```
I0111 06:56:39.568533       1 remote_mediation_client.go:214] [handleServerMessages][ServerRequestEndpoint] : received message with request type Discovery.
I0111 06:56:39.568588       1 turbo_probe.go:105] Discover Target: [key:"image"  stringValue:"docker.io/irfdocker/kubeturbo:crash-fix" key:"serverVersion"  stringValue:"v1.21.4+6438632, OCP 4.8.19" key:"targetIdentifier"  stringValue:"Kubernetes-ocp-wdc04" key:"imageID"  stringValue:"sha256:39e6d653de143587fe73b8439de75f5eda3800b07621928105e239e537f0a0e0" key:"masterHost"  stringValue:"https://172.30.0.1:443" key:"probeVersion"  stringValue:"latest"]
I0111 06:56:39.568661       1 k8s_discovery_client.go:248] Discovering kubernetes cluster...
I0111 06:56:39.576352       1 cluster_processor.go:162] Obtained kubernetes service ID: 2b6c63c5-e6aa-4dc2-9deb-36948c12485e.
I0111 06:56:39.793842       1 cluster_processor.go:171] Discovering cluster with 6 nodes and 425 pods.
I0111 06:56:39.813839       1 namespace_processor.go:32] There are 82 namespaces.
I0111 06:56:39.815456       1 namespace_processor.go:39] There are 1 resource quotas.
W0111 06:56:40.130091       1 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
I0111 06:56:40.148747       1 service_processor.go:37] There are 175 services.
I0111 06:56:40.161405       1 service_processor.go:45] There are 177 service endpoints.
E0111 06:56:40.161488       1 service_processor.go:60] Cannot find endpoint for service default/openshift
I0111 06:56:40.168263       1 volume_processor.go:31] There are 29 volumes.
I0111 06:56:40.173116       1 volume_processor.go:38] There are 29 volume claims.
...
...
E0111 09:16:42.776545       1 node_pools_group_dto_builder.go:48] Failed to build Node Pool DTO node group NodePool::machineset-isf-rackb-rsqh8-worker-0 [Kubernetes-ocp-wdc04]: NodePool::machineset-isf-rackb-rsqh8-worker-0 [Kubernetes-ocp-wdc04]: GroupBuilder errors: Error 0: empty member list
I0111 09:16:42.776555       1 k8s_discovery_client.go:406] There are totally 18 groups DTOs
I0111 09:16:42.776632       1 k8s_discovery_client.go:420] The cluster DTO has been created successfully: entityType:CONTAINER_PLATFORM_CLUSTER  id:"2b6c63c5-e6aa-4dc2-9deb-36948c12485e"  displayName:"Kubernetes-ocp-wdc04"  commoditiesSold:{commodityType:CLUSTER  key:"cluster-2b6c63c5-e6aa-4dc2-9deb-36948c12485e"  capacity:1e+10}  commoditiesSold:{commodityType:VCPU  used:28534.177385799998  capacity:384000  peak:28534.177385799998  resizable:false}  commoditiesSold:{commodityType:VMEM  used:5.889707195999999e+08  capacity:1.583810856e+09  peak:5.889707195999999e+08  resizable:false}  commoditiesSold:{commodityType:VCPU_REQUEST  used:152572  capacity:381000  peak:152572  resizable:false}  commoditiesSold:{commodityType:VMEM_REQUEST  used:6.334996480068359e+08  capacity:1.576905e+09  peak:6.334996480068359e+08  resizable:false}  commoditiesSold:{commodityType:NUMBER_CONSUMERS  used:365  capacity:1500  peak:365  resizable:false}  entityProperties:{namespace:"DEFAULT"  name:"VCPUUnit"  value:"Millicore"}  powerState:POWERED_ON  providerPolicy:{availableForPlacement:false}  actionEligibility:{suspendable:false  cloneable:false}  container_platform_cluster_data:{vcpuOvercommitment:1.1447916666666667  vmemOvercommitment:1.2612352342658775  vcpuUnit:MILLICORE}
I0111 09:16:42.776781       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 3.210 seconds
I0111 09:16:42.804013       1 remote_mediation_client.go:361] Discovery has finished for 76:FULL
```