### PR TITLE
Fix deadlock in dispatching sampling discovery tasks

### DIFF
--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -198,7 +198,7 @@ func (d *SamplingDispatcher) dispatchSamplingDiscoveries(nodes []*api.Node, samp
 		for i, node := range nodes {
 			select {
 			case <-abort:
-				glog.Warningf("Timeout dispatching sampling discovery tasks to %v out of %v nodes in this sampling cycle.",
+				glog.Warningf("Timed out dispatching sampling discovery tasks to %v out of %v nodes in this sampling cycle.",
 					i+1, len(nodes))
 				return
 			default:
@@ -215,7 +215,7 @@ func (d *SamplingDispatcher) dispatchSamplingDiscoveries(nodes []*api.Node, samp
 		d.collectedSamples++
 		return
 	case <-t.C:
-		glog.Warningf("Timeout (in %v) while dispatching sampling discovery tasks to %v nodes with %v workers.",
+		glog.Warningf("Timed out (in %v) while dispatching sampling discovery tasks to %v nodes with %v workers.",
 			samplingInterval, len(nodes), 2*d.config.workerCount)
 		// Timeout occurred, notify the child goroutine to quit
 		close(abort)


### PR DESCRIPTION
## Issue
`kubeturbo` discovery is stuck and never completes.

## Root Cause
According to @chlam4's analysis, this is due to a deadlock situation inside `dispatchSamplingDiscoveries` in a cluster where query to `kubelet` constantly times out. Detailed analysis can be found at OM-87283.

## Fix
* Instead of sending data to a channel to indicate completion, we can simply directly close the channel. Closing a channel does not block
* Closing channels should always be done on the sending end, not the receiving end, so that there is no chance of sending data to a closed channel
* Rename `finishCh` and `stopCh` to `done` and `abort` respectively Rento better describe the intention
* Move `t.Stop` to the parent goroutine as a deferred function right after the timer is created
* Rename `samplingDone` to `finishSampling` to better describe that this is a channel to stop the sampling before a main discovery can start
* Improve logging messages
* Fix a logging problem where the number of workers for sampling is twice the number of configured workers (i.e., 2x4=8)

## Test
* Sampling times out occasionally
```
I0714 19:18:11.463561       1 dispatcher.go:158] Start scheduling sampling discovery tasks.
I0714 19:25:11.063012       1 dispatcher.go:176] Completed 6 sampling cycles (10 nodes per cycle) in 419.599443523 seconds since last full discovery.
I0714 19:28:13.209260       1 dispatcher.go:158] Start scheduling sampling discovery tasks.
I0714 19:35:10.510485       1 dispatcher.go:176] Completed 6 sampling cycles (10 nodes per cycle) in 417.301209398 seconds since last full discovery.
I0714 19:38:12.864121       1 dispatcher.go:158] Start scheduling sampling discovery tasks.
I0714 19:45:10.987031       1 dispatcher.go:176] Completed 6 sampling cycles (10 nodes per cycle) in 418.122899588 seconds since last full discovery.
...
I0714 21:18:14.203476       1 dispatcher.go:158] Start scheduling sampling discovery tasks.
W0714 21:21:14.205032       1 dispatcher.go:218] Timeout (in 1m0s) while dispatching sampling discovery tasks to 10 nodes with 8 workers.
W0714 21:22:14.206031       1 dispatcher.go:218] Timeout (in 1m0s) while dispatching sampling discovery tasks to 10 nodes with 8 workers.
W0714 21:22:14.206067       1 dispatcher.go:201] Timeout dispatching sampling discovery tasks to 10 out of 10 nodes in this sampling cycle.
W0714 21:23:14.207089       1 dispatcher.go:218] Timeout (in 1m0s) while dispatching sampling discovery tasks to 10 nodes with 8 workers.
W0714 21:24:14.207311       1 dispatcher.go:218] Timeout (in 1m0s) while dispatching sampling discovery tasks to 10 nodes with 8 workers.
W0714 21:25:14.207732       1 dispatcher.go:218] Timeout (in 1m0s) while dispatching sampling discovery tasks to 10 nodes with 8 workers.
I0714 21:25:14.207770       1 dispatcher.go:176] Completed 1 sampling cycles (10 nodes per cycle) in 420.004288071 seconds since last full discovery.
I0714 21:28:17.047098       1 dispatcher.go:158] Start scheduling sampling discovery tasks.
W0714 21:31:17.049881       1 dispatcher.go:218] Timeout (in 1m0s) while dispatching sampling discovery tasks to 10 nodes with 8 workers.
W0714 21:31:17.049923       1 dispatcher.go:201] Timeout dispatching sampling discovery tasks to 10 out of 10 nodes in this sampling cycle.
```

* Main discoveries are still successful at the time when sampling are timing out
```
I0714 19:18:11.915181       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 187.334 seconds
I0714 19:28:13.525035       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 188.941 seconds
I0714 19:38:13.197729       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 188.574 seconds
I0714 19:47:57.525039       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 172.937 seconds
I0714 19:57:23.234503       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 138.663 seconds
I0714 20:08:13.385166       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 188.458 seconds
I0714 20:18:12.896874       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 188.273 seconds
I0714 20:28:13.678754       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 189.093 seconds
I0714 20:38:13.532343       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 188.957 seconds
I0714 20:48:13.688437       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 189.066 seconds
I0714 20:58:14.613519       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 190.041 seconds
I0714 21:08:16.085705       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 191.233 seconds
I0714 21:18:14.587654       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 190.016 seconds
I0714 21:28:17.442955       1 k8s_discovery_client.go:278] Successfully discovered kubernetes cluster in 192.833 seconds
```
