### PR TITLE
Fix kubeturbo crash when processing taints and tolerations

### DIFF
--- a/pkg/discovery/worker/compliance/taint_toleration_processor.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor.go
@@ -45,6 +45,9 @@ func NewTaintTolerationProcessor(cluster *repository.ClusterSummary) (*TaintTole
 
 	for nodeName, podList := range nodeToPodsMap {
 		node := cluster.NodeMap[nodeName]
+		if node == nil {
+			continue
+		}
 		nodeMap[node.UID] = node.Node
 
 		for _, pod := range podList {

--- a/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
+++ b/pkg/discovery/worker/compliance/taint_toleration_processor_test.go
@@ -22,6 +22,7 @@ var (
 	n1    = newNodeWithTaints("node-1", []api.Taint{t1})
 	n2    = newNodeWithTaints("node-2", []api.Taint{t2})
 	n3    = newNodeWithTaints("node-3", []api.Taint{t3})
+	n4    = newNodeWithTaints("node-4", []api.Taint{})
 	nodes = map[string]*api.Node{
 		string(n1.UID): n1,
 		string(n2.UID): n2,
@@ -34,6 +35,7 @@ var (
 	pod1 = newPodWithTolerations("pod-1", "node-1", []api.Toleration{})
 	pod2 = newPodWithTolerations("pod-2", "node-2", []api.Toleration{tole1})
 	pod3 = newPodWithTolerations("pod-3", "node-3", []api.Toleration{tole1, tole2})
+	pod4 = newPodWithTolerations("pod-4", "node-4", []api.Toleration{})
 
 	podDTO1 = newEntityDTO("pod-1", proto.EntityDTO_CONTAINER_POD, createCommBoughtForPod("node-1"))
 	podDTO2 = newEntityDTO("pod-2", proto.EntityDTO_CONTAINER_POD, createCommBoughtForPod("node-2"))
@@ -59,6 +61,7 @@ func TestProcess(t *testing.T) {
 	clusterSummary.NodeToRunningPods[n1.Name] = []*api.Pod{pod1}
 	clusterSummary.NodeToRunningPods[n2.Name] = []*api.Pod{pod2}
 	clusterSummary.NodeToRunningPods[n3.Name] = []*api.Pod{pod3}
+	clusterSummary.NodeToRunningPods[n4.Name] = []*api.Pod{pod4}
 
 	taintTolerationProcessor, err := NewTaintTolerationProcessor(clusterSummary)
 


### PR DESCRIPTION
This PR addresses a segmentation fault error when processing taints and tolerations:

```I0131 15:11:08.187401       1 kubelet_client.go:136] Failed to query kubelet endpoint /stats/summary/ on node ip-10-0-71-227.ec2.internal/10.0.71.227: request failed - \"500 Internal Server Error\", response: \"Internal Error: failed to get imageFs stats: failed to get image stats: rpc error: code = Unknown desc = Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\". Trying proxy endpoint.
I0131 15:12:39.634239       1 k8s_discovery_client.go:388] Successfully processed affinity.
I0131 15:12:39.634265       1 k8s_discovery_client.go:391] Begin to process taints and tolerations
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2dc0137]
goroutine 591 [running]:
github.com/turbonomic/kubeturbo/pkg/discovery/worker/compliance.NewTaintTolerationProcessor(0xc0df9a0900)
    /home/travis/gopath/src/github.com/turbonomic/kubeturbo/pkg/discovery/worker/compliance/taint_toleration_processor.go:50 +0xd7
github.com/turbonomic/kubeturbo/pkg/discovery.(*K8sDiscoveryClient).DiscoverWithNewFramework(0xc000384b00, {0xc000526540, 0x1f})
    /home/travis/gopath/src/github.com/turbonomic/kubeturbo/pkg/discovery/k8s_discovery_client.go:392 +0x1125
github.com/turbonomic/kubeturbo/pkg/discovery.(*K8sDiscoveryClient).Discover(0xc000370380, {0xc000370380, 0x6, 0x3b27e04})
    /home/travis/gopath/src/github.com/turbonomic/kubeturbo/pkg/discovery/k8s_discovery_client.go:266 +0x24e
github.com/turbonomic/turbo-go-sdk/pkg/probe.(*TurboProbe).DiscoverTarget(0xc000e08150, {0xc000370380, 0x6, 0x8})
    /home/travis/gopath/src/github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/probe/turbo_probe.go:115 +0x1ca
github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*DiscoveryRequestHandler).HandleMessage(0xc000dcb700, {{{}, {}, {}, 0xc000341648}, 0x0, {0x0, 0x0, 0x0}, {0x40729e0, ...}, ...}, ...)
    /home/travis/gopath/src/github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go:346 +0x2b8
created by github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*remoteMediationClient).RunServerMessageHandler
    /home/travis/gopath/src/github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go:221 +0x534
```

After discussion with @chlam4 , the only possibility that this can happen is when Kubernetes returns a pod with `Running` state but the hosting node for that pod is gone for some reason. We do not know how that can happen, and unfortunately we don't have the environment that can reproduce the problem any more.

This MR adds the `nil` check as a defense.

 