### PR TITLE
[OM-79224]: Make action execution timeout configurable when waiting for new pods

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -56,7 +56,7 @@ const (
 	DefaultDiscoverySamples           = 10
 	DefaultDiscoverySampleIntervalSec = 60
 	DefaultGCIntervalMin              = 10
-	DefaultFailureThreshold           = 60
+	DefaultReadinessRetryThreshold    = 60
 )
 
 var (
@@ -149,7 +149,7 @@ type VMTServer struct {
 	// Strategy to aggregate Container usage data on ContainerSpec entity
 	containerUsageDataAggStrategy string
 	// Total number of retrys. When a pod is not ready, Kubeturbo will try failureThreshold times before giving up
-	failureThreshold int
+	readinessRetryThreshold int
 }
 
 // NewVMTServer creates a new VMTServer with default parameters
@@ -203,7 +203,7 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.CpufreqJobExcludeNodeLabels, "cpufreq-job-exclude-node-labels", "", "The comma separated list of key=value node label pairs for the nodes (for example windows nodes) to be excluded from running job based cpufrequency getter.")
 	fs.StringVar(&s.containerUtilizationDataAggStrategy, "cnt-utilization-data-agg-strategy", agg.DefaultContainerUtilizationDataAggStrategy, "Container utilization data aggregation strategy.")
 	fs.StringVar(&s.containerUsageDataAggStrategy, "cnt-usage-data-agg-strategy", agg.DefaultContainerUsageDataAggStrategy, "Container usage data aggregation strategy.")
-	fs.IntVar(&s.failureThreshold, "failure-threshold", DefaultFailureThreshold, "When the pod readiness check fails, Kubeturbo will try failureThreshold times before giving up. Defaults to 60.")
+	fs.IntVar(&s.readinessRetryThreshold, "readiness-retry-threshold", DefaultReadinessRetryThreshold, "When the pod readiness check fails, Kubeturbo will try readinessRetryThreshold times before giving up. Defaults to 60.")
 }
 
 // create an eventRecorder to send events to Kubernetes APIserver
@@ -386,7 +386,7 @@ func (s *VMTServer) Run() {
 		WithVolumePodMoveConfig(s.FailVolumePodMoves).
 		WithQuotaUpdateConfig(s.UpdateQuotaToAllowMoves).
 		WithClusterAPIEnabled(clusterAPIEnabled).
-		WithFailureThreshold(s.failureThreshold)
+		WithReadinessRetryThreshold(s.readinessRetryThreshold)
 	glog.V(3).Infof("Finished creating turbo configuration: %+v", vmtConfig)
 
 	// The KubeTurbo TAP service

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
           {{- if .Values.args.sccsupport }}
           - --scc-support={{ .Values.args.sccsupport }}
           {{- end }}
+          {{ - if .Values.args.failureThreshold }}
+          - --failure-threshold={{ .Values.args.failureThreshold }}
+          {{- end }}
           {{- if .Values.args.failVolumePodMoves }}
           - --fail-volume-pod-moves={{ .Values.args.failVolumePodMoves }}
           {{- end }}

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
@@ -51,8 +51,8 @@ spec:
           {{- if .Values.args.sccsupport }}
           - --scc-support={{ .Values.args.sccsupport }}
           {{- end }}
-          {{ - if .Values.args.failureThreshold }}
-          - --failure-threshold={{ .Values.args.failureThreshold }}
+          {{ - if .Values.args.readinessRetryThreshold }}
+          - --readiness-retry-threshold={{ .Values.args.readinessRetryThreshold }}
           {{- end }}
           {{- if .Values.args.failVolumePodMoves }}
           - --fail-volume-pod-moves={{ .Values.args.failVolumePodMoves }}

--- a/deploy/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
           {{- if .Values.args.sccsupport }}
           - --scc-support={{ .Values.args.sccsupport }}
           {{- end }}
+          {{ - if .Values.args.failureThreshold }}
+          - --failure-threshold={{ .Values.args.failureThreshold }}
+          {{- end }}
           {{- if .Values.args.failVolumePodMoves }}
           - --fail-volume-pod-moves={{ .Values.args.failVolumePodMoves }}
           {{- end }}

--- a/deploy/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo/templates/deployment.yaml
@@ -51,8 +51,8 @@ spec:
           {{- if .Values.args.sccsupport }}
           - --scc-support={{ .Values.args.sccsupport }}
           {{- end }}
-          {{ - if .Values.args.failureThreshold }}
-          - --failure-threshold={{ .Values.args.failureThreshold }}
+          {{ - if .Values.args.readinessRetryThreshold }}
+          - --readiness-retry-threshold={{ .Values.args.readinessRetryThreshold }}
           {{- end }}
           {{- if .Values.args.failVolumePodMoves }}
           - --fail-volume-pod-moves={{ .Values.args.failVolumePodMoves }}

--- a/deploy/kubeturbo_yamls/step5_turbo_kubeturboDeploy.yaml
+++ b/deploy/kubeturbo_yamls/step5_turbo_kubeturboDeploy.yaml
@@ -51,6 +51,8 @@ spec:
           #- --cpufreq-job-exclude-node-labels=kubernetes.io/key=value
           # Uncomment to stitch using IP, or if using Openstack, Hyper-V/VMM
           #- --stitch-uuid=false
+          # Uncomment to customize failure threshold. Kubeturbo will try failureThreshold times before giving up. Default is 60. The retry interval is 10s.
+          #- --failure-threshold=60
         volumeMounts:
           # volume will be created, any name will work and must match below
           - name: turbo-volume

--- a/deploy/kubeturbo_yamls/step5_turbo_kubeturboDeploy.yaml
+++ b/deploy/kubeturbo_yamls/step5_turbo_kubeturboDeploy.yaml
@@ -51,8 +51,8 @@ spec:
           #- --cpufreq-job-exclude-node-labels=kubernetes.io/key=value
           # Uncomment to stitch using IP, or if using Openstack, Hyper-V/VMM
           #- --stitch-uuid=false
-          # Uncomment to customize failure threshold. Kubeturbo will try failureThreshold times before giving up. Default is 60. The retry interval is 10s.
-          #- --failure-threshold=60
+          # Uncomment to customize readiness retry threshold. Kubeturbo will try readiness-retry-threshold times before giving up. Default is 60. The retry interval is 10s.
+          #- --readiness-retry-threshold=60
         volumeMounts:
           # volume will be created, any name will work and must match below
           - name: turbo-volume

--- a/deploy/kubeturbo_yamls/turbo_kubeturbo_full.yaml
+++ b/deploy/kubeturbo_yamls/turbo_kubeturbo_full.yaml
@@ -126,8 +126,8 @@ spec:
           #- --cpufreq-job-exclude-node-labels=kubernetes.io/key=value
           # Uncomment to stitch using IP, or if using Openstack, Hyper-V/VMM
           #- --stitch-uuid=false
-          # Uncomment to customize failure threshold. Kubeturbo will try failureThreshold times before giving up. Default is 60. The retry interval is 10s.
-          #- --failure-threshold=60
+          # Uncomment to customize readiness retry threshold. Kubeturbo will try readiness-retry-threshold times before giving up. Default is 60. The retry interval is 10s.
+          #- --readiness-retry-threshold=60
         volumeMounts:
           # volume will be created, any name will work and must match below
           - name: turbo-volume

--- a/deploy/kubeturbo_yamls/turbo_kubeturbo_full.yaml
+++ b/deploy/kubeturbo_yamls/turbo_kubeturbo_full.yaml
@@ -126,6 +126,8 @@ spec:
           #- --cpufreq-job-exclude-node-labels=kubernetes.io/key=value
           # Uncomment to stitch using IP, or if using Openstack, Hyper-V/VMM
           #- --stitch-uuid=false
+          # Uncomment to customize failure threshold. Kubeturbo will try failureThreshold times before giving up. Default is 60. The retry interval is 10s.
+          #- --failure-threshold=60
         volumeMounts:
           # volume will be created, any name will work and must match below
           - name: turbo-volume

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -52,12 +52,12 @@ type ActionHandlerConfig struct {
 	ormClient               *resourcemapping.ORMClient
 	failVolumePodMoves      bool
 	updateQuotaToAllowMoves bool
-	failureThreshold        int
+	readinessRetryThreshold int
 }
 
 func NewActionHandlerConfig(cApiNamespace string, cApiClient *versioned.Clientset, kubeletClient *kubeletclient.KubeletClient,
 	clusterScraper *cluster.ClusterScraper, sccSupport []string, ormClient *resourcemapping.ORMClient,
-	failVolumePodMoves, updateQuotaToAllowMoves bool, failureThreshold int) *ActionHandlerConfig {
+	failVolumePodMoves, updateQuotaToAllowMoves bool, readinessRetryThreshold int) *ActionHandlerConfig {
 	sccAllowedSet := make(map[string]struct{})
 	for _, sccAllowed := range sccSupport {
 		sccAllowedSet[strings.TrimSpace(sccAllowed)] = struct{}{}
@@ -74,7 +74,7 @@ func NewActionHandlerConfig(cApiNamespace string, cApiClient *versioned.Clientse
 		ormClient:               ormClient,
 		failVolumePodMoves:      failVolumePodMoves,
 		updateQuotaToAllowMoves: updateQuotaToAllowMoves,
-		failureThreshold:        failureThreshold,
+		readinessRetryThreshold: readinessRetryThreshold,
 	}
 
 	return config
@@ -129,7 +129,7 @@ func (h *ActionHandler) registerActionExecutors() {
 	c := h.config
 	ae := executor.NewTurboK8sActionExecutor(c.clusterScraper, c.cApiClient, h.podManager, h.config.ormClient)
 
-	reScheduler := executor.NewReScheduler(ae, c.sccAllowedSet, c.failVolumePodMoves, c.updateQuotaToAllowMoves, h.lockMap, c.failureThreshold)
+	reScheduler := executor.NewReScheduler(ae, c.sccAllowedSet, c.failVolumePodMoves, c.updateQuotaToAllowMoves, h.lockMap, c.readinessRetryThreshold)
 
 	h.actionExecutors[turboActionPodMove] = reScheduler
 

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -52,11 +52,12 @@ type ActionHandlerConfig struct {
 	ormClient               *resourcemapping.ORMClient
 	failVolumePodMoves      bool
 	updateQuotaToAllowMoves bool
+	failureThreshold        int
 }
 
 func NewActionHandlerConfig(cApiNamespace string, cApiClient *versioned.Clientset, kubeletClient *kubeletclient.KubeletClient,
 	clusterScraper *cluster.ClusterScraper, sccSupport []string, ormClient *resourcemapping.ORMClient,
-	failVolumePodMoves, updateQuotaToAllowMoves bool) *ActionHandlerConfig {
+	failVolumePodMoves, updateQuotaToAllowMoves bool, failureThreshold int) *ActionHandlerConfig {
 	sccAllowedSet := make(map[string]struct{})
 	for _, sccAllowed := range sccSupport {
 		sccAllowedSet[strings.TrimSpace(sccAllowed)] = struct{}{}
@@ -73,6 +74,7 @@ func NewActionHandlerConfig(cApiNamespace string, cApiClient *versioned.Clientse
 		ormClient:               ormClient,
 		failVolumePodMoves:      failVolumePodMoves,
 		updateQuotaToAllowMoves: updateQuotaToAllowMoves,
+		failureThreshold:        failureThreshold,
 	}
 
 	return config
@@ -127,7 +129,7 @@ func (h *ActionHandler) registerActionExecutors() {
 	c := h.config
 	ae := executor.NewTurboK8sActionExecutor(c.clusterScraper, c.cApiClient, h.podManager, h.config.ormClient)
 
-	reScheduler := executor.NewReScheduler(ae, c.sccAllowedSet, c.failVolumePodMoves, c.updateQuotaToAllowMoves, h.lockMap)
+	reScheduler := executor.NewReScheduler(ae, c.sccAllowedSet, c.failVolumePodMoves, c.updateQuotaToAllowMoves, h.lockMap, c.failureThreshold)
 
 	h.actionExecutors[turboActionPodMove] = reScheduler
 

--- a/pkg/action/executor/constants.go
+++ b/pkg/action/executor/constants.go
@@ -5,8 +5,10 @@ import (
 )
 
 const (
-	DefaultRetryLess = 3
-	defaultRetryMore = 55
+	// Default Number of Retries for making changes during action execution
+	DefaultExecutionRetry      = 3
+	// Default number of Retries for waiting for Pod to be ready during action execution
+	DefaultWaitForPodThreshold = 55
 
 	DefaultRetrySleepInterval = time.Second * 3
 	DefaultRetryShortTimeout  = time.Second * 20
@@ -15,8 +17,7 @@ const (
 	defaultWaitLockTimeOut = time.Second * 300
 	defaultWaitLockSleep   = time.Second * 10
 
-	defaultPodCheckSleep      = time.Second * 10
-	defaultPodCreateSleep     = time.Second * 11
+	defaultPodCreateSleep     = time.Second * 10
 	defaultUpdateReplicaSleep = time.Second * 20
 
 	// this annotation is set for move/Resize actions;

--- a/pkg/action/executor/constants.go
+++ b/pkg/action/executor/constants.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	// Default Number of Retries for making changes during action execution
-	DefaultExecutionRetry      = 3
+	DefaultExecutionRetry = 3
 	// Default number of Retries for waiting for Pod to be ready during action execution
 	DefaultWaitForPodThreshold = 55
 

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -111,7 +111,7 @@ func GetSupportedResUsingKind(kind, namespace, name string) (schema.GroupVersion
 
 // updateWithRetry updates a specific k8s controller with retry and timeout
 func (c *k8sControllerUpdater) updateWithRetry(ctlrSpec *controllerSpec) error {
-	retryNum := DefaultRetryLess
+	retryNum := DefaultExecutionRetry
 	interval := defaultUpdateReplicaSleep
 	timeout := time.Duration(retryNum+1) * interval
 	err := util.RetryDuring(retryNum, timeout, interval, func() error {

--- a/pkg/action/executor/move_util.go
+++ b/pkg/action/executor/move_util.go
@@ -221,7 +221,7 @@ func movePod(clusterScraper *cluster.ClusterScraper, pod *api.Pod, nodeName, par
 				glog.V(3).Infof("Unpausing pods controller: %s for pod: %s", gPKind, podQualifiedName)
 				// We conservatively try additional 3 times in case of any failure as we don't
 				// want the parent to be left in a bad state.
-				err := commonutil.RetryDuring(DefaultRetryLess, DefaultRetryShortTimeout,
+				err := commonutil.RetryDuring(DefaultExecutionRetry, DefaultRetryShortTimeout,
 					DefaultRetrySleepInterval, func() error {
 						return ResourceRollout(gPClient, grandParent, unpause)
 					})
@@ -250,7 +250,7 @@ func movePod(clusterScraper *cluster.ClusterScraper, pod *api.Pod, nodeName, par
 			glog.V(3).Infof("Updating scheduler of %s for pod %s back to default.", parentKind, podQualifiedName)
 			// We conservatively try additional 3 times in case of any failure as we don't
 			// want the parent to be left in a bad state.
-			err := commonutil.RetryDuring(DefaultRetryLess, DefaultRetryShortTimeout,
+			err := commonutil.RetryDuring(DefaultExecutionRetry, DefaultRetryShortTimeout,
 				DefaultRetrySleepInterval, func() error {
 					return ChangeScheduler(pClient, parent, valid)
 				})
@@ -277,7 +277,6 @@ func movePod(clusterScraper *cluster.ClusterScraper, pod *api.Pod, nodeName, par
 			return nil, err
 		}
 	}
-
 	//step A2/B5: wait until podC gets ready
 	err = podutil.WaitForPodReady(clusterScraper.Clientset, npod.Namespace, npod.Name, nodeName,
 		retryNum, defaultPodCreateSleep)
@@ -369,7 +368,7 @@ func deleteInvalidPendingPods(parent *unstructured.Unstructured, podClient v1.Po
 	// Find the pods which weren't there and if attributed to invalid
 	// turbo-scheduler, delete them.
 	for _, pod := range newPendingInvalidPods(newPodList, podList) {
-		err := commonutil.RetryDuring(DefaultRetryLess, DefaultRetryShortTimeout,
+		err := commonutil.RetryDuring(DefaultExecutionRetry, DefaultRetryShortTimeout,
 			DefaultRetrySleepInterval, func() error {
 				return podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 			})

--- a/pkg/action/executor/rescheduler.go
+++ b/pkg/action/executor/rescheduler.go
@@ -18,18 +18,18 @@ type ReScheduler struct {
 	failVolumePodMoves      bool
 	updateQuotaToAllowMoves bool
 	lockMap                 *util.ExpirationMap
-	failureThreshold        int
+	readinessRetryThreshold int
 }
 
 func NewReScheduler(ae TurboK8sActionExecutor, sccAllowedSet map[string]struct{},
-	failVolumePodMoves, updateQuotaToAllowMoves bool, lockMap *util.ExpirationMap, failureThreshold int) *ReScheduler {
+	failVolumePodMoves, updateQuotaToAllowMoves bool, lockMap *util.ExpirationMap, readinessRetryThreshold int) *ReScheduler {
 	return &ReScheduler{
 		TurboK8sActionExecutor:  ae,
 		sccAllowedSet:           sccAllowedSet,
 		failVolumePodMoves:      failVolumePodMoves,
 		updateQuotaToAllowMoves: updateQuotaToAllowMoves,
 		lockMap:                 lockMap,
-		failureThreshold:        failureThreshold,
+		readinessRetryThreshold: readinessRetryThreshold,
 	}
 }
 
@@ -180,7 +180,7 @@ func (r *ReScheduler) reSchedule(pod *api.Pod, node *api.Node) (*api.Pod, error)
 	}
 	//2. move
 	return movePod(r.clusterScraper, pod, nodeName, ownerInfo.Kind,
-		ownerInfo.Name, r.failureThreshold, r.failVolumePodMoves, r.updateQuotaToAllowMoves, r.lockMap)
+		ownerInfo.Name, r.readinessRetryThreshold, r.failVolumePodMoves, r.updateQuotaToAllowMoves, r.lockMap)
 }
 
 func getVMIps(entity *proto.EntityDTO) []string {

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -260,7 +260,7 @@ func resizeSingleContainer(client *kclient.Clientset, originalPod *k8sapi.Pod, s
 	}()
 
 	// wait until the clone pod gets ready
-	err = podutil.WaitForPodReady(client, clonePod.Namespace, clonePod.Name, "", defaultRetryMore, defaultPodCreateSleep)
+	err = podutil.WaitForPodReady(client, clonePod.Namespace, clonePod.Name, "", DefaultWaitForPodThreshold, defaultPodCreateSleep)
 	if err != nil {
 		glog.Errorf("Wait for cloned Pod ready timeout: %v", err)
 		return nil, err

--- a/pkg/discovery/worker/garbage_collector.go
+++ b/pkg/discovery/worker/garbage_collector.go
@@ -184,7 +184,7 @@ func (g *GarbageCollector) revertControllers() {
 func (g *GarbageCollector) revertSchedulers() {
 	for _, parentRes := range supportedParents {
 		var objList *unstructured.UnstructuredList
-		err := commonutil.RetryDuring(executor.DefaultRetryLess, 0,
+		err := commonutil.RetryDuring(executor.DefaultExecutionRetry, 0,
 			executor.DefaultRetrySleepInterval, func() error {
 				var internalErr error
 				objList, internalErr = g.dynClient.Resource(parentRes).Namespace("").List(context.TODO(), gcListOpts)
@@ -200,7 +200,7 @@ func (g *GarbageCollector) revertSchedulers() {
 		}
 		for _, item := range objList.Items {
 			valid := true
-			err := commonutil.RetryDuring(executor.DefaultRetryLess, 0,
+			err := commonutil.RetryDuring(executor.DefaultExecutionRetry, 0,
 				executor.DefaultRetrySleepInterval, func() error {
 					return executor.ChangeScheduler(g.dynClient.Resource(parentRes).Namespace(item.GetNamespace()), &item, valid)
 				})
@@ -215,7 +215,7 @@ func (g *GarbageCollector) revertSchedulers() {
 func (g *GarbageCollector) unpauseRollouts() {
 	for _, grandParentRes := range supportedGrandParents {
 		var objList *unstructured.UnstructuredList
-		err := commonutil.RetryDuring(executor.DefaultRetryLess, 0,
+		err := commonutil.RetryDuring(executor.DefaultExecutionRetry, 0,
 			executor.DefaultRetrySleepInterval, func() error {
 				var internalErr error
 				objList, internalErr = g.dynClient.Resource(grandParentRes).Namespace("").List(context.TODO(), gcListOpts)
@@ -231,7 +231,7 @@ func (g *GarbageCollector) unpauseRollouts() {
 		}
 		for _, item := range objList.Items {
 			unpause := false
-			err := commonutil.RetryDuring(executor.DefaultRetryLess, 0,
+			err := commonutil.RetryDuring(executor.DefaultExecutionRetry, 0,
 				executor.DefaultRetrySleepInterval, func() error {
 					return executor.ResourceRollout(g.dynClient.Resource(grandParentRes).Namespace(item.GetNamespace()), &item, unpause)
 				})
@@ -244,7 +244,7 @@ func (g *GarbageCollector) unpauseRollouts() {
 
 func (g *GarbageCollector) cleanupQuotas() {
 	var quotaList *api.ResourceQuotaList
-	err := commonutil.RetryDuring(executor.DefaultRetryLess, 0,
+	err := commonutil.RetryDuring(executor.DefaultExecutionRetry, 0,
 		executor.DefaultRetrySleepInterval, func() error {
 			var internalErr error
 			quotaList, internalErr = g.client.CoreV1().ResourceQuotas("").List(context.TODO(), gcListOpts)
@@ -286,7 +286,7 @@ func revertQuota(client *kubernetes.Clientset, quota *api.ResourceQuota) {
 	}
 	executor.RemoveGCLabelFromQuota(quota)
 
-	err = commonutil.RetryDuring(executor.DefaultRetryLess, 0,
+	err = commonutil.RetryDuring(executor.DefaultExecutionRetry, 0,
 		executor.DefaultRetrySleepInterval, func() error {
 			_, err := client.CoreV1().ResourceQuotas(quota.Namespace).Update(context.TODO(), quota, metav1.UpdateOptions{})
 			return err

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -168,7 +168,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 		config.DiscoverySamples, config.DiscoverySampleIntervalSec)
 
 	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.KubeletClient,
-		probeConfig.ClusterScraper, config.SccSupport, config.ORMClient, config.failVolumePodMoves, config.updateQuotaToAllowMoves, config.failureThreshold)
+		probeConfig.ClusterScraper, config.SccSupport, config.ORMClient, config.failVolumePodMoves, config.updateQuotaToAllowMoves, config.readinessRetryThreshold)
 
 	// Kubernetes Probe Registration Client
 	registrationClient := registration.NewK8sRegistrationClient(registrationClientConfig, config.tapSpec.K8sTargetConfig)

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -168,7 +168,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 		config.DiscoverySamples, config.DiscoverySampleIntervalSec)
 
 	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.KubeletClient,
-		probeConfig.ClusterScraper, config.SccSupport, config.ORMClient, config.failVolumePodMoves, config.updateQuotaToAllowMoves)
+		probeConfig.ClusterScraper, config.SccSupport, config.ORMClient, config.failVolumePodMoves, config.updateQuotaToAllowMoves, config.failureThreshold)
 
 	// Kubernetes Probe Registration Client
 	registrationClient := registration.NewK8sRegistrationClient(registrationClientConfig, config.tapSpec.K8sTargetConfig)

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -51,7 +51,7 @@ type Config struct {
 	failVolumePodMoves      bool
 	updateQuotaToAllowMoves bool
 	clusterAPIEnabled       bool
-	failureThreshold        int
+	readinessRetryThreshold int
 }
 
 func NewVMTConfig2() *Config {
@@ -182,7 +182,7 @@ func (c *Config) WithClusterAPIEnabled(clusterAPIEnabled bool) *Config {
 	return c
 }
 
-func (c *Config) WithFailureThreshold(failureThreshold int) *Config {
-	c.failureThreshold = failureThreshold
+func (c *Config) WithReadinessRetryThreshold(readinessRetryThreshold int) *Config {
+	c.readinessRetryThreshold = readinessRetryThreshold
 	return c
 }

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -51,6 +51,7 @@ type Config struct {
 	failVolumePodMoves      bool
 	updateQuotaToAllowMoves bool
 	clusterAPIEnabled       bool
+	failureThreshold        int
 }
 
 func NewVMTConfig2() *Config {
@@ -178,5 +179,10 @@ func (c *Config) WithQuotaUpdateConfig(updateQuotaToAllowMoves bool) *Config {
 
 func (c *Config) WithClusterAPIEnabled(clusterAPIEnabled bool) *Config {
 	c.clusterAPIEnabled = clusterAPIEnabled
+	return c
+}
+
+func (c *Config) WithFailureThreshold(failureThreshold int) *Config {
+	c.failureThreshold = failureThreshold
 	return c
 }

--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -57,7 +57,7 @@ var _ = Describe("Action Executor ", func() {
 			}
 
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, ""), []string{"*"}, nil, false, true)
+				cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, ""), []string{"*"}, nil, false, true, 60)
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 		}
 		namespace = f.TestNamespaceName()

--- a/test/integration/pod_move_with_quota.go
+++ b/test/integration/pod_move_with_quota.go
@@ -76,7 +76,7 @@ spec:
 			}
 
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, ""), []string{"*"}, nil, false, true)
+				cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, ""), []string{"*"}, nil, false, true, 60)
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 
 			namespace = f.TestNamespaceName()
@@ -115,7 +115,7 @@ spec:
 
 		It("should fail the action if the quota-update is disabled", func() {
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, ""), []string{"*"}, nil, false, false)
+				cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, ""), []string{"*"}, nil, false, false, 60)
 			actionHandler := action.NewActionHandler(actionHandlerConfig)
 
 			quota := createQuota(kubeClient, namespace, quotaFromYaml(quotaYaml))


### PR DESCRIPTION
Issue:
We identify the issues during the call with Florida Blue, that our timeout when waiting for new pods ready is pre-mature. In certain cases, the new pod will take longer than our default 10 mins timeout.

Fix:
We decided to introduce two changes. 1) Make timeout configurable. 2) Make timeout adaptive if readiness probe is set. This review includes the change needed for 1).
The value can be customized in yaml with --readiness-retry-threshold
Or in helm and operator using readinessRetryThreshold

Test:
Artificially use readiness-retry-threshold = 10 with 1s interval. I can see action failed due to timeout.
![Screen Shot 2022-01-12 at 1 26 13 PM](https://user-images.githubusercontent.com/4391815/149217134-bce9319c-0710-4936-a7eb-df489b11fe1d.png)

The following log (in v4) also indicates it worked as expected.

I0112 13:25:42.166028   42244 go_util.go:103] [retry-1/10] Warning pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Pending state
I0112 13:25:43.186118   42244 go_util.go:103] [retry-2/10] Warning pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Pending state, ContainersNotInitialized, ContainersNotReady, container istio-proxy is waiting due to PodInitializing, container twitter-cass-api is waiting due to PodInitializing
I0112 13:25:44.243834   42244 go_util.go:103] [retry-3/10] Warning pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Pending state, ContainersNotInitialized, ContainersNotReady, container istio-proxy is waiting due to PodInitializing, container twitter-cass-api is waiting due to PodInitializing
I0112 13:25:45.263718   42244 go_util.go:103] [retry-4/10] Warning pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Pending state, ContainersNotInitialized, ContainersNotReady, container istio-proxy is waiting due to PodInitializing, container twitter-cass-api is waiting due to PodInitializing
I0112 13:25:46.288024   42244 go_util.go:103] [retry-5/10] Warning pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Pending state, ContainersNotReady, container istio-proxy is waiting due to PodInitializing, container twitter-cass-api is waiting due to PodInitializing
I0112 13:25:47.306356   42244 go_util.go:103] [retry-6/10] Warning pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Pending state, ContainersNotReady, container istio-proxy is waiting due to PodInitializing, container twitter-cass-api is waiting due to PodInitializing
I0112 13:25:48.330656   42244 go_util.go:103] [retry-7/10] Warning pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Pending state, ContainersNotReady, container istio-proxy is waiting due to PodInitializing, container twitter-cass-api is waiting due to PodInitializing
I0112 13:25:50.406595   42244 go_util.go:103] [retry-8/10] Warning pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Pending state, ContainersNotReady, container istio-proxy is waiting due to PodInitializing, container twitter-cass-api is waiting due to PodInitializing
I0112 13:25:51.648771   42244 go_util.go:103] [retry-9/10] Warning pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Pending state, ContainersNotReady, container istio-proxy is waiting due to PodInitializing, container twitter-cass-api is waiting due to PodInitializing
I0112 13:25:53.020603   42244 go_util.go:103] [retry-10/10] Warning pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Running state, ContainersNotReady
E0112 13:25:53.020633   42244 go_util.go:120] Failed after 10 attepmts, last error: pod twitter-cass-api-5bd5898d6b-ftl4m-1dicp55eroefg is in Running state, ContainersNotReady

