### PR TITLE
Print out go version

### DIFF
--- a/cmd/kubeturbo/kubeturbo.go
+++ b/cmd/kubeturbo/kubeturbo.go
@@ -111,8 +111,8 @@ func main() {
 	defer klog.Flush()
 	defer glog.Flush()
 
-	glog.Infof("Running kubeturbo VERSION: %s, GIT_COMMIT: %s, BUILD_TIME: %s",
-		version.Version, version.GitCommit, version.BuildTime)
+	glog.Infof("Running kubeturbo VERSION: %s, GIT_COMMIT: %s, BUILD_TIME: %s, GO_VERSION: %s",
+		version.Version, version.GitCommit, version.BuildTime, runtime.Version())
 
 	s.Run()
 }


### PR DESCRIPTION
Print out go version during `kubeturbo` start up.

```
mengding@mengding-mac$ ./kubeturbo 
I0128 11:39:32.225185   77349 kubeturbo.go:114] Running kubeturbo VERSION: latest, GIT_COMMIT: 9c75e721f70312b65c0356e90c7478d509e94fa1, BUILD_TIME: Fri, 28 Jan 2022 11:39:20 -0500, GO_VERSION: go1.17.6
...
```