### PR TITLE
Support bare pod move in the integration test

### DIFF
--- a/test/integration/pod_move_with_quota.go
+++ b/test/integration/pod_move_with_quota.go
@@ -95,7 +95,7 @@ spec:
 			framework.ExpectNoError(err, "Error creating test resources")
 			defer deleteDeploy(kubeClient, dep)
 
-			pod, err := getDeploymentsPod(kubeClient, dep.Name, namespace, "")
+			pod, err := getPodWithNamePrefix(kubeClient, dep.Name, namespace, "")
 			framework.ExpectNoError(err, "Error getting deployments pod")
 			// This should not happen. We should ideally get a pod.
 			if pod == nil {
@@ -129,7 +129,7 @@ spec:
 			framework.ExpectNoError(err, "Error creating test resources")
 			defer deleteDeploy(kubeClient, dep)
 
-			pod, err := getDeploymentsPod(kubeClient, dep.Name, namespace, "")
+			pod, err := getPodWithNamePrefix(kubeClient, dep.Name, namespace, "")
 			framework.ExpectNoError(err, "Error getting deployments pod")
 			// This should not happen. We should ideally get a pod.
 			if pod == nil {
@@ -162,7 +162,7 @@ spec:
 			framework.ExpectNoError(err, "Error creating test resources")
 			defer deleteDeploy(kubeClient, dep)
 
-			pod, err := getDeploymentsPod(kubeClient, dep.Name, namespace, "")
+			pod, err := getPodWithNamePrefix(kubeClient, dep.Name, namespace, "")
 			framework.ExpectNoError(err, "Error getting deployments pod")
 			// This should not happen. We should ideally get a pod.
 			if pod == nil {
@@ -201,7 +201,7 @@ spec:
 				framework.ExpectNoError(err, "Error creating test resources")
 				defer deleteDeploy(kubeClient, dep)
 
-				pod, err := getDeploymentsPod(kubeClient, dep.Name, namespace, "")
+				pod, err := getPodWithNamePrefix(kubeClient, dep.Name, namespace, "")
 				framework.ExpectNoError(err, "Error getting deployments pod")
 				// This should not happen. We should ideally get a pod.
 				if pod == nil {


### PR DESCRIPTION
# Intent
Adding move action execution test for the bare pod

# Background
The current integration test doesn't include this case

# Implementation
Create a bare pod and move it from one node to another node

# Test Done

## Case 1
**1. Build the binary and run the newly added case by executing this command**
```
make integration
./build/integration.test -k8s-kubeconfig=/root/.kube/config -k8s-context=kind-kind -ginkgo.focus="executing action move bare pod"
```
![image](https://user-images.githubusercontent.com/61252360/169407503-3044b625-1bca-463a-af26-6d41e74e8ca6.png)
