### PR TITLE
[OM-79497]: Make timeout adaptive according to readiness probe

### DIFF
--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -260,7 +260,7 @@ func resizeSingleContainer(client *kclient.Clientset, originalPod *k8sapi.Pod, s
 	}()
 
 	// wait until the clone pod gets ready
-	err = podutil.WaitForPodReady(client, clonePod.Namespace, clonePod.Name, "", DefaultWaitForPodThreshold, defaultPodCreateSleep)
+	err = podutil.WaitForPodReady(client, clonePod.Namespace, clonePod.Name, "", 0, DefaultWaitForPodThreshold, defaultPodCreateSleep)
 	if err != nil {
 		glog.Errorf("Wait for cloned Pod ready timeout: %v", err)
 		return nil, err

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -311,8 +311,11 @@ func GetControllerUID(pod *api.Pod, metricsSink *metrics.EntityMetricSink) (stri
 //
 // TODO:
 // Use k8s watch API to eliminate the need for polling and improve efficiency
-func WaitForPodReady(client *client.Clientset, namespace, podName, nodeName string,
-	retry int, interval time.Duration) error {
+func WaitForPodReady(client *client.Clientset, namespace, podName, nodeName string, initDelay time.Duration,
+	retry int32, interval time.Duration) error {
+	if initDelay > 0 {
+		time.Sleep(initDelay)
+	}
 	// check pod readiness with retries
 	timeout := time.Duration(retry+1) * interval
 	err := commonutil.RetrySimple(retry, timeout, interval, func() (bool, error) {

--- a/pkg/util/go_util.go
+++ b/pkg/util/go_util.go
@@ -90,11 +90,12 @@ func RetryDuring(attempts int, timeout time.Duration, sleep time.Duration, myfun
 }
 
 //RetrySimple executes a function with retries and a timeout
-func RetrySimple(attempts int, timeout, sleep time.Duration, myfunc func() (bool, error)) error {
+func RetrySimple(attempts int32, timeout, sleep time.Duration, myfunc func() (bool, error)) error {
 	t0 := time.Now()
 
 	var err error
-	for i := 0; ; i++ {
+	var i int32
+	for i = 0; ; i++ {
 		retry := false
 		if retry, err = myfunc(); !retry {
 			return err


### PR DESCRIPTION
Issue:
Sometimes user has their own readiness probe set and it could be longer than the timeout we have. Timeout such action will be premature.

Implementation:
When executing the action, we will discover the readiness probe for each container in the pod, and use the following attributes:
FailureThreshold: Number of retries before giving up
InitialDelaySeconds: Initial delay before checking readiness
PeriodSeconds: Retry interval.

If any of the attribute is larger than our default, we are going to use that value instead.
Init Container case is not yet considered.

Test:
Created additional test assets in Turbo-ScenarioAsCode (will add to that repo later) and observed expected behavior with and without readiness probe defined.