### PR TITLE
Update go version to 1.17.6 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - docker
 
 go:
-  - 1.17
+  - 1.17.6
  
 go_import_path: github.com/turbonomic/kubeturbo
 


### PR DESCRIPTION
Update go version to `1.17.6` to fix security vulnerability:



CVE | Severity | Fixed GO version
-- | -- | --
2021-38297 | Critical | 1.17.2, 1.16.9
2021-44716 | High | 1.17.5, 1.16.12
2021-41772 | High | 1.17.3, 1.16.10
2021-41771 | High | 1.17.3, 1.16.10
2021-39293 | High | 1.17.1, 1.16.8

