### PR TITLE
Use TAINT commodity to represent taint and tolerations

### DIFF
--- a/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
-
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 )
 
 var (
@@ -69,7 +70,7 @@ func TestProcess(t *testing.T) {
 	entityDTOs := []*proto.EntityDTO{podDTO1, podDTO2, podDTO3, nodeDTO1, nodeDTO2, nodeDTO3, otherDTO1}
 	taintTolerationProcessor.Process(entityDTOs)
 
-	// Check entity DTOs for access commodities created from taints and tolerations
+	// Check entity DTOs for taint commodities created from taints and tolerations
 	checkPodEntity(t, podDTO1, "node-1")
 	checkPodEntity(t, podDTO2, "node-2")
 	checkPodEntity(t, podDTO3, "node-3")
@@ -110,7 +111,7 @@ func (m *mockNodeAndPodGetter) GetAllPods() ([]*api.Pod, error) {
 
 func TestGetTaintCollection(t *testing.T) {
 	// The unschedulable taint with any effect should be skipped from the taints collection
-	// effectively resulting in no access commodity created for the same.
+	// effectively resulting in no taint commodity created for the same.
 	unschedulableNodeTaint1 := newTaint(unschedulableNodeTaintKey, "", api.TaintEffectNoSchedule)
 	unschedulableNodeTaint2 := newTaint(unschedulableNodeTaintKey, "", api.TaintEffectNoExecute)
 	nodes[string(n1.UID)].Spec.Taints = append(nodes[string(n1.UID)].Spec.Taints,
@@ -136,10 +137,10 @@ func TestGetTaintCollection(t *testing.T) {
 	}
 }
 
-func TestCreateTaintAccessComms(t *testing.T) {
+func TestCreateTaintCommsSold(t *testing.T) {
 	taintCollection := getTaintCollection(nodes)
 
-	comms, err := createTaintAccessComms(n1, taintCollection)
+	comms, err := createTaintCommsSold(n1, taintCollection)
 
 	if err != nil {
 		t.Errorf("Error: %v", err)
@@ -153,7 +154,7 @@ func TestCreateTaintAccessComms(t *testing.T) {
 		t.Errorf("Comm %+v has wrong key %s", comms[0], *(comms[0].Key))
 	}
 
-	comms2, err := createTaintAccessComms(n2, taintCollection)
+	comms2, err := createTaintCommsSold(n2, taintCollection)
 
 	if len(comms2) != 1 {
 		t.Errorf("Expected 1 commodity but got %d", len(comms2))
@@ -163,7 +164,7 @@ func TestCreateTaintAccessComms(t *testing.T) {
 		t.Errorf("Comm %+v has wrong key %s", comms2[0], *(comms2[0].Key))
 	}
 
-	comms3, err := createTaintAccessComms(n3, taintCollection)
+	comms3, err := createTaintCommsSold(n3, taintCollection)
 
 	if len(comms3) != 2 {
 		t.Errorf("Expected 2 commodities but got %d", len(comms3))
@@ -178,14 +179,14 @@ func TestCreateTaintAccessComms(t *testing.T) {
 	}
 }
 
-func TestCreateTolerationAccessComms(t *testing.T) {
+func TestCreateTaintCommsBought(t *testing.T) {
 	taintCollection := getTaintCollection(nodes)
 
-	testTolerationAccessComms(t, pod1, taintCollection, []string{key1, key2})
+	testTaintCommsBought(t, pod1, taintCollection, []string{key1, key2})
 
-	testTolerationAccessComms(t, pod2, taintCollection, []string{key2})
+	testTaintCommsBought(t, pod2, taintCollection, []string{key2})
 
-	testTolerationAccessComms(t, pod3, taintCollection, []string{})
+	testTaintCommsBought(t, pod3, taintCollection, []string{})
 }
 
 func newNodeWithTaints(id string, taints []api.Taint) *api.Node {
@@ -238,8 +239,8 @@ func newToleration(key, value string, effect api.TaintEffect, tolerationOp api.T
 	return toleration
 }
 
-func testTolerationAccessComms(t *testing.T, pod *api.Pod, taintCollection map[api.Taint]string, keys []string) {
-	comms, err := createTolerationAccessComms(pod, taintCollection)
+func testTaintCommsBought(t *testing.T, pod *api.Pod, taintCollection map[api.Taint]string, keys []string) {
+	comms, err := createTaintCommsBought(pod, taintCollection)
 
 	if err != nil {
 		t.Errorf("Error: %v", err)

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -3,13 +3,13 @@ package registration
 import (
 	"fmt"
 
-	"github.com/turbonomic/turbo-go-sdk/pkg/builder"
-
-	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
-
 	"github.com/golang/glog"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"github.com/turbonomic/turbo-go-sdk/pkg/supplychain"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 )
 
 var (
@@ -28,6 +28,7 @@ var (
 	vStorageType           = proto.CommodityDTO_VSTORAGE
 	storageAmountType      = proto.CommodityDTO_STORAGE_AMOUNT
 	numberReplicasType     = proto.CommodityDTO_NUMBER_REPLICAS
+	taintType              = proto.CommodityDTO_TAINT
 
 	fakeKey = "fake"
 
@@ -70,6 +71,7 @@ var (
 	vmpmAccessTemplateComm         = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &vmPMAccessType}
 	applicationTemplateCommWithKey = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &appCommType}
 	clusterTemplateCommWithKey     = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &clusterType}
+	taintTemplateCommWithKey       = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &taintType}
 
 	// Resold TemplateCommodity with key
 	vCpuLimitQuotaTemplateCommWithKeyResold   = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &vCpuLimitQuotaType, IsResold: &commIsResold}
@@ -254,6 +256,7 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 	return mergedEntityMetadataBuilder.
 		PatchSoldMetadata(proto.CommodityDTO_CLUSTER, fieldsCapactiy).
 		PatchSoldMetadata(proto.CommodityDTO_VMPM_ACCESS, fieldsCapactiy).
+		PatchSoldMetadata(proto.CommodityDTO_TAINT, fieldsCapactiy).
 		PatchSoldMetadata(proto.CommodityDTO_VCPU, fieldsUsedCapacityPeak).
 		PatchSoldMetadata(proto.CommodityDTO_VMEM, fieldsUsedCapacityPeak).
 		PatchSoldMetadata(proto.CommodityDTO_VCPU_REQUEST, fieldsUsedCapacity).
@@ -279,8 +282,9 @@ func (f *SupplyChainFactory) buildNodeSupplyBuilder() (*proto.TemplateDTO, error
 		Sells(vMemRequestTemplateComm).        // sells to Pods
 		Sells(vmpmAccessTemplateComm).         // sells to Pods
 		Sells(numPodNumConsumersTemplateComm). // sells to Pods
-		Sells(vStorageTemplateComm)            // sells to Pods
-		// also sells Cluster to Pods
+		Sells(vStorageTemplateComm).           // sells to Pods
+		Sells(taintTemplateCommWithKey)
+	// also sells Cluster to Pods
 
 	return nodeSupplyChainNodeBuilder.Create()
 }
@@ -355,6 +359,7 @@ func (f *SupplyChainFactory) buildPodSupplyBuilder() (*proto.TemplateDTO, error)
 		Buys(vMemRequestTemplateComm).
 		Buys(numPodNumConsumersTemplateComm).
 		Buys(vStorageTemplateComm).
+		Buys(taintTemplateCommWithKey).
 		ProviderOpt(proto.EntityDTO_WORKLOAD_CONTROLLER, proto.Provider_HOSTING, &isProviderOptional).
 		Buys(vCpuLimitQuotaTemplateCommWithKey).
 		Buys(vMemLimitQuotaTemplateCommWithKey).


### PR DESCRIPTION
This PR uses `TATINT` commodity to represent taint and tolerations discovered in a Kubernetes cluster. Supply chain definition is also updated to add the `TAINT` commodity, and update the merging metadata.

![image](https://user-images.githubusercontent.com/10012486/152613747-23e21323-969e-47c0-86f0-e4f97e5a6e1e.png)

