### PR TITLE
Allow turbo-cluster-reader and turbo-cluster-admin to access turbo policy resources

### DIFF
--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/serviceaccount.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/serviceaccount.yaml
@@ -53,6 +53,15 @@ rules:
       - nodes/proxy
     verbs:
       - get
+  - apiGroups:
+      - policy.turbonomic.io
+    resources:
+      - slohorizontalscales
+      - policybindings
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}
 {{- if eq .Values.roleName "turbo-cluster-admin" }}
 ---
@@ -126,6 +135,15 @@ rules:
       - pods/log
     verbs:
       - get
+  - apiGroups:
+      - policy.turbonomic.io
+    resources:
+      - slohorizontalscales
+      - policybindings
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}
 ---
 kind: ClusterRoleBinding

--- a/deploy/kubeturbo/templates/serviceaccount.yaml
+++ b/deploy/kubeturbo/templates/serviceaccount.yaml
@@ -53,6 +53,15 @@ rules:
       - nodes/proxy
     verbs:
       - get
+  - apiGroups:
+      - policy.turbonomic.io
+    resources:
+      - slohorizontalscales
+      - policybindings
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}
 {{- if eq .Values.roleName "turbo-cluster-admin" }}
 ---
@@ -126,6 +135,15 @@ rules:
       - pods/log
     verbs:
       - get
+  - apiGroups:
+      - policy.turbonomic.io
+    resources:
+      - slohorizontalscales
+      - policybindings
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}
 ---
 kind: ClusterRoleBinding

--- a/deploy/kubeturbo_yamls/turbo-admin.yaml
+++ b/deploy/kubeturbo_yamls/turbo-admin.yaml
@@ -68,3 +68,12 @@ rules:
       - pods/log
     verbs:
       - get
+  - apiGroups:
+      - policy.turbonomic.io
+    resources:
+      - slohorizontalscales
+      - policybindings
+    verbs:
+      - get
+      - list
+      - watch

--- a/deploy/kubeturbo_yamls/turbo-reader.yaml
+++ b/deploy/kubeturbo_yamls/turbo-reader.yaml
@@ -47,3 +47,12 @@ rules:
       - nodes/proxy
     verbs:
       - get
+  - apiGroups:
+      - policy.turbonomic.io
+    resources:
+      - slohorizontalscales
+      - policybindings
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
## Backround
`kubeturbo` with `turbo-cluster-reader` and `turbo-cluster-admin` role permission cannot list turbo policies:

```
spec:
  args:
    sccsupport: '*'
  restAPIConfig:
    opsManagerPassword: administrator
    opsManagerUserName: administrator
  roleBinding: kubeturbo-meng-lab2-binding
  roleName: turbo-cluster-reader
  serverMeta:
    turboServer: https://35.174.206.243:9406
    version: 8.6.0
  serviceAccountName: kubeturbo-meng-lab2
  targetConfig:
    targetName: OCP47-AWS
```

```
W0727 20:14:52.161541       1 turbo_policy_processor.go:28] Failed to list SLOHorizontalScales: slohorizontalscales.policy.turbonomic.io is forbidden: User "system:serviceaccount:turbo:kubeturbo-meng-lab2" cannot list resource "slohorizontalscales" in API group "policy.turbonomic.io" at the cluster scope.
```

## Solution
* Add the permissions into `kubeturbo` deployment, including operator, helm, and pure yaml

## Test
* Deploy a dev build `kubeturbo-operator` and make sure the errors are gone