### PR TITLE
[OM-82931]: Added VMPM_ACCESS back to the list of commodities sold by pods.

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -328,6 +328,16 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesSold(
 	}
 	commoditiesSold = append(commoditiesSold, resourceCommoditiesSold...)
 
+	// vmpmAccess commodity
+	podAccessComm, err := sdkbuilder.NewCommodityDTOBuilder(proto.CommodityDTO_VMPM_ACCESS).
+		Key(string(pod.UID)).
+		Capacity(accessCommodityDefaultCapacity).
+		Create()
+	if err != nil {
+		return nil, err
+	}
+	commoditiesSold = append(commoditiesSold, podAccessComm)
+
 	return commoditiesSold, nil
 }
 


### PR DESCRIPTION
Reverted change that removed VMPM_ACCESS commodity from the list of commodities sold by pods.