### PR TITLE
Fix index of range issue for checking owner reference

### DIFF
--- a/pkg/action/executor/k8s_controller.go
+++ b/pkg/action/executor/k8s_controller.go
@@ -136,20 +136,20 @@ func (c *parentController) update(updatedSpec *k8sControllerSpec) error {
 	}
 
 	controllerOwnerReferences := c.obj.GetOwnerReferences()
-	if !c.shouldSkipOperator(c.obj) {
-		/*There is 2 situation to determine whether to use orm
-		1)the current work-contoller has an owner and the owner has the controller field which is set to true
-		2)the current work-controller has an owner and the kind of the owner is ClusterServiceVersion
-		*/
-		isControlledByOwner := (controllerOwnerReferences[0].Controller != nil && *controllerOwnerReferences[0].Controller) || "ClusterServiceVersion" == controllerOwnerReferences[0].Kind
-		if isControlledByOwner {
-			// If k8s controller is controlled by custom controller, update the CR using OperatorResourceMapping
-			// if SkipOperatorLabel is not set or not true.
-			if c.ormClient == nil {
-				return fmt.Errorf("failed to execute action with nil ORMClient")
-			}
-			err = c.ormClient.Update(origControllerObj, c.obj, controllerOwnerReferences[0])
+	/*There are 2 conditions to determine whether to use ORM to update the workload controller or directly update it
+	1)the current workload contoller has the ownerReference and the owner has the controller field which is set to true
+	2)the current workload controller has the ownerReference and the kind of the owner is ClusterServiceVersion
+	*/
+	if !c.shouldSkipOperator(c.obj) && // Check if the label kubeturbo.io/skipOperator is set or not
+		len(controllerOwnerReferences) > 0 && // Check if the workcontroller has the owner
+		((controllerOwnerReferences[0].Controller != nil && *controllerOwnerReferences[0].Controller) || // case 1: owner exists and has a true controller field
+			"ClusterServiceVersion" == controllerOwnerReferences[0].Kind) { // case 2: owner exists and its kind is ClusterServiceVersion
+		// If k8s controller is controlled by custom controller, update the CR using OperatorResourceMapping
+		// if SkipOperatorLabel is not set or not true.
+		if c.ormClient == nil {
+			return fmt.Errorf("failed to execute action with nil ORMClient")
 		}
+		err = c.ormClient.Update(origControllerObj, c.obj, controllerOwnerReferences[0])
 	} else {
 		_, err = c.clients.dynNamespacedClient.Update(context.TODO(), c.obj, metav1.UpdateOptions{})
 	}


### PR DESCRIPTION
Add a length check to make sure the owner reference does exist

## Case 1 Resize a workload controller with one container spec
**1. Resize the deployment cert-manager-cainjector which has only one container and has the owner reference set**
```
[root@localvm ~]# k get pods cert-manager-cainjector-7cff9df4f8-djd7g 
NAME                                       READY   STATUS    RESTARTS   AGE
cert-manager-cainjector-7cff9df4f8-djd7g   1/1     Running   0          23h
```
![image](https://user-images.githubusercontent.com/61252360/165345391-9452a4bb-087a-48af-91da-e8755353f0f6.png)

**2. Check the execution result and also check the ORM CR**
![image](https://user-images.githubusercontent.com/61252360/165346003-f18b2b09-5363-4f33-84a5-04a292120494.png)

![image](https://user-images.githubusercontent.com/61252360/165346179-fc7008c7-8fe5-4ed9-bfd0-13f2d6e592d1.png)

## Case 2 Resize a workload controller with multiple container specs
**1. Resize the deployment auth-pap which has 2 containers**
![image](https://user-images.githubusercontent.com/61252360/165358440-f02b285c-2ef0-4c50-bf88-80f3e61224f5.png)
**2. Check the execution result**
![image](https://user-images.githubusercontent.com/61252360/165358498-219a12fc-7f08-4311-b37f-4331a0d346d0.png)

## Case 3 Resize a bare pod
**1. Resize the bare pod xxx**
![image](https://user-images.githubusercontent.com/61252360/165356163-acbe820e-702c-416e-b5a8-4f98c862aaac.png)

**2. Check the execution result**
![image](https://user-images.githubusercontent.com/61252360/165356111-70ea51d2-6d58-47b0-96d1-e633c22ed214.png)
![image](https://user-images.githubusercontent.com/61252360/165356654-f73bbfc5-5362-4d84-87cc-9b49f9010146.png)


