### PR TITLE
Fix range loop variable issue when iterating through turbo policies and bindings

### DIFF
--- a/pkg/discovery/processor/turbo_policy_processor.go
+++ b/pkg/discovery/processor/turbo_policy_processor.go
@@ -47,36 +47,38 @@ func (p *TurboPolicyProcessor) ProcessTurboPolicies() {
 
 	policyMap := make(map[string]*repository.TurboPolicy)
 	for _, sloScale := range turboSloScalings {
-		turboSloScaling := sloScale
-		gvk := turboSloScaling.GetObjectKind().GroupVersionKind()
+		// Create a copy as sloScale variable is reused during range loop
+		sloScaleCopy := sloScale
+		gvk := sloScaleCopy.GetObjectKind().GroupVersionKind()
 		if gvk.Empty() {
 			continue
 		}
-		policyId := createPolicyId(gvk.Kind, turboSloScaling.GetNamespace(), turboSloScaling.GetName())
+		policyId := createPolicyId(gvk.Kind, sloScaleCopy.GetNamespace(), sloScaleCopy.GetName())
 		policyMap[policyId] = repository.
 			NewTurboPolicy().
-			WithSLOHorizontalScale(&turboSloScaling)
+			WithSLOHorizontalScale(&sloScaleCopy)
 	}
 
 	var policyBindings []*repository.TurboPolicyBinding
 	for _, policyBinding := range turboPolicyBindings {
-		turboPolicyBinding := policyBinding
-		targets := turboPolicyBinding.Spec.Targets
+		// Create a copy as policyBinding variable is reused during range loop
+		policyBindingCopy := policyBinding
+		targets := policyBindingCopy.Spec.Targets
 		if len(targets) == 0 {
 			glog.Warningf("PolicyBinding %v/%v has no targets defined. Skip.",
-				turboPolicyBinding.Namespace, turboPolicyBinding.Name)
+				policyBindingCopy.Namespace, policyBindingCopy.Name)
 			continue
 		}
-		policyRef := turboPolicyBinding.Spec.PolicyRef
-		policyId := createPolicyId(policyRef.Kind, turboPolicyBinding.GetNamespace(), policyRef.Name)
+		policyRef := policyBindingCopy.Spec.PolicyRef
+		policyId := createPolicyId(policyRef.Kind, policyBindingCopy.GetNamespace(), policyRef.Name)
 		if policy, found := policyMap[policyId]; found {
 			policyBindings = append(policyBindings, repository.
-				NewTurboPolicyBinding(&turboPolicyBinding).
+				NewTurboPolicyBinding(&policyBindingCopy).
 				WithTurboPolicy(policy))
 		} else {
 			glog.Warningf("PolicyBinding %v/%v refers to %v policy %v/%v which does not exist. Skip.",
-				turboPolicyBinding.Namespace, turboPolicyBinding.Name, policyRef.Kind,
-				turboPolicyBinding.Namespace, policyRef.Name)
+				policyBindingCopy.Namespace, policyBindingCopy.Name, policyRef.Kind,
+				policyBindingCopy.Namespace, policyRef.Name)
 		}
 	}
 	glog.V(2).Infof("Discovered %v valid PolicyBindings.", len(policyBindings))

--- a/pkg/discovery/processor/turbo_policy_processor.go
+++ b/pkg/discovery/processor/turbo_policy_processor.go
@@ -46,7 +46,8 @@ func (p *TurboPolicyProcessor) ProcessTurboPolicies() {
 	glog.V(2).Infof("Discovered %v PolicyBindings.", len(turboPolicyBindings))
 
 	policyMap := make(map[string]*repository.TurboPolicy)
-	for _, turboSloScaling := range turboSloScalings {
+	for _, sloScale := range turboSloScalings {
+		turboSloScaling := sloScale
 		gvk := turboSloScaling.GetObjectKind().GroupVersionKind()
 		if gvk.Empty() {
 			continue
@@ -59,22 +60,23 @@ func (p *TurboPolicyProcessor) ProcessTurboPolicies() {
 
 	var policyBindings []*repository.TurboPolicyBinding
 	for _, policyBinding := range turboPolicyBindings {
-		targets := policyBinding.Spec.Targets
+		turboPolicyBinding := policyBinding
+		targets := turboPolicyBinding.Spec.Targets
 		if len(targets) == 0 {
 			glog.Warningf("PolicyBinding %v/%v has no targets defined. Skip.",
-				policyBinding.Namespace, policyBinding.Name)
+				turboPolicyBinding.Namespace, turboPolicyBinding.Name)
 			continue
 		}
-		policyRef := policyBinding.Spec.PolicyRef
-		policyId := createPolicyId(policyRef.Kind, policyBinding.GetNamespace(), policyRef.Name)
+		policyRef := turboPolicyBinding.Spec.PolicyRef
+		policyId := createPolicyId(policyRef.Kind, turboPolicyBinding.GetNamespace(), policyRef.Name)
 		if policy, found := policyMap[policyId]; found {
 			policyBindings = append(policyBindings, repository.
-				NewTurboPolicyBinding(&policyBinding).
+				NewTurboPolicyBinding(&turboPolicyBinding).
 				WithTurboPolicy(policy))
 		} else {
 			glog.Warningf("PolicyBinding %v/%v refers to %v policy %v/%v which does not exist. Skip.",
-				policyBinding.Namespace, policyBinding.Name, policyRef.Kind,
-				policyBinding.Namespace, policyRef.Name)
+				turboPolicyBinding.Namespace, turboPolicyBinding.Name, policyRef.Kind,
+				turboPolicyBinding.Namespace, policyRef.Name)
 		}
 	}
 	glog.V(2).Infof("Discovered %v valid PolicyBindings.", len(policyBindings))


### PR DESCRIPTION
## Problem
This PR fixes a bug where we forgot to redefine range loop variables when iterating turbo policies and policybindings. This leads to the problem where only one policy and policybinding is cached no matter how many policies and bindings are available in the cluster.

## Fix
Redefine range loop variables

## Test
- Dev build has been verified by QA
- Add unit tests
