### PR TITLE
Implement the PR mode support for argoCD gitops actions

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -214,6 +214,7 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.gitConfig.GitSecretName, "git-secret-name", "", "The name of the secret which holds the git credentials.")
 	fs.StringVar(&s.gitConfig.GitUsername, "git-username", "", "The user name to be used to push changes to git.")
 	fs.StringVar(&s.gitConfig.GitEmail, "git-email", "", "The email to be used to push changes to git.")
+	fs.StringVar(&s.gitConfig.CommitMode, "git-commit-mode", "direct", "The commit mode that should be used for git action executions. One of pr|direct. Defaults to direct.")
 }
 
 // create an eventRecorder to send events to Kubernetes APIserver

--- a/pkg/action/executor/gitops/github_manager.go
+++ b/pkg/action/executor/gitops/github_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	typedClient "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
@@ -26,7 +28,11 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/util"
 )
 
-const kubeturboNamespaceEnv = "KUBETURBO_NAMESPACE"
+const (
+	kubeturboNamespaceEnv = "KUBETURBO_NAMESPACE"
+	commitModePR          = "pr"
+	commitModeDirect      = "direct"
+)
 
 type GitConfig struct {
 	// Namespace which holds the git secret that stores the git credential token
@@ -37,12 +43,19 @@ type GitConfig struct {
 	GitUsername string
 	// Email to be used for git operations on the remote repos
 	GitEmail string
+	// The mode in which git action should be executed [one of pr/direct]
+	CommitMode string
 }
 
 type PatchItem struct {
 	Op    string      `json:"op,omitempty"`
 	Path  string      `json:"path"`
 	Value interface{} `json:"value,omitempty"`
+}
+
+type gitWaitData struct {
+	handler *GitHandler
+	prNum   int
 }
 
 type GitHubManager struct {
@@ -64,25 +77,25 @@ func NewGitHubManager(gitConfig GitConfig, typedClient *typedClient.Clientset, d
 	}
 }
 
-func (r *GitHubManager) Update(replicas int64, podSpec map[string]interface{}) error {
+func (r *GitHubManager) Update(replicas int64, podSpec map[string]interface{}) (interface{}, error) {
 	token, err := r.getAuthTokenFromSecret()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	path, repo, revision, err := r.getFieldsFromManagerApp()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Parse the URL and ensure there are no errors.
 	url, err := url.Parse(repo)
 	if err != nil {
-		return fmt.Errorf("repo url: %s in manager app of workload controller: %s seems invalid: %v", repo, r, err)
+		return nil, fmt.Errorf("repo url: %s in manager app of workload controller: %s seems invalid: %v", repo, r, err)
 	}
 
 	if url.Host != "github.com" {
-		return fmt.Errorf("repo host: %s unsupported as gitops remote for workload controller: %s", url.Host, r)
+		return nil, fmt.Errorf("repo host: %s unsupported as gitops remote for workload controller: %s", url.Host, r)
 	}
 
 	pathParts := strings.Split(url.Path, "/")
@@ -93,7 +106,7 @@ func (r *GitHubManager) Update(replicas int64, podSpec map[string]interface{}) e
 	// pathParts[1] = "irfanurrehman"
 	// pathParts[2] = "kubeturbo"
 	if len(pathParts) != 3 {
-		return fmt.Errorf("source url: %s in manager app of workload controller: %s is not valid. "+
+		return nil, fmt.Errorf("source url: %s in manager app of workload controller: %s is not valid. "+
 			"It should have 2 sections in path", repo, r)
 	}
 
@@ -112,6 +125,7 @@ func (r *GitHubManager) Update(replicas int64, podSpec map[string]interface{}) e
 		path:        path,
 		commitUser:  r.gitConfig.GitUsername,
 		commitEmail: r.gitConfig.GitEmail,
+		commitMode:  r.gitConfig.CommitMode,
 	}
 
 	patches := []PatchItem{
@@ -131,6 +145,40 @@ func (r *GitHubManager) Update(replicas int64, podSpec map[string]interface{}) e
 
 	glog.Infof("Updating the source of truth at: %s on branch: %s and path: %s.", url.Path, baseBranch, path)
 	return handler.updateRemote(r.obj.GetName(), patches)
+}
+
+func (r *GitHubManager) WaitForActionCompletion(completionData interface{}) error {
+	if r.gitConfig.CommitMode == commitModeDirect || completionData == nil {
+		// Commit is already created, no wait needed further
+		return nil
+	}
+
+	var waitData gitWaitData
+	switch data := completionData.(type) {
+	case gitWaitData:
+		waitData = data
+	default:
+		return fmt.Errorf("wrong type of completion data received in"+
+			"githubManager waitforActionCompletion: expected: [gitWaitData], got: [%t]", data)
+	}
+
+	// We currently wait for the PR to be merged with a big timeout (1 week), which is
+	// although unrealistic for an action to be completed but still big enough to not
+	// time out the action prematurely in kubeturbo.
+	// TODO: At some point we will need a better strategy to handle long running actions.
+	return wait.PollImmediate(20*time.Second, 24*7*time.Hour, func() (bool, error) {
+		handler := waitData.handler
+		isMerged, _, err := handler.client.PullRequests.IsMerged(handler.ctx, handler.user, handler.repo, waitData.prNum)
+		if err != nil {
+			return false, err
+		}
+		if isMerged {
+			return true, nil
+		}
+
+		// Retry
+		return false, nil
+	})
 }
 
 func (r *GitHubManager) getAuthTokenFromSecret() (string, error) {
@@ -214,9 +262,10 @@ type GitHandler struct {
 	path        string
 	commitUser  string
 	commitEmail string
+	commitMode  string
 }
 
-func (g *GitHandler) getBranchRef() (*github.Reference, error) {
+func (g *GitHandler) getBaseBranchRef() (*github.Reference, error) {
 	baseRef, _, err := g.client.Git.GetRef(g.ctx, g.user, g.repo, "refs/heads/"+g.baseBranch)
 	if err != nil {
 		return nil, err
@@ -308,32 +357,54 @@ func (g *GitHandler) getTree(ref *github.Reference, fileContent []byte) (tree *g
 	return tree, err
 }
 
-func (r *GitHandler) updateRemote(resName string, patches []PatchItem) error {
-	yamlContent, err := r.getRemoteFileContent(resName, r.path)
+func (g *GitHandler) updateRemote(resName string, patches []PatchItem) (interface{}, error) {
+	yamlContent, err := g.getRemoteFileContent(resName, g.path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	patchedYamlContent, err := ApplyPatch([]byte(yamlContent), patches)
 	if err != nil {
-		return fmt.Errorf("error applying patches to file %s: patches: %v, err: %v", r.path, patches, err)
+		return nil, fmt.Errorf("error applying patches to file %s: patches: %v, err: %v", g.path, patches, err)
 	}
 
-	branchRef, err := r.getBranchRef()
-	if err != nil {
-		return err
+	var branchRef *github.Reference
+	newBranchName := g.baseBranch + "-" + strconv.FormatInt(time.Now().UnixNano(), 32)
+	if g.commitMode == commitModePR {
+		branchRef, err = g.createNewBranch(newBranchName)
+		if err != nil {
+			return nil, fmt.Errorf("error creating new branch %s, %v", newBranchName, err)
+		}
+	} else {
+		branchRef, err = g.getBaseBranchRef()
+		if err != nil {
+			return nil, fmt.Errorf("error getting branch ref %s, %v", g.baseBranch, err)
+		}
 	}
 
-	tree, err := r.getTree(branchRef, patchedYamlContent)
+	tree, err := g.getTree(branchRef, patchedYamlContent)
 	if err != nil {
-		return fmt.Errorf("error getting branch ref: %s, %v", r.baseBranch, err)
+		return nil, fmt.Errorf("error getting branch ref: %s, %v", g.baseBranch, err)
 	}
 
-	_, err = r.pushCommit(branchRef, tree)
+	_, err = g.pushCommit(branchRef, tree)
 	if err != nil {
-		return fmt.Errorf("error committing new content to branch %s, %v", r.baseBranch, err)
+		return nil, fmt.Errorf("error committing new content to branch %s, %v", g.baseBranch, err)
 	}
-	return nil
+
+	if g.commitMode == commitModePR {
+		pr, err := g.newPR(resName, newBranchName)
+		if err != nil {
+			return nil, err
+		}
+		// TODO: check if we need to validate if the pr number is set in response
+		// after the create request
+		return gitWaitData{
+			handler: g,
+			prNum:   pr.GetNumber(),
+		}, nil
+	}
+	return nil, nil
 }
 
 func (g *GitHandler) pushCommit(ref *github.Reference, tree *github.Tree) (*github.Reference, error) {
@@ -360,6 +431,37 @@ func (g *GitHandler) pushCommit(ref *github.Reference, tree *github.Tree) (*gith
 	ref.Object.SHA = newCommit.SHA
 	newRef, _, err := g.client.Git.UpdateRef(g.ctx, g.user, g.repo, ref, false)
 	return newRef, err
+}
+
+func (g *GitHandler) createNewBranch(newBranch string) (ref *github.Reference, err error) {
+	var baseRef *github.Reference
+	if baseRef, _, err = g.client.Git.GetRef(g.ctx, g.user, g.repo, "refs/heads/"+g.baseBranch); err != nil {
+		return nil, err
+	}
+	newRef := &github.Reference{Ref: github.String("refs/heads/" + newBranch), Object: &github.GitObject{SHA: baseRef.Object.SHA}}
+	ref, _, err = g.client.Git.CreateRef(g.ctx, g.user, g.repo, newRef)
+	return ref, err
+}
+
+func (g *GitHandler) newPR(resName string, newBranch string) (*github.PullRequest, error) {
+	prTitle := fmt.Sprintf("Turbonomic Action: update yaml file `%s`", g.path)
+	prDescription := "This PR is automatically created via `Turbonomic action execution` \n\n" +
+		"This PR intends to update pod template resources or replicas of resource `" + resName + "`"
+	baseBranch := g.baseBranch
+
+	newPR := &github.NewPullRequest{
+		Title:               &prTitle,
+		Head:                &newBranch, // Head may need user:ref_name
+		Base:                &baseBranch,
+		Body:                &prDescription,
+		MaintainerCanModify: github.Bool(true),
+	}
+
+	pr, _, err := g.client.PullRequests.Create(g.ctx, g.user, g.repo, newPR)
+	if err != nil {
+		return nil, err
+	}
+	return pr, nil
 }
 
 // TODO: Enhance the support to identify json or yaml content on the fly

--- a/pkg/action/executor/gitops/github_manager_test.go
+++ b/pkg/action/executor/gitops/github_manager_test.go
@@ -39,7 +39,7 @@ func TestGitHandler_PushCommit(t *testing.T) {
 	// GetCommit() handling
 	mux.HandleFunc("/repos/o/r/commits/existing-commit-sha-1", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
-			t.Errorf("Error in METHOD. Expected: POST, Got: %s", r.Method)
+			t.Errorf("Error in METHOD. Expected: GET, Got: %s", r.Method)
 		}
 
 		fmt.Fprint(w, `
@@ -80,7 +80,7 @@ func TestGitHandler_PushCommit(t *testing.T) {
 	// UpdateRef() handling
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "PATCH" {
-			t.Errorf("Error in METHOD. Expected: POST, Got: %s", r.Method)
+			t.Errorf("Error in METHOD. Expected: PATCH, Got: %s", r.Method)
 		}
 
 		updateRef := new(updateRefRequest)
@@ -156,4 +156,144 @@ func TestGitHandler_PushCommit(t *testing.T) {
 		t.Errorf("Git.CreateTree returned %+v, want %+v", newRef, wantRef)
 	}
 
+}
+
+func TestGitHandler_CreateNewBranch(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	author := "a"
+	email := "e"
+	path := "p"
+
+	// GetRef() handling
+	mux.HandleFunc("/repos/o/r/git/ref/heads/b", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("Error in METHOD. Expected: GET, Got: %s", r.Method)
+		}
+
+		fmt.Fprint(w, `
+			  {
+				"ref": "refs/heads/b",
+				"url": "https://api.github.com/repos/o/r/git/refs/heads/b",
+				"object": {
+				  "type": "commit",
+				  "sha": "base-commit-sha-1",
+				  "url": "https://api.github.com/repos/o/r/git/commits/new-commit-sha-1"
+				}
+			  }`)
+	})
+
+	// CreateRef() handling
+	mux.HandleFunc("/repos/o/r/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Error in METHOD. Expected: POST, Got: %s", r.Method)
+		}
+
+		createdRef := new(updateRefRequest)
+		json.NewDecoder(r.Body).Decode(createdRef)
+		if *createdRef.SHA != "base-commit-sha-1" {
+			fmt.Fprintf(w, "Wrong create ref commit sha. Expected: base-commit-sha-1, Got: %s", *createdRef.SHA)
+		}
+
+		fmt.Fprint(w, `
+			  {
+				"ref": "refs/heads/newBranch",
+				"url": "https://api.github.com/repos/o/r/git/refs/heads/newBranch",
+				"object": {
+				  "type": "commit",
+				  "sha": "new-commit-sha-1",
+				  "url": "https://api.github.com/repos/o/r/git/commits/new-commit-sha-1"
+				}
+			  }`)
+	})
+
+	ctx := context.Background()
+	handler := &GitHandler{
+		ctx:         ctx,
+		client:      client,
+		user:        "o",
+		repo:        "r",
+		baseBranch:  "b",
+		path:        path,
+		commitUser:  author,
+		commitEmail: email,
+	}
+
+	createdRef, err := handler.createNewBranch("newBranch")
+	if err != nil {
+		t.Errorf("Git Handler createNewBranch returned error: %v", err)
+	}
+
+	wantRef := &github.Reference{
+		Ref: String("refs/heads/newBranch"),
+		URL: String("https://api.github.com/repos/o/r/git/refs/heads/newBranch"),
+		Object: &github.GitObject{
+			Type: String("commit"),
+			SHA:  String("new-commit-sha-1"),
+			URL:  String("https://api.github.com/repos/o/r/git/commits/new-commit-sha-1"),
+		},
+	}
+
+	if !cmp.Equal(createdRef, wantRef) {
+		t.Errorf("Git.CreateTree returned %+v, want %+v", createdRef, wantRef)
+	}
+
+}
+
+func TestGitHandler_NewPR(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	author := "a"
+	email := "e"
+	path := "p"
+
+	expectedReceivedPR := &github.NewPullRequest{
+		Title: String("Turbonomic Action: update yaml file `p`"),
+		Head:  String("test-branch"),
+		Base:  String("b"),
+		Body: String("This PR is automatically created via `Turbonomic action execution` \n\n" +
+			"This PR intends to update pod template resources or replicas of resource `test-res`"),
+		MaintainerCanModify: Bool(true),
+	}
+
+	mux.HandleFunc("/repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Error in METHOD. Expected: POST, Got: %s", r.Method)
+		}
+
+		receivedPR := new(github.NewPullRequest)
+		json.NewDecoder(r.Body).Decode(receivedPR)
+		if !cmp.Equal(receivedPR, expectedReceivedPR) {
+			t.Errorf("Expected PR in newPR did not match got %+v, want %+v", receivedPR, expectedReceivedPR)
+		}
+
+		fmt.Fprint(w, `{"number":1}`)
+	})
+
+	ctx := context.Background()
+	handler := &GitHandler{
+		ctx:         ctx,
+		client:      client,
+		user:        "o",
+		repo:        "r",
+		baseBranch:  "b",
+		path:        path,
+		commitUser:  author,
+		commitEmail: email,
+	}
+
+	expectedCreatedPR := &github.PullRequest{
+		Number: Int(1),
+	}
+
+	createdPR, err := handler.newPR("test-res", "test-branch")
+	if err != nil {
+		t.Errorf("Git Handler newPR returned error: %v", err)
+	}
+
+	if !cmp.Equal(expectedCreatedPR, createdPR) {
+		t.Errorf("Created PR from newPR did not match got %+v, want %+v", createdPR, expectedCreatedPR)
+	}
 }

--- a/pkg/action/executor/gitops/gitops_manager.go
+++ b/pkg/action/executor/gitops/gitops_manager.go
@@ -1,5 +1,6 @@
 package gitops
 
 type GitopsManager interface {
-	Update(replicas int64, podSpec map[string]interface{}) error
+	Update(replicas int64, podSpec map[string]interface{}) (interface{}, error)
+	WaitForActionCompletion(completionData interface{}) error
 }


### PR DESCRIPTION
~~Updating the finalised code changes as preview. Will update rest of the details once I complete the unit tests and the e2e testing this.~~

**Intent**
This PR implements support of PR mode for actions executed on applications managed by gitops pipeline specific to argoCD as the CD tool and github as source of truth.
This implements https://vmturbo.atlassian.net/browse/OM-82668 as the story.

**Background**
This update builds on the older work completed as part of #655.
This PR implements basic support using which the actions result will be updated by pushing a PR to the source of truth. This PR assumes that as of now only supported types will be a git repo with yaml files stored in it.

**Implementation**
This change introduces a new option in kubeturbo under the git config
```
--git-commit-mode The commit mode that should be used for git action executions. One of pr|direct. Defaults to direct.
```
If gitops based actions are enabled and `pr` mode is set, the action execution will push a PR to the remote source of truth and wait for the PR to be merged to complete the action. Until the PR is merged the action will remain in progress.

**Testing**
Action generated on gitops managed workload
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/10027921/167619610-c48ccaa1-2c20-4a85-b2a9-698a46f2e5fb.png">


<img width="1726" alt="image" src="https://user-images.githubusercontent.com/10027921/167619396-1493b044-1be7-4a57-967e-7074bd0f2f9c.png">
 
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/10027921/167619752-faae1ab7-352f-4bc2-9712-176cff343f6d.png">

Executing action creates a PR and remains pending
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/10027921/167620128-07252faf-13c2-4c01-b2c6-f5b95a62682a.png">
<img width="1779" alt="image" src="https://user-images.githubusercontent.com/10027921/167620216-88772b18-b8e4-49e1-b214-87180ba0c63c.png">

PR is created based on the resource name (not the file name)
<img width="1360" alt="image" src="https://user-images.githubusercontent.com/10027921/167620647-85e286db-da5a-4030-9711-aa520d1967df.png">


Completes the action when PR is merged
<img width="1779" alt="image" src="https://user-images.githubusercontent.com/10027921/167620315-28aad34c-2fcb-4d09-97c6-68f8cb7e3408.png">
<img width="1779" alt="image" src="https://user-images.githubusercontent.com/10027921/167620352-a339a4c9-1bb3-429a-94ba-b76468f26a78.png">





