### PR TITLE
Add support for imagePull secret in the integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ script:
   - ./hack/create_kind_cluster.sh
   - ./hack/generate_ocp_context.sh
   - make integration
-  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind
-  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=ocp47 --openshift-tests=true
+  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind --docker-user-name=${DOCKER_USERNAME} --docker-user-password=${DOCKER_PASSWORD}
+  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=ocp47 --openshift-tests=true --docker-user-name=${DOCKER_USERNAME} --docker-user-password=${DOCKER_PASSWORD}
   - make product
 
 after_success:

--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -87,6 +87,7 @@ var _ = Describe("Action Executor ", func() {
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 		}
 		namespace = f.TestNamespaceName()
+		f.GenerateCustomImagePullSecret(namespace)
 	})
 
 	Describe("executing action move pod", func() {
@@ -396,6 +397,11 @@ func depSingleContainerWithResources(namespace, claimName string, replicas int32
 					},
 				},
 				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: framework.DockerImagePullSecretName,
+						},
+					},
 					Containers: []corev1.Container{
 						genContainerSpec("test-cont", "50m", "100Mi", "100m", "200Mi"),
 					},
@@ -450,6 +456,11 @@ func depMultiContainerWithResources(namespace, claimName string, containerNum, r
 					},
 				},
 				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: framework.DockerImagePullSecretName,
+						},
+					},
 					Containers: containerlst,
 				},
 			},
@@ -484,23 +495,13 @@ func genBarePodWithResources(namespace, claimName string, replicas int32, withVo
 		},
 
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
+			ImagePullSecrets: []corev1.LocalObjectReference{
 				{
-					Name:    "test-cont",
-					Image:   "busybox",
-					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", "while true; do sleep 30; done;"},
-					Resources: corev1.ResourceRequirements{
-						Limits: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceCPU:    resource.MustParse("100m"),
-							corev1.ResourceMemory: resource.MustParse("200Mi"),
-						},
-						Requests: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("100Mi"),
-						},
-					},
+					Name: framework.DockerImagePullSecretName,
 				},
+			},
+			Containers: []corev1.Container{
+				genContainerSpec("test-cont", "50m", "100Mi", "100m", "200Mi"),
 			},
 		},
 	}
@@ -541,6 +542,11 @@ func rsSingleContainerWithResources(namespace string, replicas int32, withGCLabe
 					},
 				},
 				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: framework.DockerImagePullSecretName,
+						},
+					},
 					Containers: []corev1.Container{
 						genContainerSpec("test-cont", "50m", "100Mi", "100m", "200Mi"),
 					},
@@ -609,6 +615,11 @@ func genDeploymentConfigWithResources(namespace, claimName string, containerNum,
 					},
 				},
 				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: framework.DockerImagePullSecretName,
+						},
+					},
 					Containers: containerlst,
 				},
 			},

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -107,6 +107,7 @@ var _ = Describe("Discover Cluster", func() {
 			discoveryClient = discovery.NewK8sDiscoveryClient(discoveryClientConfig)
 		}
 		namespace = f.TestNamespaceName()
+		f.GenerateCustomImagePullSecret(namespace)
 	})
 
 	Describe("discovering with discovery framework", func() {
@@ -329,6 +330,11 @@ func depMultiContainer(namespace string, replicas int32, withDuplicateAffinityRu
 					},
 				},
 				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: framework.DockerImagePullSecretName,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:    "cont-test-app-mc-1",
@@ -399,6 +405,11 @@ func deplMultiContainerWithResources(namespace string, replicas int32) *appsv1.D
 					},
 				},
 				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: framework.DockerImagePullSecretName,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:    "cont-test-app-mc-wr-1",

--- a/test/integration/framework/test_context.go
+++ b/test/integration/framework/test_context.go
@@ -17,6 +17,8 @@ type TestContextType struct {
 	TestNamespace     string
 	SingleCallTimeout time.Duration
 	IsOpenShiftTest   bool
+	DockerUserName    string
+	DockerUserPwd     string
 }
 
 var TestContext *TestContextType = &TestContextType{}
@@ -32,6 +34,10 @@ func registerFlags(t *TestContextType) {
 		fmt.Sprintf("The maximum duration of a single call.  If unset, will default to %v", DefaultSingleCallTimeout))
 	flag.BoolVar(&t.IsOpenShiftTest, "openshift-tests", false,
 		"If set, the test will only run the Openshift case. By default, it's set to false, only the non-Openshift cases get run")
+	flag.StringVar(&t.DockerUserName, "docker-user-name", "",
+		"The docker user name used to generate the pull secret.")
+	flag.StringVar(&t.DockerUserPwd, "docker-user-password", "",
+		"The docker user password used to generate the pull secret.")
 }
 
 func validateFlags(t *TestContextType) {

--- a/test/integration/garbage_collection.go
+++ b/test/integration/garbage_collection.go
@@ -73,6 +73,7 @@ spec:
 			}
 		}
 		namespace = f.TestNamespaceName()
+		f.GenerateCustomImagePullSecret(namespace)
 	})
 
 	Describe("periodic garbage collection", func() {
@@ -163,6 +164,11 @@ func podSingleContainerWithKubeturboGCLabel(namespace string) *corev1.Pod {
 			},
 		},
 		Spec: corev1.PodSpec{
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{
+					Name: framework.DockerImagePullSecretName,
+				},
+			},
 			Containers: []corev1.Container{
 				{
 					Name:    "test-cont",

--- a/test/integration/pod_move_with_quota.go
+++ b/test/integration/pod_move_with_quota.go
@@ -86,6 +86,7 @@ spec:
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 
 			namespace = f.TestNamespaceName()
+			f.GenerateCustomImagePullSecret(namespace)
 		}
 	})
 


### PR DESCRIPTION
# Intent

Make intergation test support imagePull secret generated by docker credentials. 

# Background
Often seen the tests fail because the newly created workloads cannot pull the image because of the docker image throttling issues.

# Implementation
Pass the docker credentials from the command line and parse it to a k8s secret with the tpye of `dockerconfigjson`, and use this secret as the `imagePullSecrets` when generating any new pods.

# Test Done
## Case1:  Run the command with the right docker username and password
1. Run the following command to trigger the test
```
[root@localvm kubeturbo]#./build/integration.test -k8s-kubeconfig=/root/.kube/config -k8s-context=kind-kind -ginkgo.focus="executing action move bare pod"  --docker-user-name=kevin0204 --docker-user-password=myrightpassword(sorry for hidding this)
```

2. Get the result at the end of the test
![image](https://user-images.githubusercontent.com/61252360/173073498-06548b34-95b0-4cb4-adda-c0cc33cf7c0b.png)



3. Check the secret and the pods
![image](https://user-images.githubusercontent.com/61252360/173073870-10d23299-80f7-4f32-8c97-dbc310247913.png)
```
[root@localvm ~]# k get pods test-zrc24-1dtq4s7rapn99 -o yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubeturbo.io/action: move
  creationTimestamp: "2022-06-10T13:18:45Z"
  name: test-zrc24-1dtq4s7rapn99
  namespace: kubeturbo-test-action-executor-gcbqd
  resourceVersion: "2547"
  selfLink: /api/v1/namespaces/kubeturbo-test-action-executor-gcbqd/pods/test-zrc24-1dtq4s7rapn99
  uid: 1b25a72c-1d88-4492-b4f0-3b4e307b65b7
spec:
  containers:
  - args:
    - -c
    - while true; do sleep 30; done;
    command:
    - /bin/sh
    image: busybox
    imagePullPolicy: Always
    name: test-cont
    resources:
      limits:
        cpu: 100m
        memory: 200Mi
      requests:
        cpu: 50m
        memory: 100Mi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: default-token-jxtxt
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  imagePullSecrets:
  - name: integration-test <--------------------------use the secret here
  nodeName: kind-worker
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: pod-move-test
    persistentVolumeClaim:
      claimName: pod-move-test-46pmr
  - name: default-token-jxtxt
    secret:
      defaultMode: 420
      secretName: default-token-jxtxt
```

## Case2:  Run the command without the username and password
1. Run the following command to trigger the test
```
[root@localvm kubeturbo]#./build/integration.test -k8s-kubeconfig=/root/.kube/config -k8s-context=kind-kind -ginkgo.focus="executing action move bare pod"  
```

2. Check the result:
```
I0615 11:58:16.970325   54199 integration_test.go:52] Starting integration run on Ginkgo node 1
Running Suite: Kubeturbo integration suite
==========================================
Random Seed: 1655308696
Will run 1 of 20 specs

SSSSSSSSSSSSE0615 11:58:22.008393   54199 util.go:96] cannot found node name from properites: []
W0615 11:58:22.012339   54199 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-hlncj/test-9nlxh]'s new host(kind-worker) in bad condition: MemoryPressure
W0615 11:58:22.012356   54199 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-hlncj/test-9nlxh]'s new host(kind-worker) in bad condition: DiskPressure
W0615 11:58:22.012359   54199 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-hlncj/test-9nlxh]'s new host(kind-worker) in bad condition: PIDPressure

------------------------------
• [SLOW TEST:15.085 seconds]
Action Executor 
/opt/git/kubeturbo/test/integration/action_execution.go:55
  executing action move bare pod with volum attached
  /opt/git/kubeturbo/test/integration/action_execution.go:242
    should result in new pod on target node
    /opt/git/kubeturbo/test/integration/action_execution.go:243
------------------------------
SSSSSSS
Ran 1 of 20 Specs in 15.086 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 19 Skipped
PASS
```

3. Check the pod's description:
```
[root@localvm kubeturbo]# k get pods test-9nlxh-1du6mfq4iueb1 -o yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubeturbo.io/action: move
  creationTimestamp: "2022-06-15T15:58:22Z"
  name: test-9nlxh-1du6mfq4iueb1
  namespace: kubeturbo-test-action-executor-hlncj
  resourceVersion: "591861"
  selfLink: /api/v1/namespaces/kubeturbo-test-action-executor-hlncj/pods/test-9nlxh-1du6mfq4iueb1
  uid: edb3d4e3-6e14-42a8-ada3-b78c6aec6fd1
spec:
  containers:
  - args:
    - -c
    - while true; do sleep 30; done;
    command:
    - /bin/sh
    image: busybox
    imagePullPolicy: Always
    name: test-cont
    resources:
      limits:
        cpu: 100m
        memory: 200Mi
      requests:
        cpu: 50m
        memory: 100Mi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: default-token-p7jhd
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  imagePullSecrets:
  - name: integration-test <----- The secret name is specified. 
  nodeName: kind-worker
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: pod-move-test
    persistentVolumeClaim:
      claimName: pod-move-test-94nbg
  - name: default-token-p7jhd
    secret:
      defaultMode: 420
      secretName: default-token-p7jhd
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T15:58:22Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T15:58:24Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T15:58:24Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T15:58:22Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: containerd://bf222c4850dacfa6958cedf614e17b0dc1073114d08668312f0255055b98b0c6
    image: docker.io/library/busybox:latest
    imageID: docker.io/library/busybox@sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83
    lastState: {}
    name: test-cont
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2022-06-15T15:58:23Z"
  hostIP: 172.18.0.3
  phase: Running <-----------------Pod pull the image and start running
  podIP: 10.244.2.20
  podIPs:
  - ip: 10.244.2.20
  qosClass: Burstable
  startTime: "2022-06-15T15:58:22Z"
```

4. check the secret, `integration-test` secret is NOT created. 
```
[root@localvm kubeturbo]# k get secret
NAME                  TYPE                                  DATA   AGE
default-token-p7jhd   kubernetes.io/service-account-token   3      4m33s
```

## Case3:  Run the command with a wrong password
1. Run the following command to trigger the test
```
[root@localvm kubeturbo]#./build/integration.test -k8s-kubeconfig=/root/.kube/config -k8s-context=kind-kind -ginkgo.focus="executing action move bare pod"  --docker-user-name=kevin0204 --docker-user-password=xxxxxx
```

2. Check the result:
```
I0615 12:08:40.061012   57775 integration_test.go:52] Starting integration run on Ginkgo node 1
Running Suite: Kubeturbo integration suite
==========================================
Random Seed: 1655309320
Will run 1 of 20 specs

SSSSSSSSSSSSSI0615 12:10:40.121976   57775 integration_test.go:57] Failed
STEP: Reading cluster configuration
Jun 15 12:08:40.066: INFO: >>> kubeConfig: /root/.kube/config
Jun 15 12:08:40.068: INFO: >>> kubeContext: kind-kind
STEP: Creating a namespace to execute the test in
STEP: Created test namespace kubeturbo-test-action-executor-k2jpb
Jun 15 12:10:40.121: INFO: Unexpected error occurred: timed out waiting for the condition

------------------------------
•! Panic [120.060 seconds]
Action Executor 
/opt/git/kubeturbo/test/integration/action_execution.go:55
  executing action move bare pod with volum attached
  /opt/git/kubeturbo/test/integration/action_execution.go:242
    should result in new pod on target node [It]
    /opt/git/kubeturbo/test/integration/action_execution.go:243

    Test Panicked
    runtime error: invalid memory address or nil pointer dereference
    /usr/local/go/src/runtime/panic.go:221

    Full Stack Trace
    github.com/turbonomic/kubeturbo/test/integration.getTargetSENodeName(0x1, 0x0)
    	/opt/git/kubeturbo/test/integration/action_execution.go:1120 +0x5c
    github.com/turbonomic/kubeturbo/test/integration.glob..func1.7.1()
    	/opt/git/kubeturbo/test/integration/action_execution.go:251 +0x145
    github.com/turbonomic/kubeturbo/test/integration.RunIntegrationTests(0xc0001ebfb0)
    	/opt/git/kubeturbo/test/integration/integration_test.go:53 +0xd0
    github.com/turbonomic/kubeturbo/test/integration.TestIntegration(0x0)
    	/opt/git/kubeturbo/test/integration/integration_test.go:66 +0x19
    testing.tRunner(0xc00035a680, 0x1ced898)
    	/usr/local/go/src/testing/testing.go:1259 +0x102
    created by testing.(*T).Run
    	/usr/local/go/src/testing/testing.go:1306 +0x35a
------------------------------
SSSSSS

Summarizing 1 Failure:

[Panic!] Action Executor  executing action move bare pod with volum attached [It] should result in new pod on target node 
/usr/local/go/src/runtime/panic.go:221

Ran 1 of 20 Specs in 120.061 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 19 Skipped
--- FAIL: TestIntegration (120.07s)
FAIL
```

3. Check the pods:
```
[root@localvm ~]# k get pods test-m7xzx -o yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2022-06-15T16:08:40Z"
  generateName: test-
  name: test-m7xzx
  namespace: kubeturbo-test-action-executor-k2jpb
  resourceVersion: "594168"
  selfLink: /api/v1/namespaces/kubeturbo-test-action-executor-k2jpb/pods/test-m7xzx
  uid: 0bcde1ca-de10-4eda-80f5-32f37d0e8ec3
spec:
  containers:
  - args:
    - -c
    - while true; do sleep 30; done;
    command:
    - /bin/sh
    image: busybox
    imagePullPolicy: Always
    name: test-cont
    resources:
      limits:
        cpu: 100m
        memory: 200Mi
      requests:
        cpu: 50m
        memory: 100Mi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: default-token-n8zs9
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  imagePullSecrets:    <-----------------The secret name is specified. 
  - name: integration-test
  nodeName: kind-worker2
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: pod-move-test
    persistentVolumeClaim:
      claimName: pod-move-test-7tq9p
  - name: default-token-n8zs9
    secret:
      defaultMode: 420
      secretName: default-token-n8zs9
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:08:43Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:08:43Z"
    message: 'containers with unready status: [test-cont]'
    reason: ContainersNotReady
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:08:43Z"
    message: 'containers with unready status: [test-cont]'
    reason: ContainersNotReady
    status: "False"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:08:43Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - image: busybox
    imageID: ""
    lastState: {}
    name: test-cont
    ready: false
    restartCount: 0
    started: false
    state:
      waiting:
        message: Back-off pulling image "busybox"   <-----------------can't pull the image
        reason: ImagePullBackOff
  hostIP: 172.18.0.2
  phase: Pending
  podIP: 10.244.1.25
  podIPs:
  - ip: 10.244.1.25
  qosClass: Burstable
  startTime: "2022-06-15T16:08:43Z"
```

4.Check the secret:
```
[root@localvm ~]# k get secrets 
NAME                  TYPE                                  DATA   AGE
default-token-n8zs9   kubernetes.io/service-account-token   3      2m44s
integration-test      kubernetes.io/dockerconfigjson        1      2m44s
[root@localvm ~]# k get secrets integration-test -o yaml
apiVersion: v1
data:
  .dockerconfigjson: eyJhdXRocyI6eyJkb2NrZXIuaW8iOnsidXNlcm5hbWUiOiJrZXZpbjAyMDQiLCJwYXNzd29yZCI6Inh4eHh4eCJ9fX0=
kind: Secret
metadata:
  creationTimestamp: "2022-06-15T16:08:40Z"
  name: integration-test
  namespace: kubeturbo-test-action-executor-k2jpb
  resourceVersion: "593951"
  selfLink: /api/v1/namespaces/kubeturbo-test-action-executor-k2jpb/secrets/integration-test
  uid: f5cb4349-8c6a-4328-9203-bf7cc28a155a
type: kubernetes.io/dockerconfigjson
```

## Case4:  Run the command with the username only
1. Run the following command to trigger the test
```
[root@localvm kubeturbo]#./build/integration.test -k8s-kubeconfig=/root/.kube/config -k8s-context=kind-kind -ginkgo.focus="executing action move bare pod"  --docker-user-name=kevin0204
```

2. Check the result:
```
I0615 12:15:00.806780   60340 integration_test.go:52] Starting integration run on Ginkgo node 1
Running Suite: Kubeturbo integration suite
==========================================
Random Seed: 1655309700
Will run 1 of 20 specs

SSSSSE0615 12:15:06.332876   60340 util.go:96] cannot found node name from properites: []
W0615 12:15:06.335978   60340 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-qxbww/test-xmx6j]'s new host(kind-worker) in bad condition: MemoryPressure
W0615 12:15:06.335995   60340 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-qxbww/test-xmx6j]'s new host(kind-worker) in bad condition: DiskPressure
W0615 12:15:06.335998   60340 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-qxbww/test-xmx6j]'s new host(kind-worker) in bad condition: PIDPressure

------------------------------
• [SLOW TEST:15.572 seconds]
Action Executor 
/opt/git/kubeturbo/test/integration/action_execution.go:55
  executing action move bare pod with volum attached
  /opt/git/kubeturbo/test/integration/action_execution.go:242
    should result in new pod on target node
    /opt/git/kubeturbo/test/integration/action_execution.go:243
------------------------------
SSSSSSSSSSSSSS
Ran 1 of 20 Specs in 15.573 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 19 Skipped
PASS
```
3. Check the pod:
```
[root@localvm kubeturbo]# k get pods -n kubeturbo-test-action-executor-qxbww test-xmx6j-1du6nd1fohkae -o yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubeturbo.io/action: move
  creationTimestamp: "2022-06-15T16:15:06Z"
  name: test-xmx6j-1du6nd1fohkae
  namespace: kubeturbo-test-action-executor-qxbww
  resourceVersion: "595425"
  selfLink: /api/v1/namespaces/kubeturbo-test-action-executor-qxbww/pods/test-xmx6j-1du6nd1fohkae
  uid: 8898b4ee-5620-4dcf-8fcb-75b6ebe0555c
spec:
  containers:
  - args:
    - -c
    - while true; do sleep 30; done;
    command:
    - /bin/sh
    image: busybox
    imagePullPolicy: Always
    name: test-cont
    resources:
      limits:
        cpu: 100m
        memory: 200Mi
      requests:
        cpu: 50m
        memory: 100Mi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: default-token-sp98f
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  imagePullSecrets:
  - name: integration-test     <---------The secret name is specified
  nodeName: kind-worker
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: pod-move-test
    persistentVolumeClaim:
      claimName: pod-move-test-lz4ql
  - name: default-token-sp98f
    secret:
      defaultMode: 420
      secretName: default-token-sp98f
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:15:06Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:15:07Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:15:07Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:15:06Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: containerd://e45445faedd7b8f8fa29849be4f832354e8368a478cc67fe1bfdc2f5011484c0
    image: docker.io/library/busybox:latest
    imageID: docker.io/library/busybox@sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83
    lastState: {}
    name: test-cont
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2022-06-15T16:15:07Z"
  hostIP: 172.18.0.3
  phase: Running   <----------------running well
  podIP: 10.244.2.21
  podIPs:
  - ip: 10.244.2.21
  qosClass: Burstable
  startTime: "2022-06-15T16:15:06Z"
```
4. Check the secret,  found no `integration-test` secret is created. 
```
[root@localvm kubeturbo]# k get secret -n kubeturbo-test-action-executor-qxbww
NAME                  TYPE                                  DATA   AGE
default-token-sp98f   kubernetes.io/service-account-token   3      76s
```

## Case5:  Run the command with the password only
1. Run the following command to trigger the test
```
[root@localvm kubeturbo]#./build/integration.test -k8s-kubeconfig=/root/.kube/config -k8s-context=kind-kind -ginkgo.focus="executing action move bare pod"  --docker-user-password=xxxxxx
```

2. Check the result:
```
I0615 12:18:08.644929   61992 integration_test.go:52] Starting integration run on Ginkgo node 1
Running Suite: Kubeturbo integration suite
==========================================
Random Seed: 1655309888
Will run 1 of 20 specs

SSSSSSSSSSSSSE0615 12:18:13.622868   61992 util.go:96] cannot found node name from properites: []
W0615 12:18:13.626377   61992 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-5mj29/test-tvlxv]'s new host(kind-worker) in bad condition: MemoryPressure
W0615 12:18:13.626396   61992 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-5mj29/test-tvlxv]'s new host(kind-worker) in bad condition: DiskPressure
W0615 12:18:13.626399   61992 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-5mj29/test-tvlxv]'s new host(kind-worker) in bad condition: PIDPressure

------------------------------
• [SLOW TEST:15.029 seconds]
Action Executor 
/opt/git/kubeturbo/test/integration/action_execution.go:55
  executing action move bare pod with volum attached
  /opt/git/kubeturbo/test/integration/action_execution.go:242
    should result in new pod on target node
    /opt/git/kubeturbo/test/integration/action_execution.go:243
------------------------------
SSSSSS
Ran 1 of 20 Specs in 15.030 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 19 Skipped
PASS
```
3. Check the pod:
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubeturbo.io/action: move
  creationTimestamp: "2022-06-15T16:15:06Z"
  name: test-xmx6j-1du6nd1fohkae
  namespace: kubeturbo-test-action-executor-qxbww
  resourceVersion: "595425"
  selfLink: /api/v1/namespaces/kubeturbo-test-action-executor-qxbww/pods/test-xmx6j-1du6nd1fohkae
  uid: 8898b4ee-5620-4dcf-8fcb-75b6ebe0555c
spec:
  containers:
  - args:
    - -c
    - while true; do sleep 30; done;
    command:
    - /bin/sh
    image: busybox
    imagePullPolicy: Always
    name: test-cont
    resources:
      limits:
        cpu: 100m
        memory: 200Mi
      requests:
        cpu: 50m
        memory: 100Mi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: default-token-sp98f
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  imagePullSecrets:
  - name: integration-test    <---------The secret name is specified
  nodeName: kind-worker
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: pod-move-test
    persistentVolumeClaim:
      claimName: pod-move-test-lz4ql
  - name: default-token-sp98f
    secret:
      defaultMode: 420
      secretName: default-token-sp98f
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:15:06Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:15:07Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:15:07Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2022-06-15T16:15:06Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: containerd://e45445faedd7b8f8fa29849be4f832354e8368a478cc67fe1bfdc2f5011484c0
    image: docker.io/library/busybox:latest
    imageID: docker.io/library/busybox@sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83
    lastState: {}
    name: test-cont
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2022-06-15T16:15:07Z"
  hostIP: 172.18.0.3
  phase: Running            <---------------running well
  podIP: 10.244.2.21
  podIPs:
  - ip: 10.244.2.21
  qosClass: Burstable
  startTime: "2022-06-15T16:15:06Z"
```
4. Check the secret,  found no `integration-test` secret is created. 
```
[root@localvm kubeturbo]# k get secret -n kubeturbo-test-action-executor-5mj29
NAME                  TYPE                                  DATA   AGE
default-token-lfqgl   kubernetes.io/service-account-token   3      43s


```