### PR TITLE
Refactor the monitoring worker to better handle concurrency

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -57,7 +57,7 @@ const (
 	defaultDiscoveryIntervalSec       = 600
 	DefaultValidationWorkers          = 10
 	DefaultValidationTimeout          = 60
-	DefaultDiscoveryWorkers           = 4
+	DefaultDiscoveryWorkers           = 10
 	DefaultDiscoveryTimeoutSec        = 180
 	DefaultDiscoverySamples           = 10
 	DefaultDiscoverySampleIntervalSec = 60

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -26,7 +26,6 @@ import (
 
 const (
 	minDiscoveryWorker = 1
-	maxDiscoveryWorker = 10
 	// Max number of data samples to be collected for each resource metric
 	maxDataSamples = 60
 	// Min sampling discovery interval
@@ -60,10 +59,6 @@ func NewDiscoveryConfig(probeConfig *configs.ProbeConfig,
 		glog.Warningf("Invalid number of discovery workers %v, set it to %v.",
 			discoveryWorkers, minDiscoveryWorker)
 		discoveryWorkers = minDiscoveryWorker
-	} else if discoveryWorkers > maxDiscoveryWorker {
-		glog.Warningf("Discovery workers %v is higher than %v, set it to %v.", discoveryWorkers,
-			maxDiscoveryWorker, maxDiscoveryWorker)
-		discoveryWorkers = maxDiscoveryWorker
 	} else {
 		glog.Infof("Number of discovery workers: %v.", discoveryWorkers)
 	}

--- a/pkg/discovery/monitoring/dummy_monitor.go
+++ b/pkg/discovery/monitoring/dummy_monitor.go
@@ -49,9 +49,9 @@ func (m *DummyMonitor) ReceiveTask(task *task.Task) {
 	m.reset()
 }
 
-func (m *DummyMonitor) Do(stopChan <-chan struct{}) *metrics.EntityMetricSink {
+func (m *DummyMonitor) Do() *metrics.EntityMetricSink {
 	glog.V(4).Infof("%s has started task.", m.GetMonitoringSource())
-	err := m.ActualDummyWork(stopChan)
+	err := m.ActualDummyWork()
 	if err != nil {
 		glog.Errorf("Failed to execute task: %s", err)
 	}
@@ -59,18 +59,13 @@ func (m *DummyMonitor) Do(stopChan <-chan struct{}) *metrics.EntityMetricSink {
 	return m.metricSink
 }
 
-func (m *DummyMonitor) ActualDummyWork(stopChan <-chan struct{}) error {
+func (m *DummyMonitor) ActualDummyWork() error {
 	numWorkers := 4 // some arbitrary number of parallel routines
 	for i := 0; i < numWorkers; i++ {
 		m.wg.Add(1)
 		go func() {
 			defer m.wg.Done()
-			select {
-			case <-stopChan:
-				return
-			default:
-				time.Sleep(time.Second * time.Duration(m.config.TaskRunTime))
-			}
+			time.Sleep(time.Second * time.Duration(m.config.TaskRunTime))
 		}()
 	}
 	m.wg.Wait()

--- a/pkg/discovery/monitoring/dummy_monitor.go
+++ b/pkg/discovery/monitoring/dummy_monitor.go
@@ -49,14 +49,15 @@ func (m *DummyMonitor) ReceiveTask(task *task.Task) {
 	m.reset()
 }
 
-func (m *DummyMonitor) Do() *metrics.EntityMetricSink {
+func (m *DummyMonitor) Do() (*metrics.EntityMetricSink, error) {
 	glog.V(4).Infof("%s has started task.", m.GetMonitoringSource())
 	err := m.ActualDummyWork()
 	if err != nil {
 		glog.Errorf("Failed to execute task: %s", err)
+		return m.metricSink, err
 	}
 	glog.V(4).Infof("%s monitor has finished task.", m.GetMonitoringSource())
-	return m.metricSink
+	return m.metricSink, nil
 }
 
 func (m *DummyMonitor) ActualDummyWork() error {

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -118,7 +118,7 @@ func (m *KubeletMonitor) scrapeKubelet(node *api.Node) error {
 		} else {
 			// It's a valid case if a node is available from the full discovery but not available during sampling discoveries.
 			// Need to wait for a full discovery to fetch the available nodes.
-			glog.Warningf("Failed to get resource metrics summary sample from %s. Waiting for the next full discovery.", node.Name)
+			return fmt.Errorf("failed to get resource metrics summary sample from %s", node.Name)
 		}
 	}
 

--- a/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
+++ b/pkg/discovery/monitoring/kubelet/kubelet_monitor.go
@@ -63,6 +63,9 @@ func (m *KubeletMonitor) ReceiveTask(task *task.Task) {
 }
 
 func (m *KubeletMonitor) Do() (*metrics.EntityMetricSink, error) {
+	if m.node == nil {
+		return m.metricSink, errors.New("empty node")
+	}
 	glog.V(4).Infof("%s has started task.", m.GetMonitoringSource())
 	err := m.RetrieveResourceStat()
 	if err != nil {
@@ -75,9 +78,6 @@ func (m *KubeletMonitor) Do() (*metrics.EntityMetricSink, error) {
 
 // RetrieveResourceStat retrieves resource stats for the received node.
 func (m *KubeletMonitor) RetrieveResourceStat() error {
-	if m.node == nil {
-		return errors.New("empty node")
-	}
 	err := m.scrapeKubelet(m.node)
 	if err != nil {
 		return err

--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -70,7 +70,10 @@ func (m *ClusterMonitor) RetrieveClusterStat() error {
 	if err != nil {
 		return fmt.Errorf("failed to find cluster ID based on Kubernetes service: %v", err)
 	}
-	m.findNodeStates()
+	err = m.findNodeStates()
+	if err != nil {
+		return fmt.Errorf("failed to find node states: %v", err)
+	}
 	return nil
 }
 
@@ -95,11 +98,10 @@ func (m *ClusterMonitor) findClusterID() error {
 }
 
 // ----------------------------------------- Node State --------------------------------------------
-func (m *ClusterMonitor) findNodeStates() {
+func (m *ClusterMonitor) findNodeStates() error {
 	key := util.NodeKeyFunc(m.node)
 	if key == "" {
-		glog.Warning("Invalid node")
-		return
+		return fmt.Errorf("invalid node")
 	}
 	// node/pod/container cpu/mem resource capacities
 	m.genNodeResourceMetrics(m.node, key)
@@ -108,8 +110,8 @@ func (m *ClusterMonitor) findNodeStates() {
 	labelMetrics := parseNodeLabels(m.node)
 	m.sink.AddNewMetricEntries(labelMetrics)
 	glog.V(3).Infof("Successfully generated label metrics for node %s", key)
+	return nil
 	// owner labels - TODO:
-
 }
 
 // Generate resource metrics of a node:

--- a/pkg/discovery/monitoring/master/cluster_monitor.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor.go
@@ -50,14 +50,15 @@ func (m *ClusterMonitor) ReceiveTask(task *task.Task) {
 	m.nodePodMap = util.GroupPodsByNode(task.PodList())
 }
 
-func (m *ClusterMonitor) Do() *metrics.EntityMetricSink {
+func (m *ClusterMonitor) Do() (*metrics.EntityMetricSink, error) {
 	glog.V(4).Infof("%s has started task.", m.GetMonitoringSource())
 	err := m.RetrieveClusterStat()
 	if err != nil {
 		glog.Errorf("Failed to execute task: %s", err)
+		return m.sink, err
 	}
 	glog.V(4).Infof("%s monitor has finished task.", m.GetMonitoringSource())
-	return m.sink
+	return m.sink, nil
 }
 
 // RetrieveClusterStat retrieves resource stats for the received node.

--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -152,7 +152,7 @@ func TestGenNodeResourceMetrics(t *testing.T) {
 	clusterMonitor.clusterClient = cluster.NewClusterScraper(&client.Clientset{}, nil, nil,
 		false, nil, "")
 	clusterMonitor.sink = metrics.NewEntityMetricSink()
-	clusterMonitor.nodeList = []*api.Node{node}
+	clusterMonitor.node = node
 	clusterMonitor.nodePodMap = make(map[string][]*api.Pod)
 	clusterMonitor.nodePodMap["mynode"] = pods
 	// Collect node/pod/container metrics

--- a/pkg/discovery/monitoring/monitoring_worker.go
+++ b/pkg/discovery/monitoring/monitoring_worker.go
@@ -17,7 +17,7 @@ type MonitorWorkerConfig interface {
 }
 
 type MonitoringWorker interface {
-	Do() *metrics.EntityMetricSink
+	Do() (*metrics.EntityMetricSink, error)
 	ReceiveTask(task *task.Task)
 	GetMonitoringSource() types.MonitoringSource
 }

--- a/pkg/discovery/monitoring/monitoring_worker.go
+++ b/pkg/discovery/monitoring/monitoring_worker.go
@@ -17,7 +17,7 @@ type MonitorWorkerConfig interface {
 }
 
 type MonitoringWorker interface {
-	Do(stopChan <-chan struct{}) *metrics.EntityMetricSink
+	Do() *metrics.EntityMetricSink
 	ReceiveTask(task *task.Task)
 	GetMonitoringSource() types.MonitoringSource
 }

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -19,7 +19,7 @@ const (
 type Task struct {
 	uid         string
 	name        string
-	nodes       []*api.Node
+	node        *api.Node
 	pendingPods []*api.Pod
 	runningPods []*api.Pod
 	pods        []*api.Pod
@@ -38,14 +38,8 @@ func NewTask() *Task {
 	}
 }
 
-// Assign nodes to the task.
-func (t *Task) WithNodes(nodes []*api.Node) *Task {
-	t.nodes = nodes
-	return t
-}
-
 func (t *Task) WithNode(node *api.Node) *Task {
-	t.nodes = append(t.nodes, node)
+	t.node = node
 	return t
 }
 
@@ -85,9 +79,9 @@ func (t *Task) WithCluster(cluster *repository.ClusterSummary) *Task {
 	return t
 }
 
-// Get node list from the task.
-func (t *Task) NodeList() []*api.Node {
-	return t.nodes
+// Get node from the task.
+func (t *Task) Node() *api.Node {
+	return t.node
 }
 
 // Get pod list from the task.
@@ -118,11 +112,7 @@ func (t *Task) Cluster() *repository.ClusterSummary {
 }
 
 func (t *Task) String() string {
-	var nodes []string
-	for _, node := range t.nodes {
-		nodes = append(nodes, node.GetName())
-	}
-	return "[id: " + t.name + ", node: " + strings.Join(nodes, ",") + "]"
+	return "[id: " + t.name + ", node: " + t.node.GetName() + "]"
 }
 
 type TaskResultState string

--- a/pkg/discovery/worker/dispatcher_test.go
+++ b/pkg/discovery/worker/dispatcher_test.go
@@ -82,6 +82,7 @@ func getDispatcherAndCollector(workerCount, taskRunTimeSec int) (*Dispatcher, *R
 		MonitoringConfigs: []monitoring.MonitorWorkerConfig{&monitoring.DummyMonitorConfig{
 			TaskRunTime: taskRunTimeSec,
 		}},
+		StitchingPropertyType: "IP",
 	}
 	dispatcherConfig := NewDispatcherConfig(clusterScraper, probeConfig, workerCount, 10, 1, 1)
 	dispatcher := NewDispatcher(dispatcherConfig, metrics.NewEntityMetricSink())
@@ -108,7 +109,8 @@ func TestDispatcher_Dispatch_1000_Tasks_With_100_Workers(t *testing.T) {
 		var nodes = make([]struct{}, taskCount)
 		go func() {
 			for range nodes {
-				currTask := task.NewTask().WithNodes([]*v1.Node{}).WithCluster(clusterSummary)
+				node := new(v1.Node)
+				currTask := task.NewTask().WithNode(node).WithCluster(clusterSummary)
 				dispatcher.assignTask(currTask)
 			}
 		}()

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -214,7 +214,7 @@ func (worker *k8sDiscoveryWorker) executeTask(currTask *task.Task) *task.TaskRes
 					}
 					// glog.Infof("%s has finished", w.GetMonitoringSource())
 					t.Stop()
-					if err != nil {
+					if err == nil {
 						// Don't do any filtering
 						worker.sink.MergeSink(monitoringSink, nil)
 						if worker.isFullDiscoveryWorker {

--- a/pkg/discovery/worker/k8s_discovery_worker_test.go
+++ b/pkg/discovery/worker/k8s_discovery_worker_test.go
@@ -29,7 +29,7 @@ func TestBuildDTOsWithMissingMetrics(t *testing.T) {
 	pod := new(api.Pod)
 	pod.Name = "pod-1"
 
-	currTask := task.NewTask().WithNodes([]*api.Node{node}).WithPods([]*api.Pod{pod})
+	currTask := task.NewTask().WithNode(node).WithPods([]*api.Pod{pod})
 
 	entityDtos, kubePods, _ := worker.buildEntityDTOs(currTask)
 	if len(entityDtos) != 0 || len(kubePods) != 0 {

--- a/pkg/discovery/worker/metrics_collector_test.go
+++ b/pkg/discovery/worker/metrics_collector_test.go
@@ -255,7 +255,7 @@ func TestAccumulatingOverPodMetricsList(t *testing.T) {
 func TestPodMetricsCollectionNullCluster(t *testing.T) {
 	collector := &MetricsCollector{
 		MetricsSink: metricsSink,
-		NodeList:    []*v1.Node{n1},
+		Node:        n1,
 		PodList:     nodeToPodsMap[node1],
 	}
 
@@ -280,7 +280,7 @@ func TestPodMetricsCollectionUnknownNamespace(t *testing.T) {
 		Cluster:     clusterSummary,
 		MetricsSink: metricsSink,
 		PodList:     []*v1.Pod{pod1, pod2},
-		NodeList:    []*v1.Node{n1},
+		Node:        n1,
 	}
 
 	podCollection := collector.CollectPodMetrics()
@@ -323,7 +323,7 @@ func TestPodMetricsCollectionSingleNode(t *testing.T) {
 		Cluster:     clusterSummary,
 		MetricsSink: metricsSink,
 		PodList:     nodeToPodsMap[node1],
-		NodeList:    []*v1.Node{n1},
+		Node:        n1,
 	}
 
 	podCollection := collector.CollectPodMetrics()


### PR DESCRIPTION
Intent: 
Thanks to Cheuk's analysis on what happened at BMO, the worker go routine will be stuck in certain scenario when certain nodes are not accessible.

Fix:
Here're the changes in this PR:
1. Refactor Task to take node as field instead of array of nodes. This is the case after we refactor the discovery framework. The node array always only contains one node before the change.
2. Refactor the downstream struct like kubelet_monitor and cluster_monitor and dummy_monitor.
3. Modified all the downstream files after change in 2)
4. Change the default discovery worker count to 10 from 4.
5. Remove the boundary of max discovery worker

Test:
Unit tests passed and sanity check passed. Will check PS later.