### PR TITLE
[OM-87621]: Handle the case when user turned off secure probe after enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20220630141538-af77c3ed6c6f
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20220725163105-e668b90f8813
 )
 
 // k8s and relevant dependencies

--- a/go.sum
+++ b/go.sum
@@ -887,12 +887,12 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/turbonomic/turbo-api v0.0.0-20220606151638-bcdf1d7b4ab8 h1:KNqHTUIunOPSHyO8FHgrMq8KMzgXpxHe7nW0dCnkfic=
-github.com/turbonomic/turbo-api v0.0.0-20220606151638-bcdf1d7b4ab8/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+github.com/turbonomic/turbo-api v0.0.0-20220725155952-ec41db73695d h1:msuY0XieGEq+a7fZdJZ3u9vH0AGpRhVZUNhJ9eUjOYY=
+github.com/turbonomic/turbo-api v0.0.0-20220725155952-ec41db73695d/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec h1:AmQY0cCtDy28QkzPcyHNjMmY54agR87FPZ5EluG7ChY=
 github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec/go.mod h1:yUpUS3CIq74nyG/OmIYFu4Uw8eKg5om58cOk2dz4xMA=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20220630141538-af77c3ed6c6f h1:mbkemc0jx3mr5iBbJ3F/fwWMwHb+cSWHbDc3BzYo0bM=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20220630141538-af77c3ed6c6f/go.mod h1:8KDYKAtQ/0IfWEJ34N/vfZ1U0fbSEUKyv4Pf/WciNds=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20220725163105-e668b90f8813 h1:gMj7CcVHmiQxkg6esakY6OC0jEzz+t+GEqDo8IjpFaU=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20220725163105-e668b90f8813/go.mod h1:wxS6vmK6bt65shLTlXcV+iGTglmnbJE2mt06Kshgq84=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -174,13 +174,13 @@ github.com/spf13/pflag
 # github.com/stretchr/testify v1.7.0
 ## explicit
 github.com/stretchr/testify/assert
-# github.com/turbonomic/turbo-api v0.0.0-20220606151638-bcdf1d7b4ab8
+# github.com/turbonomic/turbo-api v0.0.0-20220725155952-ec41db73695d
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
 # github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec
 ## explicit
 github.com/turbonomic/turbo-crd/api/v1alpha1
-# github.com/turbonomic/turbo-go-sdk v0.0.0-20220630141538-af77c3ed6c6f
+# github.com/turbonomic/turbo-go-sdk v0.0.0-20220725163105-e668b90f8813
 ## explicit
 github.com/turbonomic/turbo-go-sdk/pkg
 github.com/turbonomic/turbo-go-sdk/pkg/builder


### PR DESCRIPTION
Intent:
Updated the dependency for turbo-go-sdk, see more details in https://github.com/turbonomic/turbo-api/pull/14