### PR TITLE
Add ORM case in the integration test

### DIFF
--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -38,16 +38,8 @@ const (
 	cpuIncrement                 = 50
 	memoryIncrement              = 75
 	cpuDecrement                 = 25
-	memoryDecrement              = 50
+	memoryDecrement              = 10
 	injectedSidecarContainerName = "istio-proxy"
-)
-
-const (
-	REQUEST_SINGLE_CONTAINER = iota
-	LIMIT_SINGLE_CONTAINER
-	REQLIM_MULTI_CONTAINER
-	ORM_RESIZE_UP
-	ORM_RESIZE_DOWN
 )
 
 const (
@@ -238,7 +230,7 @@ var _ = Describe("Action Executor ", func() {
 			framework.ExpectNoError(err, "Error creating test resources")
 
 			targetSE := newResizeWorkloadControllerTargetSE(dc)
-			resizeAction, desiredPodSpec := newResizeActionExecutionDTO(targetSE, REQLIM_MULTI_CONTAINER, &dc.Spec.Template.Spec)
+			resizeAction, desiredPodSpec := newResizeActionExecutionDTO(targetSE, &dc.Spec.Template.Spec, "test-cont-1", "test-cont-2")
 			_, err = actionHandler.ExecuteAction(resizeAction, nil, &mockProgressTrack{})
 			framework.ExpectNoError(err, "Resize action on multiple container failed")
 
@@ -284,25 +276,14 @@ var _ = Describe("Action Executor ", func() {
 
 			targetSE := newResizeWorkloadControllerTargetSE(dep)
 
-			// Resize up cpu and memory on resource/limit
-			resizeAction, desiredPodSpec := newResizeActionExecutionDTO(targetSE, LIMIT_SINGLE_CONTAINER, &dep.Spec.Template.Spec)
+			// Resize up cpu and memory
+			resizeAction, desiredPodSpec := newResizeActionExecutionDTO(targetSE, &dep.Spec.Template.Spec, "test-cont")
 			_, err = actionHandler.ExecuteAction(resizeAction, nil, &mockProgressTrack{})
 			framework.ExpectNoError(err, "Resize action on limit failed")
 
-			controllerObj, err := waitForWorkloadControllerToUpdateResource(kubeClient, dep, desiredPodSpec)
-			if err != nil {
-				framework.Failf("Failed to check the change of resource/limit in the new deployment: %s", err)
-			}
-
-			// Resize up cpu and memory on resource/request
-			dep = controllerObj.(*appsv1.Deployment)
-			resizeAction, desiredPodSpec = newResizeActionExecutionDTO(targetSE, REQUEST_SINGLE_CONTAINER, &dep.Spec.Template.Spec)
-			_, err = actionHandler.ExecuteAction(resizeAction, nil, &mockProgressTrack{})
-			framework.ExpectNoError(err, "Resize action on request failed")
-
 			_, err = waitForWorkloadControllerToUpdateResource(kubeClient, dep, desiredPodSpec)
 			if err != nil {
-				framework.Failf("Failed to check the change of the resource/request in the new deployment: %s", err)
+				framework.Failf("Failed to check the change of resource/limit in the new deployment: %s", err)
 			}
 		})
 	})
@@ -327,7 +308,7 @@ var _ = Describe("Action Executor ", func() {
 			}
 
 			targetSE := newResizeWorkloadControllerTargetSE(dep)
-			resizeAction, desiredPodSpec := newResizeActionExecutionDTO(targetSE, REQLIM_MULTI_CONTAINER, &dep.Spec.Template.Spec)
+			resizeAction, desiredPodSpec := newResizeActionExecutionDTO(targetSE, &dep.Spec.Template.Spec, "test-cont-1", "test-cont-2")
 			_, err = actionHandler.ExecuteAction(resizeAction, nil, &mockProgressTrack{})
 			framework.ExpectNoError(err, "Resize action on multiple container failed")
 
@@ -952,119 +933,43 @@ type mockProgressTrack struct{}
 func (p *mockProgressTrack) UpdateProgress(actionState proto.ActionResponseState, description string, progress int32) {
 }
 
-func newResizeActionExecutionDTO(targetSE *proto.EntityDTO, changeType int, podSpec *corev1.PodSpec) (*proto.ActionExecutionDTO, *corev1.PodSpec) {
+func newResizeActionExecutionDTO(targetSE *proto.EntityDTO, podSpec *corev1.PodSpec, containerNames ...string) (*proto.ActionExecutionDTO, *corev1.PodSpec) {
 	dto := &proto.ActionExecutionDTO{}
 	actionType := proto.ActionItemDTO_RIGHT_SIZE
 	desiredPodSpec := podSpec.DeepCopy()
+	for _, containerName := range containerNames {
+		currentSE := newContainerEntity(containerName)
+		containerIdx, err := findContainerIdxInPodSpecByName(podSpec, containerName)
+		framework.ExpectNoError(err, "Can't find the container<%v> in the pod's spec", containerName)
 
-	switch changeType {
-	case REQUEST_SINGLE_CONTAINER:
-		currentSE := newContainerEntity("test-cont")
+		// Build the action item on limits/cpu
+		oldLimCpuCap := podSpec.Containers[containerIdx].Resources.Limits.Cpu().MilliValue()
+		newLimCpuCap := oldLimCpuCap + cpuIncrement
+		aiOnLimCpu := newActionItemDTO(actionType, proto.CommodityDTO_VCPU, oldLimCpuCap, newLimCpuCap, currentSE, targetSE)
 
-		// Build the action item on cpu
-		oldCpuCap := podSpec.Containers[0].Resources.Requests.Cpu().MilliValue()
-		newCpuCap := oldCpuCap + cpuIncrement
-		aiOnCpu := newActionItemDTO(actionType, proto.CommodityDTO_VCPU_REQUEST, oldCpuCap, newCpuCap, currentSE, targetSE)
+		// Build the action item on limits/memory
+		oldLimMemCap := podSpec.Containers[containerIdx].Resources.Limits.Memory().Value() / 1024
+		newLimMemCap := oldLimMemCap - memoryDecrement*1024
+		aiOnLimMem := newActionItemDTO(actionType, proto.CommodityDTO_VMEM, oldLimMemCap, newLimMemCap, currentSE, targetSE)
 
-		// Build the action item on memory
-		oldMemCap := podSpec.Containers[0].Resources.Requests.Memory().Value() / 1024
-		newMemCap := oldMemCap + memoryIncrement*1024
-		aiOnMem := newActionItemDTO(actionType, proto.CommodityDTO_VMEM_REQUEST, oldMemCap, newMemCap, currentSE, targetSE)
+		// Build the action item on requests/cpu
+		oldReqCpuCap := podSpec.Containers[containerIdx].Resources.Requests.Cpu().MilliValue()
+		newReqCpuCap := oldReqCpuCap + cpuIncrement
+		aiOnReqCpu := newActionItemDTO(actionType, proto.CommodityDTO_VCPU_REQUEST, oldReqCpuCap, newReqCpuCap, currentSE, targetSE)
 
-		dto.ActionItem = []*proto.ActionItemDTO{aiOnCpu, aiOnMem}
+		// Build the action item on requests/memory
+		oldReqMemCap := podSpec.Containers[containerIdx].Resources.Requests.Memory().Value() / 1024
+		newReqMemCap := oldReqMemCap - memoryDecrement*1024
+		aiOnReqMem := newActionItemDTO(actionType, proto.CommodityDTO_VMEM_REQUEST, oldReqMemCap, newReqMemCap, currentSE, targetSE)
 
-		// Update the desired podSpec
-		updatePodSpec(desiredPodSpec, 0, "requests", "cpu", RESIZE_UP, cpuIncrement)
-		updatePodSpec(desiredPodSpec, 0, "requests", "memory", RESIZE_UP, memoryIncrement)
-	case LIMIT_SINGLE_CONTAINER:
-		currentSE := newContainerEntity("test-cont")
-
-		// Build the action item on cpu
-		oldCpuCap := podSpec.Containers[0].Resources.Limits.Cpu().MilliValue()
-		newCpuCap := oldCpuCap + cpuIncrement
-		aiOnCpu := newActionItemDTO(actionType, proto.CommodityDTO_VCPU, oldCpuCap, newCpuCap, currentSE, targetSE)
-
-		// Build the action item on memory
-		oldMemCap := podSpec.Containers[0].Resources.Limits.Memory().Value() / 1024
-		newMemCap := oldMemCap + memoryIncrement*1024
-		aiOnMem := newActionItemDTO(actionType, proto.CommodityDTO_VMEM, oldMemCap, newMemCap, currentSE, targetSE)
-
-		dto.ActionItem = []*proto.ActionItemDTO{aiOnCpu, aiOnMem}
+		dto.ActionItem = append(dto.ActionItem, aiOnLimCpu, aiOnLimMem, aiOnReqCpu, aiOnReqMem)
 
 		// Update the desired podSpec
-		updatePodSpec(desiredPodSpec, 0, "limits", "cpu", RESIZE_UP, cpuIncrement)
-		updatePodSpec(desiredPodSpec, 0, "limits", "memory", RESIZE_UP, memoryIncrement)
-	case REQLIM_MULTI_CONTAINER:
-		containerSE1 := newContainerEntity("test-cont-1")
-		// Build the resize up action item on request/cpu and resize down action on request/memory for the first container
-		oldCpuCap1 := podSpec.Containers[0].Resources.Requests.Cpu().MilliValue()
-		newCpuCap1 := oldCpuCap1 + cpuIncrement
-		aiOnCpu1 := newActionItemDTO(actionType, proto.CommodityDTO_VCPU_REQUEST, oldCpuCap1, newCpuCap1, containerSE1, targetSE)
-		oldMemCap1 := podSpec.Containers[0].Resources.Requests.Memory().Value() / 1024
-		newMemCap1 := oldMemCap1 - memoryDecrement*1024
-		aiOnMem1 := newActionItemDTO(actionType, proto.CommodityDTO_VMEM_REQUEST, oldMemCap1, newMemCap1, containerSE1, targetSE)
-
-		// Build the resize down action item on limit/cpu and resize up action on limit/memory for the second container
-		containerSE2 := newContainerEntity("test-cont-2")
-		oldCpuCap2 := podSpec.Containers[1].Resources.Limits.Cpu().MilliValue()
-		newCpuCap2 := oldCpuCap2 - cpuDecrement
-		aiOnCpu2 := newActionItemDTO(actionType, proto.CommodityDTO_VCPU, oldCpuCap2, newCpuCap2, containerSE2, targetSE)
-		oldMemCap2 := podSpec.Containers[1].Resources.Limits.Memory().Value() / 1024
-		newMemCap2 := oldMemCap2 + memoryIncrement*1024
-		aiOnMem2 := newActionItemDTO(actionType, proto.CommodityDTO_VMEM, oldMemCap2, newMemCap2, containerSE2, targetSE)
-
-		dto.ActionItem = []*proto.ActionItemDTO{aiOnCpu1, aiOnMem1, aiOnCpu2, aiOnMem2}
-
-		// Update the desired podSpec
-		updatePodSpec(desiredPodSpec, 0, "requests", "cpu", RESIZE_UP, cpuIncrement)
-		updatePodSpec(desiredPodSpec, 0, "requests", "memory", RESIZE_DOWN, memoryDecrement)
-		updatePodSpec(desiredPodSpec, 1, "limits", "cpu", RESIZE_DOWN, cpuDecrement)
-		updatePodSpec(desiredPodSpec, 1, "limits", "memory", RESIZE_UP, memoryIncrement)
-	case ORM_RESIZE_UP:
-		currentSE := newContainerEntity(namespacescope_operand_container_name)
-		containerIdx, _ := findContainerIdxInPodSpecByName(podSpec, namespacescope_operand_container_name)
-		if containerIdx != -1 {
-			// Build the action item on cpu
-			oldCpuCap := podSpec.Containers[containerIdx].Resources.Limits.Cpu().MilliValue()
-			newCpuCap := oldCpuCap + cpuIncrement
-			aiOnCpu := newActionItemDTO(actionType, proto.CommodityDTO_VCPU, oldCpuCap, newCpuCap, currentSE, targetSE)
-
-			// Build the action item on memory
-			oldMemCap := podSpec.Containers[containerIdx].Resources.Limits.Memory().Value() / 1024
-			newMemCap := oldMemCap + memoryIncrement*1024
-			aiOnMem := newActionItemDTO(actionType, proto.CommodityDTO_VMEM, oldMemCap, newMemCap, currentSE, targetSE)
-
-			dto.ActionItem = []*proto.ActionItemDTO{aiOnCpu, aiOnMem}
-
-			// Update the desired podSpec
-			updatePodSpec(desiredPodSpec, containerIdx, "limits", "cpu", RESIZE_UP, cpuIncrement)
-			updatePodSpec(desiredPodSpec, containerIdx, "limits", "memory", RESIZE_UP, memoryIncrement)
-		}
-	case ORM_RESIZE_DOWN:
-		currentSE := newContainerEntity(clusterscope_operand_container_name)
-		containerIdx, _ := findContainerIdxInPodSpecByName(podSpec, clusterscope_operand_container_name)
-		if containerIdx != -1 {
-			// Build the action item on cpu
-			oldCpuCap := podSpec.Containers[containerIdx].Resources.Limits.Cpu().MilliValue()
-			newCpuCap := oldCpuCap - cpuDecrement
-			aiOnCpu := newActionItemDTO(actionType, proto.CommodityDTO_VCPU, oldCpuCap, newCpuCap, currentSE, targetSE)
-
-			// Build the action item on memory
-			oldMemCap := podSpec.Containers[containerIdx].Resources.Limits.Memory().Value() / 1024
-			newMemCap := oldMemCap - memoryDecrement*1024
-			aiOnMem := newActionItemDTO(actionType, proto.CommodityDTO_VMEM, oldMemCap, newMemCap, currentSE, targetSE)
-
-			dto.ActionItem = []*proto.ActionItemDTO{aiOnCpu, aiOnMem}
-
-			// Update the desired podSpec
-			updatePodSpec(desiredPodSpec, containerIdx, "limits", "cpu", RESIZE_DOWN, cpuDecrement)
-			updatePodSpec(desiredPodSpec, containerIdx, "limits", "memory", RESIZE_DOWN, memoryDecrement)
-		}
-
-	default:
-		framework.Errorf("The change type<%d> isn't supported", changeType)
+		updatePodSpec(desiredPodSpec, containerIdx, "limits", "cpu", RESIZE_UP, cpuIncrement)
+		updatePodSpec(desiredPodSpec, containerIdx, "limits", "memory", RESIZE_DOWN, memoryDecrement)
+		updatePodSpec(desiredPodSpec, containerIdx, "requests", "cpu", RESIZE_UP, cpuIncrement)
+		updatePodSpec(desiredPodSpec, containerIdx, "requests", "memory", RESIZE_DOWN, memoryDecrement)
 	}
-
 	return dto, desiredPodSpec
 }
 

--- a/test/integration/orm_action_execution.go
+++ b/test/integration/orm_action_execution.go
@@ -110,8 +110,8 @@ var _ = Describe("Action Executor ", func() {
 			// Kubernetes Probe Discovery Client
 			defer TimeCost("DiscoverWithNewFramework", time.Now())
 			discoveryClient := discovery.NewK8sDiscoveryClient(discoveryClientConfig)
-			_, _, err = discoveryClient.DiscoverWithNewFramework("discovery-integration-test")
-			framework.ExpectNoError(err, "Failed completing discovery of test cluster")
+			// Cache operatorResourceSpecMap in ormClient
+			discoveryClient.Config.OrmClient.CacheORMSpecMap()
 		}
 
 	})

--- a/test/integration/orm_action_execution.go
+++ b/test/integration/orm_action_execution.go
@@ -1,0 +1,216 @@
+package integration
+
+import (
+	"context"
+	"strings"
+
+	set "github.com/deckarep/golang-set"
+	"github.com/golang/glog"
+	"github.com/turbonomic/kubeturbo/cmd/kubeturbo/app"
+	"github.com/turbonomic/kubeturbo/test/integration/framework"
+	v1 "k8s.io/api/core/v1"
+	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+
+	. "github.com/onsi/ginkgo"
+
+	"github.com/turbonomic/kubeturbo/pkg/action"
+	"github.com/turbonomic/kubeturbo/pkg/action/executor/gitops"
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
+	"github.com/turbonomic/kubeturbo/pkg/discovery"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
+	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
+	"github.com/turbonomic/kubeturbo/pkg/util"
+)
+
+const (
+	ormtest_namespace                      = "ibm-common-services"
+	namespacescope_operand_deployment_name = "auth-idp"
+	namespacescope_operand_container_name  = "icp-audit-service"
+	namespacescope_operator_cr_name        = "example-authentication"
+	namespacescope_operand_path_in_cr      = ".spec.auditService.resources"
+
+	clusterscope_operand_deployment_name = "cert-manager-cainjector"
+	clusterscope_operand_container_name  = "cert-manager-cainjector"
+	clusterscope_operator_cr_name        = "default"
+	clusterscope_operand_path_in_cr      = ".spec.certManagerCAInjector.resources"
+)
+
+var (
+	groupVersionRes4nsscope = schema.GroupVersionResource{
+		Group:    "operator.ibm.com",
+		Version:  "v1alpha1",
+		Resource: "authentications",
+	}
+	groupVersionRes4clusterscope = schema.GroupVersionResource{
+		Group:    "operator.ibm.com",
+		Version:  "v1alpha1",
+		Resource: "certmanagers",
+	}
+)
+
+var _ = Describe("Action Executor ", func() {
+	f := framework.NewTestFramework("orm-action-executor")
+	var kubeConfig *restclient.Config
+	var actionHandler *action.ActionHandler
+	var kubeClient *kubeclientset.Clientset
+	var dynamicClient dynamic.Interface
+	var origCRValue4NsScope, origCRValue4ClusterScope interface{}
+	var needRevertCR4NsScope, needRevertCR4ClusterScope bool
+
+	BeforeEach(func() {
+		f.BeforeEach()
+		// The following setup is shared across tests here
+		if kubeConfig == nil {
+
+			kubeConfig := f.GetKubeConfig()
+			kubeClient = f.GetKubeClient("orm-action-executor")
+
+			var err error
+			dynamicClient, err = dynamic.NewForConfig(kubeConfig)
+			if err != nil {
+				framework.Failf("Failed to generate dynamic client for kubernetes test cluster: %v", err)
+			}
+
+			s := app.NewVMTServer()
+			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "", "busybox", map[string]set.Set{}, true)
+			apiExtClient, err := apiextclient.NewForConfig(kubeConfig)
+			if err != nil {
+				glog.Fatalf("Failed to generate apiExtensions client for kubernetes target: %v", err)
+			}
+			ormClient := resourcemapping.NewORMClient(dynamicClient, apiExtClient)
+
+			probeConfig := createProbeConfigOrDie(kubeClient, kubeletClient, dynamicClient)
+
+			discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, nil, app.DefaultValidationWorkers,
+				app.DefaultValidationTimeout, aggregation.DefaultContainerUtilizationDataAggStrategy,
+				aggregation.DefaultContainerUsageDataAggStrategy, ormClient, app.DefaultDiscoveryWorkers, app.DefaultDiscoveryTimeoutSec,
+				app.DefaultDiscoverySamples, app.DefaultDiscoverySampleIntervalSec)
+			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
+				cluster.NewClusterScraper(kubeClient, dynamicClient, false, nil, ""),
+				[]string{"*"}, ormClient, false, true, 60, gitops.GitConfig{})
+			actionHandler = action.NewActionHandler(actionHandlerConfig)
+
+			// Kubernetes Probe Discovery Client
+			discoveryClient := discovery.NewK8sDiscoveryClient(discoveryClientConfig)
+			_, _, err = discoveryClient.DiscoverWithNewFramework("discovery-integration-test")
+			framework.ExpectNoError(err, "Failed completing discovery of test cluster")
+		}
+
+	})
+
+	Describe("ORM test for namespace scope", func() {
+		It("should match with the new CR", func() {
+			// 1. Get the deployment
+			dep, err := kubeClient.AppsV1().Deployments(ormtest_namespace).Get(context.TODO(), namespacescope_operand_deployment_name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "Error gettting the deployment for ORM test")
+
+			// 2. Get the CR and backup the resource value
+			operatorCR, err := dynamicClient.Resource(groupVersionRes4nsscope).Namespace(ormtest_namespace).Get(context.TODO(), namespacescope_operator_cr_name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "Error gettting the operator CR")
+			origCRValue4NsScope, _, err = util.NestedField(operatorCR, "destPath", namespacescope_operand_path_in_cr)
+
+			// 3. Build and execute resize action on the deployment
+			targetSE := newResizeWorkloadControllerTargetSE(dep)
+			resizeupAction, desiredPodSpec := newResizeActionExecutionDTO(targetSE, ORM_RESIZE_UP, &dep.Spec.Template.Spec)
+			_, err = actionHandler.ExecuteAction(resizeupAction, nil, &mockProgressTrack{})
+			if err != nil {
+				framework.Failf("Failed to execute resizing action for ORM namespace case")
+			}
+
+			// 4. Set the revert flag for afterEach
+			needRevertCR4NsScope = true
+
+			// 5. Wait and check the result
+			containerIdx, err := findContainerIdxInPodSpecByName(desiredPodSpec, namespacescope_operand_container_name)
+			framework.ExpectNoError(err, "Can't find the container in the pod's spec")
+			waitForOperatorCRToUpdateResource(dynamicClient, groupVersionRes4nsscope, ormtest_namespace, namespacescope_operator_cr_name, namespacescope_operand_path_in_cr, &desiredPodSpec.Containers[containerIdx].Resources)
+
+		})
+
+	})
+
+	Describe("ORM test for cluster scope", func() {
+		It("should match with the new CR", func() {
+			// 1. Get the deployment
+			dep, err := kubeClient.AppsV1().Deployments(ormtest_namespace).Get(context.TODO(), clusterscope_operand_deployment_name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "Error gettting the deployment for ORM test")
+
+			// 2. Get the CR and backup the resource value
+			operatorCR, err := dynamicClient.Resource(groupVersionRes4clusterscope).Namespace(v1.NamespaceAll).Get(context.TODO(), clusterscope_operator_cr_name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "Error gettting the operator CR")
+			origCRValue4ClusterScope, _, err = util.NestedField(operatorCR, "destPath", clusterscope_operand_path_in_cr)
+
+			// 3. Build and execute resize action on the deployment
+			targetSE := newResizeWorkloadControllerTargetSE(dep)
+			resizeupAction, desiredPodSpec := newResizeActionExecutionDTO(targetSE, ORM_RESIZE_DOWN, &dep.Spec.Template.Spec)
+			_, err = actionHandler.ExecuteAction(resizeupAction, nil, &mockProgressTrack{})
+			if err != nil {
+				framework.Failf("Failed to execute resizing action for ORM cluster case")
+			}
+
+			// 4. Set the revert flag for afterEach
+			needRevertCR4ClusterScope = true
+
+			// 5. Wait and check the result
+			containerIdx, err := findContainerIdxInPodSpecByName(desiredPodSpec, clusterscope_operand_container_name)
+			framework.ExpectNoError(err, "Can't find the container in the pod's spec")
+			waitForOperatorCRToUpdateResource(dynamicClient, groupVersionRes4clusterscope, v1.NamespaceAll, clusterscope_operator_cr_name, clusterscope_operand_path_in_cr, &desiredPodSpec.Containers[containerIdx].Resources)
+		})
+	})
+
+	AfterEach(func() {
+		if needRevertCR4NsScope {
+			err := revertOperatorCR(dynamicClient, groupVersionRes4nsscope, ormtest_namespace, namespacescope_operator_cr_name, namespacescope_operand_path_in_cr, origCRValue4NsScope)
+			framework.ExpectNoError(err, "Error reverting the namespace scope operator CR")
+		}
+		if needRevertCR4ClusterScope {
+			err := revertOperatorCR(dynamicClient, groupVersionRes4clusterscope, v1.NamespaceAll, clusterscope_operator_cr_name, clusterscope_operand_path_in_cr, origCRValue4ClusterScope)
+			framework.ExpectNoError(err, "Error reverting the cluster scope operator CR")
+		}
+	})
+})
+
+func revertOperatorCR(client dynamic.Interface, groupVersionRes schema.GroupVersionResource, nsName, crName, destPath string, value interface{}) error {
+	operatorCR, err := client.Resource(groupVersionRes).Namespace(nsName).Get(context.TODO(), crName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "Error gettting the operator CR")
+	fields := strings.Split(destPath, ".")
+	err = util.SetNestedField(operatorCR.Object, value, fields[1:]...)
+	dynResourceClient := client.Resource(groupVersionRes).Namespace(nsName)
+	_, err = dynResourceClient.Update(context.TODO(), operatorCR, metav1.UpdateOptions{})
+	return err
+}
+
+func waitForOperatorCRToUpdateResource(client dynamic.Interface, groupVersionRes schema.GroupVersionResource, nsName, crName, resPath string, expectedRes *v1.ResourceRequirements) (*unstructured.Unstructured, error) {
+	if waitErr := wait.PollImmediate(framework.PollInterval, framework.TestContext.SingleCallTimeout, func() (bool, error) {
+		operatorCR, err := client.Resource(groupVersionRes).Namespace(nsName).Get(context.TODO(), crName, metav1.GetOptions{})
+		if err != nil {
+			glog.Errorf("Unexpected error while getting the operator CR: %v", err)
+			return false, nil
+		}
+		var cpuVal, memVal string
+		newCRValue, _, err := util.NestedField(operatorCR, "destPath", resPath)
+		if resVal, ok := newCRValue.(map[string]interface{}); ok {
+			if limVal, ok := resVal["limits"].(map[string]interface{}); ok {
+				cpuVal, _ = limVal["cpu"].(string)
+				memVal, _ = limVal["memory"].(string)
+			}
+		}
+		cpuQuan, _ := resource.ParseQuantity(cpuVal)
+		memQuan, _ := resource.ParseQuantity(memVal)
+		if cpuQuan.Equal(expectedRes.Limits["cpu"]) && memQuan.Equal(expectedRes.Limits["memory"]) {
+			return true, nil
+		}
+		return false, nil
+	}); waitErr != nil {
+		return nil, waitErr
+	}
+	return nil, nil
+}


### PR DESCRIPTION
# Intent

Add ORM case in the integration test

# Background
The current integration test doesn't include the test for the ORM feature

# Implementation
Use the pre-existing OpenShift cluster and resize one of the containers in the deployment `auth-idp` which is managed by the `authentications.operator.ibm.com` CR `example-authentication` ,  and then validate the change on the CR, which should be updated according to the ORM CR. finally, revert the change on the CR no matter the test passes or not.
Do the similar test on the deployment `cert-manager-cainjector` to test the cluster scope case.

# Test Done

## Run both of the cases 
1. Run the following command to trigger the test
```
[root@localvm kubeturbo]# ./build/integration.test -k8s-kubeconfig=/root/.kube/config -k8s-context=ocp47 -ginkgo.focus="ORM test"
```

2. Get the result at the end of the test

![image](https://user-images.githubusercontent.com/61252360/172204355-c939e28a-085b-40ee-acf8-0a2e17e7911a.png)

3. Check the message in the logging output:
```
I0606 12:21:04.696170   99930 operator_resource_mapping.go:306] Successfully updated CR Authentication/example-authentication '.spec.auditService.resources' from map[limits:map[cpu:120m memory:40Mi] requests:map[cpu:10m memory:20Mi]] to map[limits:map[cpu:170m memory:115Mi] requests:map[cpu:10m memory:20Mi]] for Deployment/auth-idp in namespace ibm-common-services
...
I0606 12:21:15.515440   99930 operator_resource_mapping.go:306] Successfully updated CR CertManager/default '.spec.certManagerCAInjector.resources' from map[limits:map[cpu:800m memory:392Mi] requests:map[cpu:20m memory:282Mi]] to map[limits:map[cpu:775m memory:342Mi] requests:map[cpu:20m memory:282Mi]] for Deployment/cert-manager-cainjector in namespace 
```

4. Check the CR on the cluster to see if it's changed back after test.
```
k edit authentications.operator.ibm.com example-authentication
```
![image](https://user-images.githubusercontent.com/61252360/172205223-20300bc3-f714-47df-ba7d-b260bfead75c.png)
```
k edit certmanagers.operator.ibm.com default
```
![image](https://user-images.githubusercontent.com/61252360/172205416-24c7e704-4aa5-44fd-939d-9d86972d7236.png)
