### PR TITLE
Add kubernetes orchestrator property to k8s nodes

### DIFF
--- a/pkg/discovery/dtofactory/property/node_properties.go
+++ b/pkg/discovery/dtofactory/property/node_properties.go
@@ -6,6 +6,11 @@ import (
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
+const (
+	k8sOrchestratorName  = "orchestrator"
+	k8sOrchestratorValue = "Kubernetes"
+)
+
 // Build entity properties for a node. The name is the name of the node shown inside Kubernetes cluster.
 func BuildNodeProperties(node *api.Node) []*proto.EntityDTO_EntityProperty {
 	var properties []*proto.EntityDTO_EntityProperty
@@ -32,6 +37,16 @@ func BuildNodeProperties(node *api.Node) []*proto.EntityDTO_EntityProperty {
 		properties = append(properties, tagProperty)
 	}
 
+	orchestratorNamespace := VCTagsPropertyNamespace
+	orchestratorName := k8sOrchestratorName
+	orchestratorValue := k8sOrchestratorValue
+	orchestratorProperty := &proto.EntityDTO_EntityProperty{
+		Namespace: &orchestratorNamespace,
+		Name:      &orchestratorName,
+		Value:     &orchestratorValue,
+	}
+
+	properties = append(properties, orchestratorProperty)
 	return properties
 }
 

--- a/pkg/discovery/dtofactory/property/pod_properties.go
+++ b/pkg/discovery/dtofactory/property/pod_properties.go
@@ -1,9 +1,10 @@
 package property
 
 import (
+	"fmt"
+
 	api "k8s.io/api/core/v1"
 
-	"fmt"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 


### PR DESCRIPTION
**Intent**
Implementation of the suspend functionality in Azure probe needs identification of the VM as a regular VM or an AKS VM. This implementation aids the same.
Ref https://vmturbo.atlassian.net/browse/OM-80453

**Background**
While an AKS provisioned VM already carries a `orchestrator` or an `aks-managed-orchestrator` tag, there might be clusters where this tag is missing on the AKS VM.

Example
![image](https://user-images.githubusercontent.com/10027921/153208725-098ae289-3a16-420b-bf1b-7f6e6c3653b7.png)

**Implementation**
This implementation adds an `orchestrator`:`Kubernetes` tag property on each of the VMs to ensure availability of the same in the  `TargetSE` of `ActionItemDTO` received in the suspend action.

**Testing**
The property is available in the tags section of the VM
![image](https://user-images.githubusercontent.com/10027921/153211966-e2cfa3e7-7ef3-4caa-b5a7-eff793fbcb85.png)

