### PR TITLE
Don't push docker image when the release is created

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 after_success:
   - |
     if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-      if [ -n "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" == "master" ]; then
+      if [ "$TRAVIS_BRANCH" == "master" ]; then
         # Update docker
         sudo rm -rf /var/lib/apt/lists/*
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
@@ -45,12 +45,7 @@ after_success:
         docker buildx create --use
         # Build and push the image
         cd build
-        if [ -n "$TRAVIS_TAG" ]; then
-            # Push a release image triggered by a git tag
-            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME:$TRAVIS_TAG .
-        else
-            # Push the latest image built from master branch
-            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME .
-        fi
+        # Push the latest image built from master branch
+        docker buildx build --platform $PLATFORM_OS_ARCH_LIST --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME .
       fi
     fi


### PR DESCRIPTION
Intent:
Now we have migrated the build/image push job to jenkins, we no longer need to push the release tagged image through travis.