### PR TITLE
[OM-83722] do not copy annotations during a pod move

### DIFF
--- a/pkg/action/executor/move_util.go
+++ b/pkg/action/executor/move_util.go
@@ -35,7 +35,7 @@ func copyPodInfo(oldPod, newPod *api.Pod, copySpec bool) {
 	newPod.TypeMeta = oldPod.TypeMeta
 
 	//2. objectMeta
-	newPod.ObjectMeta = oldPod.ObjectMeta
+	newPod.ObjectMeta.SetNamespace(oldPod.ObjectMeta.GetNamespace())
 	newPod.SelfLink = ""
 	newPod.ResourceVersion = ""
 	newPod.Generation = 0


### PR DESCRIPTION
Background:
the copyPodInfo copies of the annotations and the labels
https://github.com/turbonomic/kubeturbo/blob/master/pkg/action/executor/move_util.go#L72
but we override the labels in #74

Intent:
This change only copies the namespace attribute of the meta and the rest of the code already handles the labels and annotations

Testing:
test a pod move on OKD with ovn-kubernetes and got a new ip assigned
$ oc get pods -n bookinfo -o wide
reviews-v3-7c4ddcf67c-lmwlk                 1/1     Running   0          86s   10.129.2.15   ocp-preview-2k5k2-worker-hbr9f   <none>           <none>
reviews-v3-7c4ddcf67c-lmwlk-1dqbm0b0hfmlr   1/1     Running   0          7s    10.131.0.9    ocp-preview-2k5k2-worker-qlgrl   <none>           <none>