### PR TITLE
Fix nil pointer when moving a bare pod

### DIFF
--- a/pkg/action/executor/move_util.go
+++ b/pkg/action/executor/move_util.go
@@ -444,6 +444,9 @@ func newPendingInvalidPods(newList, oldList *api.PodList) []*api.Pod {
 }
 
 func parentsPods(parent *unstructured.Unstructured, podClient v1.PodInterface) (*api.PodList, error) {
+	if parent == nil {
+		return nil, nil
+	}
 	kind, objName := parent.GetKind(), parent.GetName()
 	selectorUnstructured, found, err := unstructured.NestedFieldCopy(parent.Object, "spec", "selector")
 	if err != nil || !found {
@@ -614,6 +617,9 @@ func ResourceRollout(client dynamic.ResourceInterface, obj *unstructured.Unstruc
 // ChangeScheduler sets the scheduler value to default or unsets it to an invalid one
 // This additionally adds or removes the garbage collection label on the resource
 func ChangeScheduler(client dynamic.ResourceInterface, obj *unstructured.Unstructured, valid bool) error {
+	if obj == nil {
+		return nil
+	}
 	kind := obj.GetKind()
 	name := obj.GetName()
 	// This takes care of conflicting updates for example by operator


### PR DESCRIPTION
# Intent
Prevent kubeturbo from crashing when moving a bare pod 

# Background
Adding moving bare pod cases in the integration test

# Implementation
Check the pointer before using it

# Test Done

## Case 1
**1. Move a volume-based bare pod**
```
[root@localvm kubeturbo]# ./build/integration.test -k8s-kubeconfig=/root/.kube/config -k8s-context=kind-kind -ginkgo.focus="executing action move bare pod"
I0525 18:01:00.858690   41479 integration_test.go:52] Starting integration run on Ginkgo node 1
Running Suite: Kubeturbo integration suite
==========================================
Random Seed: 1653516060
Will run 1 of 17 specs

SSSSSSSSSSSSE0525 18:01:06.215046   41479 util.go:96] cannot found node name from properites: []
W0525 18:01:06.217848   41479 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-spz2d/test-2kf4c]'s new host(kind-worker2) in bad condition: MemoryPressure
W0525 18:01:06.217866   41479 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-spz2d/test-2kf4c]'s new host(kind-worker2) in bad condition: DiskPressure
W0525 18:01:06.217869   41479 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-spz2d/test-2kf4c]'s new host(kind-worker2) in bad condition: PIDPressure

------------------------------
• [SLOW TEST:15.397 seconds]
Action Executor 
/opt/git/kubeturbo/test/integration/action_execution.go:49
  executing action move bare pod with volum attached
  /opt/git/kubeturbo/test/integration/action_execution.go:204
    should result in new pod on target node
    /opt/git/kubeturbo/test/integration/action_execution.go:205
------------------------------
SSSS
Ran 1 of 17 Specs in 15.401 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 16 Skipped
PASS

[root@localvm kubeturbo]# k get pods
NAME                       READY   STATUS        RESTARTS   AGE
test-2kf4c                 1/1     Terminating   0          34s         <------old pods get terminated
test-2kf4c-1dsjo37uo191k   1/1     Running       0          29s <------old pods start running
[root@localvm kubeturbo]# k describe pods test-2kf4c-1dsjo37uo191k
Name:         test-2kf4c-1dsjo37uo191k
Namespace:    kubeturbo-test-action-executor-spz2d
Priority:     0
Node:         kind-worker2/172.18.0.2
Start Time:   Wed, 25 May 2022 18:01:06 -0400
Labels:       <none>
Annotations:  kubeturbo.io/action: move
Status:       Running
IP:           10.244.2.23
IPs:
  IP:  10.244.2.23
Containers:
  test-cont:
    Container ID:  containerd://d0b49a2eaab2cc41bea6e28e972f19f4227116ee05c950ab2494f78f8e1b9914
    Image:         busybox
    Image ID:      docker.io/library/busybox@sha256:547706ea975b810cbddc457dcfd2fcc2bd935da585c0ae72a64a341863582f1e
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
    Args:
      -c
      while true; do sleep 30; done;
    State:          Running
      Started:      Wed, 25 May 2022 18:01:07 -0400
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     100m
      memory:  200Mi
    Requests:
      cpu:        50m
      memory:     100Mi
    Environment:  <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-f2t95 (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  pod-move-test:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  pod-move-test-lx7ms     <----------------volume allocated
    ReadOnly:   false
  default-token-f2t95:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-f2t95
    Optional:    false
QoS Class:       Burstable
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason   Age   From     Message
  ----    ------   ----  ----     -------
  Normal  Pulling  36s   kubelet  Pulling image "busybox"
  Normal  Pulled   35s   kubelet  Successfully pulled image "busybox"
  Normal  Created  35s   kubelet  Created container test-cont
  Normal  Started  35s   kubelet  Started container test-cont

```
