### PR TITLE
[OM-83922]: Add support to load client Id and client Secret from k8s secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20220405155252-eb6acce31600
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20220607022735-161ae61e0587
 )
 
 // k8s and relevant dependencies

--- a/go.sum
+++ b/go.sum
@@ -873,10 +873,10 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca h1:kWhxdWkGgeMNZQgZ+FQVFW0FEau2fHwraM7OGFug6Tw=
-github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20220405155252-eb6acce31600 h1:yNn4SrdZyatS+0wh4S2rAYwMjjg9e7dAUkYxQUzVTxM=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20220405155252-eb6acce31600/go.mod h1:fgT3XIFr1l915RVS3am6MHR5OyBzKcZSurt5zdXEFT4=
+github.com/turbonomic/turbo-api v0.0.0-20220606151638-bcdf1d7b4ab8 h1:KNqHTUIunOPSHyO8FHgrMq8KMzgXpxHe7nW0dCnkfic=
+github.com/turbonomic/turbo-api v0.0.0-20220606151638-bcdf1d7b4ab8/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20220607022735-161ae61e0587 h1:uHIB7mk0vGpDFgZ8uV+TbItM6eRyXeTNjDsCqk3xvjs=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20220607022735-161ae61e0587/go.mod h1:8KDYKAtQ/0IfWEJ34N/vfZ1U0fbSEUKyv4Pf/WciNds=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/vendor/github.com/turbonomic/turbo-api/pkg/api/resource_type.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/api/resource_type.go
@@ -8,4 +8,6 @@ const (
 	Resource_Type_Target          ResourceType = "target"
 	Resource_Type_Probe           ResourceType = "probe"
 	Resource_Type_External_Target ResourceType = "externaltargets"
+	Resource_Type_hydra_token     ResourceType = "token"
+	Resource_Type_auth_token      ResourceType = "exchange"
 )

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
@@ -1,10 +1,12 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/turbonomic/turbo-api/pkg/api"
+	"mime/multipart"
 	"net/http"
 	"strings"
 )
@@ -13,11 +15,71 @@ import (
 type APIClient struct {
 	*RESTClient
 	SessionCookie *http.Cookie
+	ClientId      string
+	ClientSecret  string
 }
 
 const (
 	SessionCookie string = "JSESSIONID"
 )
+
+type HydraTokenBody struct {
+	AccessToken string `json:"access_token,omitempty"`
+	ExpiresIn   int    `json:"expires_in,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+	TokenType   string `json:"token_type,omitempty"`
+}
+
+func (c *APIClient) GetJwtToken(hydraToken string) (string, error) {
+	if hydraToken == "" {
+		glog.V(4).Infof("The hydra token is empty")
+		return "", nil
+	}
+	// the format of getting jwtToken with auth requires the following header
+	// key: x-oauth2, value: "hydra"
+	// key: x-auth-token, value: hydra access token
+	request := c.Post().Resource(api.Resource_Type_auth_token).Header("x-oauth2", "hydra").Header("x-auth-token", hydraToken)
+	// Execute the request
+	response, err := request.Do()
+	if err != nil {
+		return "", fmt.Errorf("request %v failed: %s", request, err)
+	}
+	return response.body, nil
+}
+
+func (c *APIClient) GetHydraAccessToken() (string, error) {
+	if c.ClientId == "" || c.ClientSecret == "" {
+		glog.V(4).Infof("The client id or client secret are not provided")
+		return "", nil
+	}
+	// Create the form-data format payload
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	writer.WriteField("client_id", c.ClientId)
+	writer.WriteField("client_secret", c.ClientSecret)
+	writer.WriteField("grant_type", "client_credentials")
+	err := writer.Close()
+	if err != nil {
+		return "", fmt.Errorf("failed to Close the writer: %v", err)
+	}
+	// Create the rest api request
+	// the format of get hydra access token requires the following in the body, as form-data format
+	// key: client_id, value: client id value
+	// key: client_secret, value: client secret value
+	// key: grant_type, value: client_credentials
+	request := c.Post().Resource(api.Resource_Type_hydra_token).Header("Content-Type", writer.FormDataContentType()).BufferData(payload)
+	// Execute the request
+	response, err := request.Do()
+	if err != nil {
+		return "", fmt.Errorf("failed to get hydra access token: %s", err)
+	}
+	var hydraToken HydraTokenBody
+	err = json.Unmarshal([]byte(response.body), &hydraToken)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshall get hydra token response: %v", err)
+	}
+	return hydraToken.AccessToken, nil
+}
 
 // Discover a target using API
 // This function is called by turboctl which is not being maintained

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/config.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/config.go
@@ -10,13 +10,17 @@ type Config struct {
 	// For Basic authentication.
 	basicAuth *BasicAuthentication
 	// For proxy
-	proxy string
+	proxy        string
+	clientId     string
+	clientSecret string
 }
 
 type ConfigBuilder struct {
 	serverAddress *url.URL
 	basicAuth     *BasicAuthentication
 	proxy         string
+	clientId      string
+	clientSecret  string
 }
 
 func NewConfigBuilder(serverAddress *url.URL) *ConfigBuilder {
@@ -27,6 +31,16 @@ func NewConfigBuilder(serverAddress *url.URL) *ConfigBuilder {
 
 func (cb *ConfigBuilder) SetProxy(proxy string) *ConfigBuilder {
 	cb.proxy = proxy
+	return cb
+}
+
+func (cb *ConfigBuilder) SetClientId(clientId string) *ConfigBuilder {
+	cb.clientId = clientId
+	return cb
+}
+
+func (cb *ConfigBuilder) SetClientSecret(clientSecret string) *ConfigBuilder {
+	cb.clientSecret = clientSecret
 	return cb
 }
 
@@ -43,5 +57,7 @@ func (cb *ConfigBuilder) Create() *Config {
 		serverAddress: cb.serverAddress,
 		basicAuth:     cb.basicAuth,
 		proxy:         cb.proxy,
+		clientId:      cb.clientId,
+		clientSecret:  cb.clientSecret,
 	}
 }

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/request.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/request.go
@@ -123,6 +123,11 @@ func (r *Request) Data(data []byte) *Request {
 	return r
 }
 
+func (r *Request) BufferData(data *bytes.Buffer) *Request {
+	r.data = data
+	return r
+}
+
 // URL returns the current working URL.
 func (r *Request) URL() *url.URL {
 	p := r.pathPrefix

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/tp_client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/tp_client.go
@@ -22,6 +22,14 @@ type TPClient struct {
 	*RESTClient
 }
 
+func (c *TPClient) GetJwtToken(hydraToken string) (string, error) {
+	panic("the program is trying to get jwtToken from TP Client, which should never happen")
+}
+
+func (c *TPClient) GetHydraAccessToken() (string, error) {
+	panic("the program is trying to get hydra access token from TP Client, which should never happen")
+}
+
 // DiscoverTarget adds a target via Topology Processor service
 func (c *TPClient) DiscoverTarget(uuid string) (*Result, error) {
 	// Not implemented

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/mediation_communication_config.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/mediation_communication_config.go
@@ -21,9 +21,11 @@ var (
 )
 
 type ServerMeta struct {
-	TurboServer string `json:"turboServer,omitempty"`
-	Version     string `json:"version,omitempty"`
-	Proxy       string `json:"proxy,omitempty"`
+	TurboServer  string `json:"turboServer,omitempty"`
+	Version      string `json:"version,omitempty"`
+	Proxy        string `json:"proxy,omitempty"`
+	ClientId     string `json:"clientId,omitempty"`
+	ClientSecret string `json:"clientSecret,omitempty"`
 }
 
 func (meta *ServerMeta) ValidateServerMeta() error {

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/mediation_container.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/mediation_container.go
@@ -62,7 +62,7 @@ func CreateMediationContainer(containerConfig *MediationContainerConfig) *mediat
 }
 
 // Start the RemoteMediationClient
-func InitMediationContainer(probeRegisteredMsg chan bool, disconnectFromTurbo chan struct{}) {
+func InitMediationContainer(probeRegisteredMsg chan bool, disconnectFromTurbo chan struct{}, jwtToken string) {
 	theContainer := singletonMediationContainer()
 	glog.Infof("Initializing mediation container .....")
 	// Assert that the probes are registered before starting the handshake
@@ -74,7 +74,7 @@ func InitMediationContainer(probeRegisteredMsg chan bool, disconnectFromTurbo ch
 	glog.V(2).Infof("Registering %d probes", len(theContainer.allProbes))
 
 	remoteMediationClient := theContainer.theRemoteMediationClient
-	remoteMediationClient.Init(probeRegisteredMsg, disconnectFromTurbo)
+	remoteMediationClient.Init(probeRegisteredMsg, disconnectFromTurbo, jwtToken)
 }
 
 func GetMediationService() string {

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go
@@ -55,7 +55,7 @@ func CreateRemoteMediationClient(allProbes map[string]*ProbeProperties,
 
 // Establish connection with the Turbo server -  Blocks till WebSocket connection is open
 // Complete the probe registration protocol with the server and then wait for server messages
-func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh chan bool, disconnectFromTurbo chan struct{}) {
+func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh chan bool, disconnectFromTurbo chan struct{}, jwtToken string) {
 	// TODO: Assert that the probes are registered before starting the handshake ??
 
 	//// --------- Create WebSocket Transport
@@ -76,7 +76,7 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 	transport := CreateClientWebSocketTransport(connConfig) //, transportClosedNotificationCh)
 	remoteMediationClient.closeWatcherCh = make(chan bool, 1)
 
-	err = transport.Connect() // TODO: blocks till websocket connection is open or until transport is closed
+	err = transport.Connect(jwtToken) // TODO: blocks till websocket connection is open or until transport is closed
 
 	// handle WebSocket creation errors
 	if err != nil { //transport.ws == nil {
@@ -117,7 +117,7 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 				// stop server messages listener
 				remoteMediationClient.stopMessageHandler()
 				// Reconnect
-				err := transport.Connect()
+				err := transport.Connect(jwtToken)
 				// handle WebSocket creation errors
 				if err != nil { //transport.ws == nil {
 					glog.Errorf("[Reconnect] Initialization of remote mediation client failed: %v", err)

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/transport_endpoint.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/transport_endpoint.go
@@ -3,7 +3,7 @@ package mediationcontainer
 // Transport endpoint that sends and receives raw message bytes
 type ITransport interface {
 	// Open
-	Connect() error
+	Connect(jwtToken string) error
 	GetConnectionId() string
 	GetService() string
 	// Send

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,10 +178,10 @@ github.com/spf13/pflag
 # github.com/stretchr/testify v1.7.0
 ## explicit
 github.com/stretchr/testify/assert
-# github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca
+# github.com/turbonomic/turbo-api v0.0.0-20220606151638-bcdf1d7b4ab8
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
-# github.com/turbonomic/turbo-go-sdk v0.0.0-20220405155252-eb6acce31600
+# github.com/turbonomic/turbo-go-sdk v0.0.0-20220607022735-161ae61e0587
 ## explicit
 github.com/turbonomic/turbo-go-sdk/pkg
 github.com/turbonomic/turbo-go-sdk/pkg/builder


### PR DESCRIPTION
**Intent**
For secure probe registration, we now need to acquire the jwtToken in the header of websocket connection. The review includes the changes to load the client id and client secret from k8s secret
Please note, we still need to update the go.mod after the api and sdk is merged.

**Implementation**
This review only includes the change for SDK. More changes in Turbo go SDK and Kubeturbo. The flow is the following:

Kubeturbo load clientid and clientsecret from k8s secret
In Turbo Go SDK, clientid and clientsecret are parsed to APIClient during the creation of the client
GetHydraToken and GetJwtToken are invoked before the websocket connection.
**Test**
Use the secure probe enabled server.
![Screen Shot 2022-05-31 at 5 17 05 PM](https://user-images.githubusercontent.com/4391815/171783206-15ca9c52-c94b-4cde-a58c-bb8786129cb8.png)

To create the secret with the client id and client secret
➜  25secure echo -n 'my-client25' | openssl base64
bXktY2xpZW50MjU=

➜  25secure echo -n 'secret25' | openssl base64
c2VjcmV0MjU=

➜  25secure cat secret 
apiVersion: v1
kind: Secret
metadata:
  name: turbonomic-credentials-secure
  namespace: turbo
type: Opaque
data:
  username: dGVzdC11c2Vy
  password: dGVzdHBhc3N3ZA==
  clientid: bXktY2xpZW50MjU=
  clientsecret: c2VjcmV0MjU=