### PR TITLE
Refine the log message for resizing action

### DIFF
--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/action/executor"
 	"github.com/turbonomic/kubeturbo/pkg/action/util"
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
 	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
 	api "k8s.io/api/core/v1"
 
@@ -175,7 +176,7 @@ func (h *ActionHandler) ExecuteAction(actionExecutionDTO *proto.ActionExecutionD
 	glog.V(3).Infof("Now wait for action result")
 	err := h.execute(actionExecutionDTO.GetActionItem())
 	if err != nil {
-		glog.Errorf("action execution error %++v", err)
+		glog.Errorf("action execution error: %++v", err)
 		return h.failedResult(err.Error()), err
 	}
 
@@ -354,9 +355,10 @@ func (h *ActionHandler) checkActionExecutionDTO(actionExecutionDTO *proto.Action
 	if targetSE == nil {
 		return fmt.Errorf("no target SE found")
 	}
+	namespace, _ := property.GetWorkloadNamespaceFromProperty(targetSE.GetEntityProperties())
 
-	glog.V(2).Infof("Received an action %v for entity %v [%v]",
-		actionType, targetSE.GetEntityType(), targetSE.GetDisplayName())
+	glog.V(2).Infof("Received an action %v for entity %v [%v] in namespace [%v]",
+		actionType, targetSE.GetEntityType(), targetSE.GetDisplayName(), namespace)
 
 	// Check if action is supported
 	turboActionType := turboActionType{

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -228,11 +228,12 @@ func (h *ActionHandler) execute(actionItems []*proto.ActionItemDTO) error {
 
 	actionType := getTurboActionType(actionItem)
 	worker := h.actionExecutors[actionType]
+	namespace, _ := property.GetWorkloadNamespaceFromProperty(actionItem.GetTargetSE().GetEntityProperties())
 	output, err := worker.Execute(input)
 	if err != nil {
-		glog.Errorf("Failed to execute action %v on %v [%v]: %v",
+		glog.Errorf("Failed to execute action %v on %v [%v/%v]: %v",
 			actionType.actionType, actionItem.GetTargetSE().GetEntityType(),
-			actionItem.GetTargetSE().GetDisplayName(), err)
+			namespace, actionItem.GetTargetSE().GetDisplayName(), err)
 		return err
 	}
 	// Process the action execution output, including caching the pod name change.

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -178,7 +178,7 @@ func (c *k8sControllerUpdater) reconcile(current *k8sControllerSpec, desired *co
 	}
 	glog.V(4).Infof("Try to update resources for container indexes: %s in pod template spec of %v %s/%s .",
 		indexes, c.controller, c.namespace, c.name)
-	updated, err := updateResourceAmount(current.podSpec, desired.resizeSpecs, current.controllerName)
+	updated, err := updateResourceAmount(current.podSpec, desired.resizeSpecs, fmt.Sprintf("%s/%s", c.namespace, c.name))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -169,7 +169,7 @@ func (r *ContainerResizer) setZeroRequest(resizerName string, podSpec *k8sapi.Po
 
 func (r *ContainerResizer) buildResizeSpec(actionItem *proto.ActionItemDTO, resizerName string, podSpec *k8sapi.PodSpec, containerIndex int) (*containerResizeSpec, error) {
 	if containerIndex < 0 || containerIndex > len(podSpec.Containers) {
-		return nil, fmt.Errorf("invalid containerIndex %d", containerIndex)
+		return nil, fmt.Errorf("cannot find the container <%v> with the index <%v> in the parents pod spec", actionItem.GetCurrentSE().GetDisplayName(), containerIndex)
 	}
 
 	// build the new resource requirements

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -38,7 +38,7 @@ func updateRequests(container *k8sapi.Container, patchRequests k8sapi.ResourceLi
 	}
 
 	if changed {
-		glog.V(2).Infof("Try to update container %v for the workload controller [%v] resource request from %+v to %+v",
+		glog.V(2).Infof("Try to update container %v in the workload controller [%v] resource request from %+v to %+v",
 			container.Name, objectID, container.Resources.Requests, result)
 		container.Resources.Requests = result
 	}
@@ -66,7 +66,7 @@ func updateLimits(container *k8sapi.Container, patchCapacity k8sapi.ResourceList
 	}
 
 	if changed {
-		glog.V(2).Infof("Try to update container %v for the workload controller [%v] resource limit from %+v to %v",
+		glog.V(2).Infof("Try to update container %v in the workload controller [%v] resource limit from %+v to %v",
 			container.Name, objectID, container.Resources.Limits, result)
 		container.Resources.Limits = result
 	}

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -18,7 +18,7 @@ import (
 )
 
 // update the Pod.Containers[index]'s Resources.Requests
-func updateRequests(container *k8sapi.Container, patchRequests k8sapi.ResourceList) bool {
+func updateRequests(container *k8sapi.Container, patchRequests k8sapi.ResourceList, objectID string) bool {
 	glog.V(4).Infof("Begin to update Request.")
 	changed := false
 
@@ -38,15 +38,15 @@ func updateRequests(container *k8sapi.Container, patchRequests k8sapi.ResourceLi
 	}
 
 	if changed {
-		glog.V(2).Infof("Try to update container %v resource request from %+v to %+v",
-			container.Name, container.Resources.Requests, result)
+		glog.V(2).Infof("Try to update container %v for the workload controller [%v] resource request from %+v to %+v",
+			container.Name, objectID, container.Resources.Requests, result)
 		container.Resources.Requests = result
 	}
 	return changed
 }
 
 // update the Pod.Containers[index]'s Resources.Limits
-func updateLimits(container *k8sapi.Container, patchCapacity k8sapi.ResourceList) bool {
+func updateLimits(container *k8sapi.Container, patchCapacity k8sapi.ResourceList, objectID string) bool {
 	glog.V(4).Infof("Begin to update Capacity.")
 	changed := false
 
@@ -66,8 +66,8 @@ func updateLimits(container *k8sapi.Container, patchCapacity k8sapi.ResourceList
 	}
 
 	if changed {
-		glog.V(2).Infof("Try to update container %v resource limit from %+v to %v",
-			container.Name, container.Resources.Limits, result)
+		glog.V(2).Infof("Try to update container %v for the workload controller [%v] resource limit from %+v to %v",
+			container.Name, objectID, container.Resources.Limits, result)
 		container.Resources.Limits = result
 	}
 
@@ -112,12 +112,12 @@ func updateResourceAmount(podSpec *k8sapi.PodSpec, specs []*containerResizeSpec,
 
 		//2. update Limits
 		if spec.NewCapacity != nil && len(spec.NewCapacity) > 0 {
-			thisSpecChanged = thisSpecChanged || updateLimits(container, spec.NewCapacity)
+			thisSpecChanged = thisSpecChanged || updateLimits(container, spec.NewCapacity, objectID)
 		}
 
 		//3. update Requests
 		if spec.NewRequest != nil && len(spec.NewRequest) > 0 {
-			thisSpecChanged = thisSpecChanged || updateRequests(container, spec.NewRequest)
+			thisSpecChanged = thisSpecChanged || updateRequests(container, spec.NewRequest, objectID)
 		}
 
 		//4. check the new Limits vs. Requests, make sure Limits >= Requests

--- a/pkg/action/executor/resize_container_util_test.go
+++ b/pkg/action/executor/resize_container_util_test.go
@@ -141,7 +141,7 @@ func TestUpdateCapacity(t *testing.T) {
 	}
 
 	//c := NewContainerResizer(nil, nil, "1.5", "aa", nil)
-	updateLimits(container, patch)
+	updateLimits(container, patch, "")
 	if err := compareResourceList(container.Resources.Limits, 250, 500); err != nil {
 		t.Error(err)
 	}

--- a/pkg/action/executor/workload_controller_resizer.go
+++ b/pkg/action/executor/workload_controller_resizer.go
@@ -45,6 +45,7 @@ func (r *WorkloadControllerResizer) Execute(input *TurboActionExecutorInput) (*T
 	// use the node frequency of the queried pod.
 	controllerName, kind, namespace, podSpec, err := r.getWorkloadControllerDetails(actionItems[0])
 	if err != nil {
+		glog.Errorf("Failed to get workload controller %s/%s details: %v", namespace, controllerName, err)
 		return nil, err
 	}
 
@@ -55,8 +56,10 @@ func (r *WorkloadControllerResizer) Execute(input *TurboActionExecutorInput) (*T
 		// build resize specification
 		spec, err := cr.buildResizeSpec(item, controllerName, podSpec, getContainerIndex(podSpec, item.GetCurrentSE().GetDisplayName()))
 		if err != nil {
-			glog.Errorf("Failed to execute resize action: %v", err)
-			return &TurboActionExecutorOutput{}, err
+			glog.Errorf("Failed to build resize spec for the container %v of the workload controller %v/%v as the reason: %v",
+				item.GetCurrentSE().GetDisplayName(), namespace, controllerName, err)
+			return &TurboActionExecutorOutput{}, fmt.Errorf("%v, the container has the name %v and is in the namespace %v", err, item.GetCurrentSE().GetDisplayName(), namespace)
+
 		}
 
 		resizeSpecs = append(resizeSpecs, spec)
@@ -72,8 +75,10 @@ func (r *WorkloadControllerResizer) Execute(input *TurboActionExecutorInput) (*T
 		resizeSpecs,
 	)
 	if err != nil {
+		glog.Errorf("Failed to execute resize action on the workload controller %s/%s: %v", namespace, controllerName, err)
 		return &TurboActionExecutorOutput{}, err
 	}
+	glog.V(2).Infof("Successfully execute resize action on the workload controller %s/%s.", namespace, controllerName)
 
 	return &TurboActionExecutorOutput{
 		Succeeded: true,

--- a/pkg/action/executor/workload_controller_resizer.go
+++ b/pkg/action/executor/workload_controller_resizer.go
@@ -56,9 +56,9 @@ func (r *WorkloadControllerResizer) Execute(input *TurboActionExecutorInput) (*T
 		// build resize specification
 		spec, err := cr.buildResizeSpec(item, controllerName, podSpec, getContainerIndex(podSpec, item.GetCurrentSE().GetDisplayName()))
 		if err != nil {
-			glog.Errorf("Failed to build resize spec for the container %v of the workload controller %v/%v as the reason: %v",
+			glog.Errorf("Failed to build resize spec for the container %v of the workload controller %v/%v due to: %v",
 				item.GetCurrentSE().GetDisplayName(), namespace, controllerName, err)
-			return &TurboActionExecutorOutput{}, fmt.Errorf("%v, the container has the name %v and is in the namespace %v", err, item.GetCurrentSE().GetDisplayName(), namespace)
+			return &TurboActionExecutorOutput{}, fmt.Errorf("could not find container %v in parents pod template spec. It is likely an injected sidecar", item.GetCurrentSE().GetDisplayName())
 
 		}
 


### PR DESCRIPTION
# Intent
Refine the log message when resizing a workload controller

# Background

1. Action execution of workload controller resize, regardless of status (succeeded, failed, etc) should include related information of container spec(s) and namespace, commodity changes, along with the workload controller name. 
2. Log message should inform the user which specific container spec has failed the merged workload controller resize action.
3. When executing actions against multiple Workload controllers with the same name that could exist in multiple namespaces, the log message should indicate the namespace info.

# Implementation
Go through the related code and pass around the namespace, pod, or container info when logging the message

# Test Done

## Case 1
**1. Execute a resize action on a workload controller and the action gets executed successfully**
![image](https://user-images.githubusercontent.com/61252360/162525893-f903eb03-5a6f-4a65-bd4d-cec8aac8e209.png)


**2. Check the kubeturbo log**
![image](https://user-images.githubusercontent.com/61252360/162525849-cec5753b-036a-47f9-ae32-a651066fa155.png)

## Case 2
**1. Execute a resize action on a workload controller and the action failed to get executed**
![image](https://user-images.githubusercontent.com/61252360/162527731-3f3f8524-e89b-4de3-83b0-1537b6e3229c.png)


**2. Check the kubeturbo log**
![image](https://user-images.githubusercontent.com/61252360/162526865-f720e58d-9ec5-4a08-9872-fa9d6c6e9f3b.png)

