### PR TITLE
[OM-79845]: Only capture annotations that match configured regular expressions.

### DIFF
--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -45,5 +45,12 @@ data:
         "namespaces": ["{{ .Values.daemonPodDetectors.daemonPodNamespaces1 }}", "{{ .Values.daemonPodDetectors.daemonPodNamespaces2 }}"],
         "podNamePatterns": ["{{ .Values.daemonPodDetectors.daemonPodNamePatterns }}"]
       {{- end }}
+      {{- if .Values.annotationWhitelist }}
+      }, 
+      "annotationWhitelist": {
+        "containerSpec": "{{ default "" .Values.annotationWhitelist.containerSpec" }},
+        "namespace": "{{ default "" .Values.annotationWhitelist.namespace }}",
+        "workloadController": "{{ default "" .Values.annotationWhitelist.workloadController }}"
+      {{- end }}
       }
     }

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -65,6 +65,14 @@ HANodeConfig:
 #   daemonPodNamespaces2: OpenShift
 #   daemonPodNamePatterns: .*ignorePod.*
 
+# The annotationWhitelist allows users to define regular expressions to allow kubeturbo to collect
+# matching annotations for the specified entity type. By default, no annotations are collected. 
+# These regular expressions accept the RE2 syntax (except for \C) as defined here: https://github.com/google/re2/wiki/Syntax
+# annotationWhitelist:
+#   containerSpec: ""
+#   namespace: ""
+#   workloadController: ""
+
 args:
   # logging level
   logginglevel: 2

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -45,5 +45,12 @@ data:
         "namespaces": ["{{ .Values.daemonPodDetectors.daemonPodNamespaces1 }}", "{{ .Values.daemonPodDetectors.daemonPodNamespaces2 }}"],
         "podNamePatterns": ["{{ .Values.daemonPodDetectors.daemonPodNamePatterns }}"]
       {{- end }}
+      {{- if .Values.annotationWhitelist }}
+      }, 
+      "annotationWhitelist": {
+        "containerSpec": "{{ default "" .Values.annotationWhitelist.containerSpec" }},
+        "namespace": "{{ default "" .Values.annotationWhitelist.namespace }}",
+        "workloadController": "{{ default "" .Values.annotationWhitelist.workloadController }}"
+      {{- end }}
       }
     }

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -65,6 +65,14 @@ HANodeConfig:
 #   daemonPodNamespaces2: OpenShift
 #   daemonPodNamePatterns: .*ignorePod.*
 
+# The annotationWhitelist allows users to define regular expressions to allow kubeturbo to collect
+# matching annotations for the specified entity type. By default, no annotations are collected. 
+# These regular expressions accept the RE2 syntax (except for \C) as defined here: https://github.com/google/re2/wiki/Syntax
+# annotationWhitelist:
+#   containerSpec: ""
+#   namespace: ""
+#   workloadController: ""
+
 args:
   # logging level
   logginglevel: 2

--- a/deploy/kubeturbo_yamls/step4_turbo_configMap_sample.yaml
+++ b/deploy/kubeturbo_yamls/step4_turbo_configMap_sample.yaml
@@ -21,6 +21,10 @@ data:
   #
   # Define node groups by node role, and automatically enable placement policies to limit to 1 per host
   # DaemonSets are identified by default. Use daemonPodDetectors to identify by name patterns using regex or by namespace.
+  #
+  # The annotationWhitelist provides a mechanism for discovering annotations for kubernetes objects. 
+  # By default, no annotations are collected. In order to collect annotations, provide a regular 
+  # expression for each entity type for which the annotations are desired.
   turbo.config: |-
     {
         "communicationConfig": {
@@ -38,5 +42,10 @@ data:
         },
         "HANodeConfig": {
             "nodeRoles": [ "master" ]
+        },
+        "annotationWhitelist": {
+            "containerSpec": "<regex>"
+            "namespace": "<regex>",
+            "workloadController": "<regex>"
         }
     }

--- a/pkg/discovery/detectors/detector_config.go
+++ b/pkg/discovery/detectors/detector_config.go
@@ -1,11 +1,12 @@
 package detectors
 
 import (
-	"github.com/golang/glog"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Master node detection
@@ -42,6 +43,17 @@ type HANodeConfig struct {
 	NodeRoles []string `json:"nodeRoles,omitempty"`
 }
 
+// Annotations whitelists
+var AWContainerSpec string
+var AWNamespace string
+var AWWorkloadController string
+
+type AnnotationWhitelist struct {
+	ContainerSpec      string `json:"containerSpec,omitempty"`
+	Namespace          string `json:"namespace,omitempty"`
+	WorkloadController string `json:"workloadController,omitempty"`
+}
+
 func compileOrDie(pattern string) *regexp.Regexp {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
@@ -52,7 +64,7 @@ func compileOrDie(pattern string) *regexp.Regexp {
 }
 
 func ValidateAndParseDetectors(masterConfig *MasterNodeDetectors,
-	daemonConfig *DaemonPodDetectors, HAConfig *HANodeConfig) {
+	daemonConfig *DaemonPodDetectors, HAConfig *HANodeConfig, AWConfig *AnnotationWhitelist) {
 
 	// Handle default values when sections are missing
 	if masterConfig == nil {
@@ -87,6 +99,16 @@ func ValidateAndParseDetectors(masterConfig *MasterNodeDetectors,
 		}
 	}
 	glog.V(2).Infof("##### HARoles to be detected: %v", HANodeRoles)
+
+	if AWConfig != nil {
+		AWContainerSpec = AWConfig.ContainerSpec
+		AWNamespace = AWConfig.Namespace
+		AWWorkloadController = AWConfig.WorkloadController
+	}
+
+	glog.V(2).Infof("##### Container Spec Annotation Whitelist Regex: %s", AWContainerSpec)
+	glog.V(2).Infof("##### Namespace Annotation Whitelist Regex: %s", AWNamespace)
+	glog.V(2).Infof("##### Workload Controller Annotation Whitelist Regex: %s", AWWorkloadController)
 }
 
 /*

--- a/pkg/discovery/detectors/detector_config_test.go
+++ b/pkg/discovery/detectors/detector_config_test.go
@@ -27,6 +27,11 @@ const validFullConfig = `    {
         "daemonPodDetectors": {
            "namespaces": [ "kube-system", "kube-service-catalog", "openshift-.*" ],
            "podNamePatterns": ["monitor-1"]
+        },
+        "annotationWhitelist": {
+            "containerSpec": "&.*$",
+            "namespace": "^.*$",
+            "workloadController": "^.*$"
         }
     }
 `
@@ -159,6 +164,7 @@ type TestConfig struct {
 	*MasterNodeDetectors `json:"masterNodeDetectors,omitempty"`
 	*DaemonPodDetectors  `json:"daemonPodDetectors,omitempty"`
 	*HANodeConfig        `json:"HANodeConfig,omitempty"`
+	*AnnotationWhitelist `json:"AnnotationWhitelist,omitempty"`
 }
 
 func loadConfig(config string) (*TestConfig, error) {
@@ -176,7 +182,7 @@ func setupTest(scenario string) (*TestConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	ValidateAndParseDetectors(spec.MasterNodeDetectors, spec.DaemonPodDetectors, spec.HANodeConfig)
+	ValidateAndParseDetectors(spec.MasterNodeDetectors, spec.DaemonPodDetectors, spec.HANodeConfig, spec.AnnotationWhitelist)
 	return spec, nil
 }
 

--- a/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/container_spec_entity_dto_builder.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
@@ -60,13 +61,9 @@ func (builder *containerSpecDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, error) 
 		// ContainerSpec entity is not monitored and will not be sent to Market analysis engine in turbo server
 		entityDTOBuilder.Monitored(false)
 		if builder.clusterSummary != nil {
-			var labelAnnotations []map[string]string
-
 			controller, found := builder.clusterSummary.ControllerMap[containerSpec.ControllerUID]
 			if found {
-				labelAnnotations = append(labelAnnotations, controller.Labels, controller.Annotations)
-				entityDTOBuilder.WithProperties(property.BuildLabelAnnotationProperties(labelAnnotations))
-
+				entityDTOBuilder.WithProperties(property.BuildLabelAnnotationProperties(controller.Labels, controller.Annotations, detectors.AWContainerSpec))
 			}
 		}
 		dto, err := entityDTOBuilder.Create()

--- a/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/namespace_entity_dto_builder.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
@@ -70,7 +71,7 @@ func (builder *namespaceEntityDTOBuilder) BuildEntityDTOs() ([]*proto.EntityDTO,
 
 		// build entityDTO.
 		entityDto, err := entityDTOBuilder.WithProperties(property.
-			BuildLabelAnnotationProperties(namespace.TagProperties)).
+			BuildLabelAnnotationProperties(namespace.Labels, namespace.Annotations, detectors.AWNamespace)).
 			Create()
 		if err != nil {
 			glog.Errorf("Failed to build Namespace entityDTO: %s", err)

--- a/pkg/discovery/dtofactory/property/property_common.go
+++ b/pkg/discovery/dtofactory/property/property_common.go
@@ -1,22 +1,41 @@
 package property
 
-import "github.com/turbonomic/turbo-go-sdk/pkg/proto"
+import (
+	"regexp"
+
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+func BuildTagProperty(namespace string, name string, value string) *proto.EntityDTO_EntityProperty {
+	return &proto.EntityDTO_EntityProperty{
+		Namespace: &namespace,
+		Name:      &name,
+		Value:     &value,
+	}
+}
 
 // Add label and annotation
-func BuildLabelAnnotationProperties(tagMaps []map[string]string) []*proto.EntityDTO_EntityProperty {
+func BuildLabelAnnotationProperties(labelMap map[string]string, annotationMap map[string]string, annotationRegex string) []*proto.EntityDTO_EntityProperty {
 	var properties []*proto.EntityDTO_EntityProperty
 	tagsPropertyNamespace := VCTagsPropertyNamespace
 
-	for _, tagMap := range tagMaps {
-		for key, val := range tagMap {
-			tagNamePropertyName := key
-			tagNamePropertyValue := val
-			tagProperty := &proto.EntityDTO_EntityProperty{
-				Namespace: &tagsPropertyNamespace,
-				Name:      &tagNamePropertyName,
-				Value:     &tagNamePropertyValue,
+	// Add labels
+	for key, val := range labelMap {
+		tagProperty := BuildTagProperty(tagsPropertyNamespace, key, val)
+		properties = append(properties, tagProperty)
+	}
+
+	// Add annotations
+	if len(annotationRegex) > 0 { // for some reason a regex that's an empty string matches everything ¯\_(ツ)_/¯
+		r, err := regexp.Compile(annotationRegex)
+		if err == nil {
+			for key, val := range annotationMap {
+				// Only add annotations that match the supplied regex
+				if r.MatchString(key) {
+					tagProperty := BuildTagProperty(tagsPropertyNamespace, key, val)
+					properties = append(properties, tagProperty)
+				}
 			}
-			properties = append(properties, tagProperty)
 		}
 	}
 

--- a/pkg/discovery/dtofactory/property/property_common_test.go
+++ b/pkg/discovery/dtofactory/property/property_common_test.go
@@ -1,0 +1,53 @@
+package property
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+var LABEL1 string = "label1"
+var ANNOTATION1 string = "annotation1"
+var ANNOTATION2 string = "annotation2"
+
+var MockLabels map[string]string = map[string]string{
+	LABEL1: "value",
+}
+
+var MockAnnotations map[string]string = map[string]string{
+	ANNOTATION1: "value",
+	ANNOTATION2: "value",
+}
+
+func getPropertyKeys(properties []*proto.EntityDTO_EntityProperty) []string {
+	var propertyKeys []string
+	for _, property := range properties {
+		propertyKeys = append(propertyKeys, property.GetName())
+	}
+	return propertyKeys
+}
+
+func TestBuildLabelAnnotationPropertiesWithoutRegex(t *testing.T) {
+	var regex string
+
+	properties := BuildLabelAnnotationProperties(MockLabels, MockAnnotations, regex)
+
+	// Should not contain any annotations when no regex is supplied
+	propertyKeys := getPropertyKeys(properties)
+	assert.Contains(t, propertyKeys, LABEL1)
+	assert.NotContains(t, propertyKeys, ANNOTATION1)
+	assert.NotContains(t, propertyKeys, ANNOTATION2)
+}
+
+func TestBuildLabelAnnotationPropertiesWithRegex(t *testing.T) {
+	var regex string = "^.*2$"
+
+	properties := BuildLabelAnnotationProperties(MockLabels, MockAnnotations, regex)
+
+	// Should only contain annotataions that match the regex
+	propertyKeys := getPropertyKeys(properties)
+	assert.Contains(t, propertyKeys, LABEL1)
+	assert.NotContains(t, propertyKeys, ANNOTATION1)
+	assert.Contains(t, propertyKeys, ANNOTATION2)
+}

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
@@ -2,6 +2,7 @@ package dtofactory
 
 import (
 	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/detectors"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	discoveryUtil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
@@ -78,12 +79,9 @@ func (builder *workloadControllerDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, er
 		entityDTOBuilder.WithPowerState(proto.EntityDTO_POWERED_ON)
 		entityDTOBuilder.WithProperty(property.BuildWorkloadControllerNSProperty(kubeController.Namespace))
 		if builder.clusterSummary != nil {
-			var labelAnnotations []map[string]string
-
 			controller, found := builder.clusterSummary.ControllerMap[workloadControllerId]
 			if found {
-				labelAnnotations = append(labelAnnotations, controller.Labels, controller.Annotations)
-				entityDTOBuilder.WithProperties(property.BuildLabelAnnotationProperties(labelAnnotations))
+				entityDTOBuilder.WithProperties(property.BuildLabelAnnotationProperties(controller.Labels, controller.Annotations, detectors.AWWorkloadController))
 
 			}
 		}

--- a/pkg/discovery/processor/namespace_processor.go
+++ b/pkg/discovery/processor/namespace_processor.go
@@ -43,7 +43,8 @@ func (p *NamespaceProcessor) ProcessNamespaces() {
 		// Create default namespace object
 		kubeNamespaceUID := string(item.UID)
 		kubeNamespace := repository.CreateDefaultKubeNamespace(clusterName, item.Name, kubeNamespaceUID)
-		kubeNamespace.TagProperties = append(kubeNamespace.TagProperties, item.GetLabels(), item.GetAnnotations())
+		kubeNamespace.Labels = item.GetLabels()
+		kubeNamespace.Annotations = item.GetAnnotations()
 
 		// update the default quota limits using the defined resource quota objects
 		quotaList, hasQuota := quotaMap[item.Name]

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -390,7 +390,8 @@ type KubeNamespace struct {
 	QuotaDefined            map[metrics.ResourceType]bool
 
 	// Stores the labels and annotations on the given namespace
-	TagProperties []map[string]string
+	Labels      map[string]string
+	Annotations map[string]string
 }
 
 func (kubeNamespace *KubeNamespace) String() string {

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -38,6 +38,7 @@ type K8sTAPServiceSpec struct {
 	*detectors.DaemonPodDetectors     `json:"daemonPodDetectors,omitempty"`
 	*detectors.HANodeConfig           `json:"HANodeConfig,omitempty"`
 	*features.FeatureGates            `json:"featureGates,omitempty"`
+	*detectors.AnnotationWhitelist    `json:"annotationWhitelist,omitempty"`
 }
 
 func ParseK8sTAPServiceSpec(configFile string, defaultTargetName string) (*K8sTAPServiceSpec, error) {
@@ -79,7 +80,7 @@ func ParseK8sTAPServiceSpec(configFile string, defaultTargetName string) (*K8sTA
 
 	// This function aborts the program upon fatal error
 	detectors.ValidateAndParseDetectors(tapSpec.MasterNodeDetectors,
-		tapSpec.DaemonPodDetectors, tapSpec.HANodeConfig)
+		tapSpec.DaemonPodDetectors, tapSpec.HANodeConfig, tapSpec.AnnotationWhitelist)
 
 	return tapSpec, nil
 }


### PR DESCRIPTION
# Intent
Resolve an issue where collected annotations were displaying sensitive information due to server-side apply.

# Implementation
Updated the configuration to allow customers to specify annotation whitelists for the various entity types (currently we only appear to pull annotations for namespaces, workload controllers, and container specs). 

Refactored the _BuildLabelAnnotationProperties_ in `property_common.go` to take separate maps of labels and annotations in order to be able to distinguish between the two (they were previously merged prior to the method invocation), and refactored the callers to pass them individually.

# Test
Manually tested with local kubeturbo build and verified annotations would/wouldn't display depending on the configured regex. 