### PR TITLE
Add injected sidecar test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,12 @@ script:
   - $HOME/gopath/bin/goveralls -v -race -service=travis-ci -package='github.com/turbonomic/kubeturbo/cmd/kubeturbo github.com/turbonomic/kubeturbo/cmd/kubeturbo/app github.com/turbonomic/kubeturbo/pkg github.com/turbonomic/kubeturbo/pkg/action github.com/turbonomic/kubeturbo/pkg/action/executor github.com/turbonomic/kubeturbo/pkg/action/util github.com/turbonomic/kubeturbo/pkg/cluster github.com/turbonomic/kubeturbo/pkg/discovery github.com/turbonomic/kubeturbo/pkg/discovery/configs github.com/turbonomic/kubeturbo/pkg/discovery/detectors github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property github.com/turbonomic/kubeturbo/pkg/discovery/metrics github.com/turbonomic/kubeturbo/pkg/discovery/monitoring github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types github.com/turbonomic/kubeturbo/pkg/discovery/processor github.com/turbonomic/kubeturbo/pkg/discovery/repository github.com/turbonomic/kubeturbo/pkg/discovery/stitching github.com/turbonomic/kubeturbo/pkg/discovery/task github.com/turbonomic/kubeturbo/pkg/discovery/util github.com/turbonomic/kubeturbo/pkg/discovery/worker github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation github.com/turbonomic/kubeturbo/pkg/discovery/worker/compliance github.com/turbonomic/kubeturbo/pkg/kubeclient github.com/turbonomic/kubeturbo/pkg/registration github.com/turbonomic/kubeturbo/pkg/resourcemapping github.com/turbonomic/kubeturbo/pkg/turbostore github.com/turbonomic/kubeturbo/pkg/util github.com/turbonomic/kubeturbo/pkg/discovery/worker/k8sappcomponents'
   - ./hack/download_test_binaries.sh
   - ./hack/create_kind_cluster.sh
+  - ./hack/deploy_istio.sh
   - ./hack/generate_ocp_context.sh
   - make integration
-  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind --docker-user-name=${DOCKER_USERNAME} --docker-user-password=${DOCKER_PASSWORD}
-  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=ocp47 --openshift-tests=true --docker-user-name=${DOCKER_USERNAME} --docker-user-password=${DOCKER_PASSWORD}
+  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
+  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -istio-enabled=true -ginkgo.focus=Istio -ginkgo.focus=teardown -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
+  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=ocp47 -openshift-tests=true -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
   - make product
 
 after_success:

--- a/hack/deploy_istio.sh
+++ b/hack/deploy_istio.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE}")/util.sh"
+
+echo "Start deploying Istio on the cluster."
+${istioctl_path} install --set profile=demo -y
+echo "Istio deployment complete."

--- a/hack/download_test_binaries.sh
+++ b/hack/download_test_binaries.sh
@@ -27,8 +27,14 @@ curl -Lo openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshif
 tar -C ${dest_dir}  -zxvf openshift-client-linux.tar.gz oc
 chmod +x ${oc_path}
 
+#istioctl
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${istio_version} TARGET_ARCH=x86_64 sh -
+cp istio-${istio_version}/bin/istioctl ${istioctl_path}
+chmod +x ${istioctl_path}
+
 echo -n "#   kind:           "; "${kind_path}" version
 echo -n "#   kubectl:        "; "${kubectl_path}" version --client --short
 echo -n "#   oc:             "; "${oc_path}" version --client --short
+echo -n "#   istioctl:       "; "${istioctl_path}" version --short
 
 

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -18,6 +18,9 @@ kind_path="${dest_dir}/kind"
 kubectl_path="${dest_dir}/kubectl"
 #oc
 oc_path="${dest_dir}/oc"
+#istioctl
+istio_version="1.11.8"
+istioctl_path="${dest_dir}/istioctl"
 
 # Utility Functions
 #

--- a/test/integration/framework/test_context.go
+++ b/test/integration/framework/test_context.go
@@ -19,6 +19,7 @@ type TestContextType struct {
 	IsOpenShiftTest   bool
 	DockerUserName    string
 	DockerUserPwd     string
+	IsIstioEnabled    bool
 }
 
 var TestContext *TestContextType = &TestContextType{}
@@ -38,6 +39,8 @@ func registerFlags(t *TestContextType) {
 		"The docker user name used to generate the pull secret.")
 	flag.StringVar(&t.DockerUserPwd, "docker-user-password", "",
 		"The docker user password used to generate the pull secret.")
+	flag.BoolVar(&t.IsIstioEnabled, "istio-enabled", false,
+		"If set, the namespace will be patched with label [istio-injection: enabled]. By default, it's set to false.")
 }
 
 func validateFlags(t *TestContextType) {


### PR DESCRIPTION
# Intent

Test resize/move action execution on a deployment with injected sidecar container in a Istio environment

# Background
In a typical Istio environment,  the pod will be injected a sidecar container with the name `istio-proxy`, kubeturbo has to handle this situation well. 

# Implementation
1)Deploy Istio on the Kind cluster, when testing this case, patch the namespace with the label `"istio-injection": "enabled"`, trigger the Istio webhook inject the sidecar container into the pod
2)Validate if the pod has the sidecar container, if not, fail the case
3)If yes, compose the resize/move action, execute the action against the deployment
4)Validate if the pod is moved or resized as expected

# Test Done

1. Run the command to start the test 
```
./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -istio-enabled=true -ginkgo.focus=Istio -ginkgo.focus=teardown
```
2. Check the result , it includes 3 test specs, 1 for move action, 1 for resize action, and the last one for tear down.
```
I0615 16:50:12.940648   21634 integration_test.go:52] Starting integration run on Ginkgo node 1
Running Suite: Kubeturbo integration suite
==========================================
Random Seed: 1655326212
Will run 3 of 20 specs

SE0615 16:50:19.630799   21634 util.go:96] cannot found node name from properites: []
W0615 16:50:19.634718   21634 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-hbgcf/test-nrq97-987b95586-nm4mn]'s new host(kind-worker) in bad condition: MemoryPressure
W0615 16:50:19.634732   21634 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-hbgcf/test-nrq97-987b95586-nm4mn]'s new host(kind-worker) in bad condition: DiskPressure
W0615 16:50:19.634735   21634 rescheduler.go:153] Move action: pod[kubeturbo-test-action-executor-hbgcf/test-nrq97-987b95586-nm4mn]'s new host(kind-worker) in bad condition: PIDPressure

------------------------------
• [SLOW TEST:16.875 seconds]
Action Executor 
/opt/git/kubeturbo/test/integration/action_execution.go:56
  executing action move pod with volume attached, will also be tested in Istio environment
  /opt/git/kubeturbo/test/integration/action_execution.go:122
    should result in new pod on target node
    /opt/git/kubeturbo/test/integration/action_execution.go:123
------------------------------
SSSSS•S
------------------------------
• [SLOW TEST:53.833 seconds]
Action Executor 
/opt/git/kubeturbo/test/integration/action_execution.go:56
  test teardown
  /opt/git/kubeturbo/test/integration/action_execution.go:381
    Deleting framework namespace: 
    /opt/git/kubeturbo/test/integration/action_execution.go:382
------------------------------
SSSSSSSSSS
Ran 3 of 20 Specs in 75.242 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 17 Skipped
PASS
```