### PR TITLE
Fix the typo in helm and operator install

### DIFF
--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           {{- if .Values.args.sccsupport }}
           - --scc-support={{ .Values.args.sccsupport }}
           {{- end }}
-          {{ - if .Values.args.readinessRetryThreshold }}
+          {{- if .Values.args.readinessRetryThreshold }}
           - --readiness-retry-threshold={{ .Values.args.readinessRetryThreshold }}
           {{- end }}
           {{- if .Values.args.failVolumePodMoves }}

--- a/deploy/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           {{- if .Values.args.sccsupport }}
           - --scc-support={{ .Values.args.sccsupport }}
           {{- end }}
-          {{ - if .Values.args.readinessRetryThreshold }}
+          {{- if .Values.args.readinessRetryThreshold }}
           - --readiness-retry-threshold={{ .Values.args.readinessRetryThreshold }}
           {{- end }}
           {{- if .Values.args.failVolumePodMoves }}


### PR DESCRIPTION
Thanks to Arsen's test, there's a typo in the yaml for operator and helm. Trivial change.
