### PR TITLE
OM-79460 Refactored to use new ConnectedEntityMessage

### DIFF
--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
@@ -62,11 +62,11 @@ func (builder *workloadControllerDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, er
 				kubeController.GetFullName())
 		}
 
-		// To connect WorkloadController to ContainerSpec entity, WorkloadController consistsOf the associated ContainerSpecs.
-		// The platform will translate this into the following relation:
-		// WorkloadController owns Containers
+		// To connect WorkloadController to ContainerSpec entity, WorkloadController owns the associated ContainerSpecs.
 		containerSpecsIds := builder.getContainerSpecIds(kubeController)
-		entityDTOBuilder.ConsistsOf(containerSpecsIds)
+		for _, containerSpecId := range containerSpecsIds {
+			entityDTOBuilder.Owns(containerSpecId)
+		}
 
 		// Create WorkloadControllerData to store controller type data
 		entityDTOBuilder.WorkloadControllerData(builder.createWorkloadControllerData(kubeController))

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
@@ -62,7 +62,7 @@ func (builder *workloadControllerDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, er
 				kubeController.GetFullName())
 		}
 
-		// To connect WorkloadController to ContainerSpec entity, WorkloadController owns the associated ContainerSpecs.
+		// Connect WorkloadController to ContainerSpec entity, WorkloadController owns the associated ContainerSpecs.
 		containerSpecsIds := builder.getContainerSpecIds(kubeController)
 		for _, containerSpecId := range containerSpecsIds {
 			entityDTOBuilder.Owns(containerSpecId)

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
@@ -85,6 +85,11 @@ func TestBuildDTOs(t *testing.T) {
 			}
 			workloadControllerData1 := entityDTO.GetWorkloadControllerData()
 			assert.EqualValues(t, expectedWorkloadControllerData1, workloadControllerData1)
+
+			// Test Owns connection
+			assert.Equal(t, 2, len(entityDTO.ConnectedEntities))
+			assert.Equal(t, proto.ConnectedEntity_OWNS_CONNECTION, entityDTO.ConnectedEntities[1].GetConnectionType())
+			assert.Equal(t, "controller1-UID/Foo", entityDTO.ConnectedEntities[1].GetConnectedEntityId())
 		} else if entityDTO.GetId() == "controller2-UID" {
 			// cloneable and suspendable is false for WorkloadController
 			actionEligibility := entityDTO.GetActionEligibility()
@@ -159,6 +164,16 @@ func createKubeController(clustername, namespace, name, controllerType, uid stri
 	for _, allocationResource := range testAllocationResources {
 		kubeController.AddAllocationResource(allocationResource.Type, allocationResource.Capacity, allocationResource.Used)
 	}
+	pod := &api.Pod{
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name: "Foo",
+				},
+			},
+		},
+	}
+	kubeController.Pods = append(kubeController.Pods, pod)
 	return kubeController
 }
 


### PR DESCRIPTION
# Issue
Some probes are using the deprecated connections (consistsOf) instead of the new XL connection (owns). The topology processor converts the deprecated connections to the new type. Removing the need for the conversion should provide a small performance boost, as well as get us off the deprecated code.

# Test
Debugged topology processor to verify that the [conversion logic](https://git.turbonomic.com/turbonomic/xl/-/blob/staging/com.vmturbo.topology.processor/src/main/java/com/vmturbo/topology/processor/stitching/TopologyStitchingGraph.java#L372) was no longer being hit.

Pulled topology from the processor and verified it matched the data pulled before the change. 

Pulled diagnostics and verified that the entities were correct. 

Ran the unit tests.
