### PR TITLE
Add integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ script:
   - make fmtcheck
   - make vet
   - $HOME/gopath/bin/goveralls -v -race -service=travis-ci -package='github.com/turbonomic/kubeturbo/cmd/kubeturbo github.com/turbonomic/kubeturbo/cmd/kubeturbo/app github.com/turbonomic/kubeturbo/pkg github.com/turbonomic/kubeturbo/pkg/action github.com/turbonomic/kubeturbo/pkg/action/executor github.com/turbonomic/kubeturbo/pkg/action/util github.com/turbonomic/kubeturbo/pkg/cluster github.com/turbonomic/kubeturbo/pkg/discovery github.com/turbonomic/kubeturbo/pkg/discovery/configs github.com/turbonomic/kubeturbo/pkg/discovery/detectors github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property github.com/turbonomic/kubeturbo/pkg/discovery/metrics github.com/turbonomic/kubeturbo/pkg/discovery/monitoring github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types github.com/turbonomic/kubeturbo/pkg/discovery/processor github.com/turbonomic/kubeturbo/pkg/discovery/repository github.com/turbonomic/kubeturbo/pkg/discovery/stitching github.com/turbonomic/kubeturbo/pkg/discovery/task github.com/turbonomic/kubeturbo/pkg/discovery/util github.com/turbonomic/kubeturbo/pkg/discovery/worker github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation github.com/turbonomic/kubeturbo/pkg/discovery/worker/compliance github.com/turbonomic/kubeturbo/pkg/kubeclient github.com/turbonomic/kubeturbo/pkg/registration github.com/turbonomic/kubeturbo/pkg/resourcemapping github.com/turbonomic/kubeturbo/pkg/turbostore github.com/turbonomic/kubeturbo/pkg/util github.com/turbonomic/kubeturbo/pkg/discovery/worker/k8sappcomponents'
+  - ./hack/download_test_binaries.sh
+  - ./hack/create_kind_cluster.sh
+  - make integration
+  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind
   - make product
 
 after_success:

--- a/hack/create_kind_cluster.sh
+++ b/hack/create_kind_cluster.sh
@@ -49,6 +49,6 @@ EOF
 
 echo "Creating kind cluster"
 create-cluster
-kubectl config use-context kind-kind
+${kubectl_path} config use-context kind-kind
 
 echo "Cluster creation complete."


### PR DESCRIPTION
# Intent
Adding integration test into Travis

# Background
The current CI process doesn't include integration test

# Implementation
Use kind to build a 3 nodes cluster, and run the integration test in there. 

# Test Done

## Case 1
**1. Trigger the Travis job by making any new commit and then check the Travis log**
Download the binary and create the kind cluster
![image](https://user-images.githubusercontent.com/61252360/166821148-894b3b1a-762b-4a98-9dbb-2b2c1b1a20bd.png)
Run the integration test
![image](https://user-images.githubusercontent.com/61252360/166825886-65650de4-e434-4f8a-b9da-4ce239729be6.png)

Report the test result, 2 openshift cases are skipped
![image](https://user-images.githubusercontent.com/61252360/166821161-c81b4f48-6874-4244-9657-5e005c262036.png)



