### PR TITLE
Graceful handling of multiple gitops action executions

### DIFF
--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -56,11 +56,12 @@ type ActionHandlerConfig struct {
 	updateQuotaToAllowMoves bool
 	readinessRetryThreshold int
 	gitConfig               gitops.GitConfig
+	k8sClusterId            string
 }
 
 func NewActionHandlerConfig(cApiNamespace string, cApiClient *versioned.Clientset, kubeletClient *kubeletclient.KubeletClient,
 	clusterScraper *cluster.ClusterScraper, sccSupport []string, ormClient *resourcemapping.ORMClient,
-	failVolumePodMoves, updateQuotaToAllowMoves bool, readinessRetryThreshold int, gitConfig gitops.GitConfig) *ActionHandlerConfig {
+	failVolumePodMoves, updateQuotaToAllowMoves bool, readinessRetryThreshold int, gitConfig gitops.GitConfig, clusterId string) *ActionHandlerConfig {
 	sccAllowedSet := make(map[string]struct{})
 	for _, sccAllowed := range sccSupport {
 		sccAllowedSet[strings.TrimSpace(sccAllowed)] = struct{}{}
@@ -79,6 +80,7 @@ func NewActionHandlerConfig(cApiNamespace string, cApiClient *versioned.Clientse
 		updateQuotaToAllowMoves: updateQuotaToAllowMoves,
 		readinessRetryThreshold: readinessRetryThreshold,
 		gitConfig:               gitConfig,
+		k8sClusterId:            clusterId,
 	}
 
 	return config
@@ -132,7 +134,7 @@ func NewActionHandler(config *ActionHandlerConfig) *ActionHandler {
 func (h *ActionHandler) registerActionExecutors() {
 	c := h.config
 	ae := executor.NewTurboK8sActionExecutor(c.clusterScraper, c.cApiClient, h.podManager,
-		h.config.ormClient, c.gitConfig)
+		h.config.ormClient, c.gitConfig, c.k8sClusterId)
 
 	reScheduler := executor.NewReScheduler(ae, c.sccAllowedSet, c.failVolumePodMoves,
 		c.updateQuotaToAllowMoves, h.lockMap, c.readinessRetryThreshold)

--- a/pkg/action/executor/action_executor.go
+++ b/pkg/action/executor/action_executor.go
@@ -34,15 +34,17 @@ type TurboK8sActionExecutor struct {
 	podManager     util.IPodManager
 	ormClient      *resourcemapping.ORMClient
 	gitConfig      gitops.GitConfig
+	k8sClusterId   string
 }
 
 func NewTurboK8sActionExecutor(clusterScraper *cluster.ClusterScraper, cApiClient *versioned.Clientset,
-	podManager util.IPodManager, ormSpec *resourcemapping.ORMClient, gitConfig gitops.GitConfig) TurboK8sActionExecutor {
+	podManager util.IPodManager, ormSpec *resourcemapping.ORMClient, gitConfig gitops.GitConfig, clusterId string) TurboK8sActionExecutor {
 	return TurboK8sActionExecutor{
 		clusterScraper: clusterScraper,
 		cApiClient:     cApiClient,
 		podManager:     podManager,
 		ormClient:      ormSpec,
 		gitConfig:      gitConfig,
+		k8sClusterId:   clusterId,
 	}
 }

--- a/pkg/action/executor/gitops/github_manager_test.go
+++ b/pkg/action/executor/gitops/github_manager_test.go
@@ -250,7 +250,7 @@ func TestGitHandler_NewPR(t *testing.T) {
 	path := "p"
 
 	expectedReceivedPR := &github.NewPullRequest{
-		Title: String("Turbonomic Action: update yaml file `p`"),
+		Title: String("Turbonomic Action: update yaml file p for resource test-cluster-id/test-ns/test-res"),
 		Head:  String("test-branch"),
 		Base:  String("b"),
 		Body: String("This PR is automatically created via `Turbonomic action execution` \n\n" +
@@ -288,7 +288,7 @@ func TestGitHandler_NewPR(t *testing.T) {
 		Number: Int(1),
 	}
 
-	createdPR, err := handler.newPR("test-res", "test-branch")
+	createdPR, err := handler.newPR("test-res", "test-ns", "test-cluster-id", "test-branch")
 	if err != nil {
 		t.Errorf("Git Handler newPR returned error: %v", err)
 	}

--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -30,7 +30,8 @@ func (h *HorizontalScaler) Execute(input *TurboActionExecutorInput) (*TurboActio
 		return nil, err
 	}
 	//2. Prepare controllerUpdater
-	controllerUpdater, err := newK8sControllerUpdaterViaPod(h.clusterScraper, pod, h.ormClient, h.gitConfig)
+	controllerUpdater, err := newK8sControllerUpdaterViaPod(h.clusterScraper,
+		pod, h.ormClient, h.gitConfig, h.k8sClusterId)
 	if err != nil {
 		glog.Errorf("Failed to create controllerUpdater: %v", err)
 		return &TurboActionExecutorOutput{}, err

--- a/pkg/action/executor/k8s_controller.go
+++ b/pkg/action/executor/k8s_controller.go
@@ -52,12 +52,13 @@ type kubeClients struct {
 }
 
 type parentController struct {
-	clients    kubeClients
-	obj        *unstructured.Unstructured
-	name       string
-	ormClient  *resourcemapping.ORMClient
-	managerApp *repository.K8sApp
-	gitConfig  gitops.GitConfig
+	clients      kubeClients
+	obj          *unstructured.Unstructured
+	name         string
+	ormClient    *resourcemapping.ORMClient
+	managerApp   *repository.K8sApp
+	gitConfig    gitops.GitConfig
+	k8sClusterId string
 }
 
 func (c *parentController) get(name string) (*k8sControllerSpec, error) {
@@ -125,7 +126,7 @@ func (c *parentController) update(updatedSpec *k8sControllerSpec) error {
 			// The workload is managed by a pipeline controller (argoCD) which replicates
 			// it from a source of truth
 			manager = gitops.NewGitHubManager(c.gitConfig, c.clients.typedClient,
-				c.clients.dynClient, c.obj, c.managerApp)
+				c.clients.dynClient, c.obj, c.managerApp, c.k8sClusterId)
 			glog.Infof("Gitops pipeline detected.")
 		default:
 			return fmt.Errorf("unsupported gitops manager type: %v", c.managerApp.Type)

--- a/pkg/action/executor/resize_container.go
+++ b/pkg/action/executor/resize_container.go
@@ -226,6 +226,7 @@ func (r *ContainerResizer) Execute(input *TurboActionExecutorInput) (*TurboActio
 		actionItem.GetConsistentScalingCompliance(),
 		r.ormClient,
 		r.gitConfig,
+		r.k8sClusterId,
 	)
 	if err != nil {
 		glog.Errorf("Failed to execute resize action: %v", err)

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -162,9 +162,9 @@ func genMemoryQuantity(newValue float64) (resource.Quantity, error) {
 }
 
 func resizeContainer(clusterScraper *cluster.ClusterScraper, pod *k8sapi.Pod, spec *containerResizeSpec,
-	consistentResize bool, ormSpec *resourcemapping.ORMClient, gitConfig gitops.GitConfig) (*k8sapi.Pod, error) {
+	consistentResize bool, ormSpec *resourcemapping.ORMClient, gitConfig gitops.GitConfig, clusterId string) (*k8sapi.Pod, error) {
 	if consistentResize {
-		return nil, resizeControllerContainer(clusterScraper, pod, spec, ormSpec, gitConfig)
+		return nil, resizeControllerContainer(clusterScraper, pod, spec, ormSpec, gitConfig, clusterId)
 	}
 	return resizeSingleContainer(clusterScraper.Clientset, pod, spec)
 }
@@ -180,9 +180,9 @@ func resizeContainer(clusterScraper *cluster.ClusterScraper, pod *k8sapi.Pod, sp
 //   are not affected. Only newly created pods (through scaling action) will use the updated
 //   resource
 func resizeControllerContainer(clusterScraper *cluster.ClusterScraper, pod *k8sapi.Pod, spec *containerResizeSpec,
-	ormClient *resourcemapping.ORMClient, gitConfig gitops.GitConfig) error {
+	ormClient *resourcemapping.ORMClient, gitConfig gitops.GitConfig, clusterId string) error {
 	// prepare controllerUpdater
-	controllerUpdater, err := newK8sControllerUpdaterViaPod(clusterScraper, pod, ormClient, gitConfig)
+	controllerUpdater, err := newK8sControllerUpdaterViaPod(clusterScraper, pod, ormClient, gitConfig, clusterId)
 	if err != nil {
 		glog.Errorf("Failed to create controllerUpdater: %v", err)
 		return err

--- a/pkg/action/executor/workload_controller_resizer.go
+++ b/pkg/action/executor/workload_controller_resizer.go
@@ -75,6 +75,7 @@ func (r *WorkloadControllerResizer) Execute(input *TurboActionExecutorInput) (*T
 		kind,
 		controllerName,
 		namespace,
+		r.k8sClusterId,
 		resizeSpecs,
 		managerApp,
 		r.gitConfig,
@@ -165,10 +166,11 @@ func (r *WorkloadControllerResizer) getWorkloadControllerSpec(parentKind, namesp
 }
 
 func resizeWorkloadController(clusterScraper *cluster.ClusterScraper, ormClient *resourcemapping.ORMClient,
-	kind, controllerName, namespace string, specs []*containerResizeSpec, managerApp *repository.K8sApp, gitConfig gitops.GitConfig) error {
+	kind, controllerName, namespace, clusterId string, specs []*containerResizeSpec, managerApp *repository.K8sApp,
+	gitConfig gitops.GitConfig) error {
 	// prepare controllerUpdater
-	controllerUpdater, err := newK8sControllerUpdater(clusterScraper,
-		ormClient, kind, controllerName, "", namespace, managerApp, gitConfig)
+	controllerUpdater, err := newK8sControllerUpdater(clusterScraper, ormClient, kind, controllerName,
+		"", namespace, clusterId, managerApp, gitConfig)
 	if err != nil {
 		glog.Errorf("Failed to create controllerUpdater: %v", err)
 		return err

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -199,9 +199,13 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 		config.containerUsageDataAggStrategy, config.ORMClient, config.DiscoveryWorkers, config.DiscoveryTimeoutSec,
 		config.DiscoverySamples, config.DiscoverySampleIntervalSec)
 
+	k8sSvcId, err := probeConfig.ClusterScraper.GetKubernetesServiceID()
+	if err != nil {
+		glog.Fatalf("Error retrieving the Kubernetes service id: %v", err)
+	}
 	actionHandlerConfig := action.NewActionHandlerConfig(config.CAPINamespace, config.CAClient, config.KubeletClient,
 		probeConfig.ClusterScraper, config.SccSupport, config.ORMClient, config.failVolumePodMoves,
-		config.updateQuotaToAllowMoves, config.readinessRetryThreshold, config.gitConfig)
+		config.updateQuotaToAllowMoves, config.readinessRetryThreshold, config.gitConfig, k8sSvcId)
 
 	// Kubernetes Probe Registration Client
 	registrationClient := registration.NewK8sRegistrationClient(registrationClientConfig, config.tapSpec.K8sTargetConfig)
@@ -236,10 +240,6 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 		probeBuilder = probeBuilder.WithDiscoveryClient(discoveryClient)
 	}
 
-	k8sSvcId, err := probeConfig.ClusterScraper.GetKubernetesServiceID()
-	if err != nil {
-		glog.Fatalf("Error retrieving the Kubernetes service id: %v", err)
-	}
 	tapService, err :=
 		service.NewTAPServiceBuilder().
 			WithCommunicationBindingChannel(k8sSvcId).

--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -84,7 +84,7 @@ var _ = Describe("Action Executor ", func() {
 
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
 				cluster.NewClusterScraper(kubeClient, dynamicClient, nil, false, nil, ""),
-				[]string{"*"}, nil, false, true, 60, gitops.GitConfig{})
+				[]string{"*"}, nil, false, true, 60, gitops.GitConfig{}, "test-cluster-id")
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 		}
 		namespace = f.TestNamespaceName()

--- a/test/integration/pod_move_with_quota.go
+++ b/test/integration/pod_move_with_quota.go
@@ -82,7 +82,7 @@ spec:
 
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
 				cluster.NewClusterScraper(kubeClient, dynamicClient, nil, false, nil, ""),
-				[]string{"*"}, nil, false, true, 60, gitops.GitConfig{})
+				[]string{"*"}, nil, false, true, 60, gitops.GitConfig{}, "test-cluster-id")
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 
 			namespace = f.TestNamespaceName()
@@ -123,7 +123,7 @@ spec:
 		It("should fail the action if the quota-update is disabled", func() {
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
 				cluster.NewClusterScraper(kubeClient, dynamicClient, nil, false, nil, ""),
-				[]string{"*"}, nil, false, false, 60, gitops.GitConfig{})
+				[]string{"*"}, nil, false, false, 60, gitops.GitConfig{}, "test-cluster-id")
 			actionHandler := action.NewActionHandler(actionHandlerConfig)
 
 			quota := createQuota(kubeClient, namespace, quotaFromYaml(quotaYaml))


### PR DESCRIPTION
 ~~This provides the option of failing the action if a PR for the same action already exists because of a previously failed action.~~

~~The change uses clusterID/namespace/name of the resource as a unique identifier on the PR Title and adds the code to check existing PRs by the same user on the same base branch (This is up for debate).~~

~~I am still working on the portion of the code, which can identify the difference in patch content and update the already existing PR with the new content if an update has happened.~~
~~Will update the PR description and the test details after I finish the same. Opening this to get early feedback.~~

**Intent**
This implements a graceful way of handling the kubeturbo restarts when a long running gitops based action is executed on argoCD pipeline.

**Background**
Prior to this implementation a kubeturbo restart will fail the action and leave the open PR behind. If the same action is executed again, a new PR will be created. If the PR is merged after the action was failed but is reapplied for execution (the action remains but the source of truth is now aligned to the desired state), a PR with empty commit will be created.


**Implementation**
The following algorithm is implemented

1. store `cluster-unique-id/workload-ns/workload-name` as a unique identified on the PR  title that is created as part of action execution.

2. if kubeturbo restarts, the action is failed in turbo server, which is regenerated again and can be executed again.

3. on the second (or any subsequent) action execution, kubeturbo checks all open PRs of the given user, and tries to find the PR which has the unique id for the given workload controller.

4. if not found standard flow is taken which includes

    - create a new branch on the repo

    - update the yaml content with the patch from action execution

    - create a PR and

    - wait for the PR to be merged

5. if found kubeturbo first checks if there is new diff compared to the existing action commit

    - if there is new diff, kubeturbo pushes a new commit on the PR branch

    - if there is no diff, kubeturbo does not do anything in terms of the PR commit

6. kubeturbo then continues to wait on the existing PR to be merged.

**Testing**

A new PR as a result of the action has the <cluster-unique-id><namespace>/<resource-name> as the unique identifier

<img width="1694" alt="image" src="https://user-images.githubusercontent.com/10027921/173342342-36301226-5c08-4f35-a819-0288f1da286a.png">

Executing an action again after the first trial failed (because of kubeturbo restart):
<img width="1415" alt="image" src="https://user-images.githubusercontent.com/10027921/173342842-ec21c7af-7c2d-45d4-9117-3c0791bd50b8.png">

The action then continues to wait until the PR is merged
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/10027921/173342911-badd0749-fd4e-42a3-9e11-119d4d3dd23f.png">

