### PR TITLE
Add a volume property if the pod has attached PVs

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -493,6 +493,8 @@ func (builder *podEntityDTOBuilder) getPodProperties(pod *api.Pod, vols []reposi
 		if err == nil {
 			properties = append(properties, m.BuildDTOProperties(false)...)
 		}
+		// Add volume property if the pod has volumes attached
+		properties = property.AddVolumeProperties(properties)
 	}
 
 	return properties, nil

--- a/pkg/discovery/dtofactory/property/pod_properties.go
+++ b/pkg/discovery/dtofactory/property/pod_properties.go
@@ -109,3 +109,17 @@ func GetPodInfoFromProperty(properties []*proto.EntityDTO_EntityProperty) (strin
 
 	return podNamespace, podName, nil
 }
+
+// Add volume property to a pod's properties
+func AddVolumeProperties(properties []*proto.EntityDTO_EntityProperty) []*proto.EntityDTO_EntityProperty {
+	volumePropertyNamespace := VCTagsPropertyNamespace
+	volumePropertyName := k8sVolumeAttached
+	volumePropertyValue := "true"
+	volumeProperty := &proto.EntityDTO_EntityProperty{
+		Namespace: &volumePropertyNamespace,
+		Name:      &volumePropertyName,
+		Value:     &volumePropertyValue,
+	}
+	properties = append(properties, volumeProperty)
+	return properties
+}

--- a/pkg/discovery/dtofactory/property/property_common.go
+++ b/pkg/discovery/dtofactory/property/property_common.go
@@ -21,6 +21,7 @@ const (
 	k8sAppType                   = "KubernetesAppType"
 	TolerationPropertyNamePrefix = "[k8s toleration]"
 	LabelPropertyNamePrefix      = "[k8s label]"
+	k8sVolumeAttached            = "PersistentVolumeAttached"
 )
 
 func BuildTagProperty(namespace string, name string, value string) *proto.EntityDTO_EntityProperty {


### PR DESCRIPTION
# Intent
Add a new property for the pods to indicate if the pod has a PV attached

# Background
We're trying to allow users to search or group pods that have an attached PV.  Adding property will help group the PV attached pods
https://vmturbo.atlassian.net/browse/OM-87488

# Implementation
When building the pod DTO, if the pods have some PV attached, add a new property to indict the PVs counts

# Test Done

## Unit Test
**1. Compose a PV list with 2 PVs and assign pods to use that list**

```
[root@localvm property]# go test -test.v
=== RUN   TestBuildLabelAnnotationPropertiesWithoutRegex
--- PASS: TestBuildLabelAnnotationPropertiesWithoutRegex (0.00s)
=== RUN   TestBuildLabelAnnotationPropertiesWithRegex
--- PASS: TestBuildLabelAnnotationPropertiesWithRegex (0.00s)
=== RUN   TestNodeProperty
--- PASS: TestNodeProperty (0.00s)
=== RUN   TestBuildPodProperties
--- PASS: TestBuildPodProperties (0.00s)
=== RUN   TestAddHostingPodProperties
--- PASS: TestAddHostingPodProperties (0.00s)
=== RUN   TestAddVolumeProperties
--- PASS: TestAddVolumeProperties (0.00s)
PASS
ok  	github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property	0.022s
```


## Integration test 
Passed

## UI Test
**1. Create a new pod group with selecting the tag `PersistentVolumeAttached`**
![image](https://user-images.githubusercontent.com/61252360/184226921-69ff844c-f686-4b7c-bb0d-44769097915e.png)

![image](https://user-images.githubusercontent.com/61252360/184227026-69052339-4c8a-4bad-ab23-fb7d6dd64735.png)

**2. Pick one of the pods from the group and check its volumes through the CLI**
![image](https://user-images.githubusercontent.com/61252360/184227202-3ae4ea27-9efd-4222-956f-67ba8e5aa3c6.png)

```
 [root@dev4kw .kube]# k get pods -o yaml timescaledb-0 
apiVersion: v1
kind: Pod
metadata:
  annotations:
    k8s.v1.cni.cncf.io/network-status: |-
      [{
          "name": "openshift-sdn",
          "interface": "eth0",
          "ips": [
              "10.131.1.200"
          ],
          "default": true,
          "dns": {}
      }]
    k8s.v1.cni.cncf.io/networks-status: |-
      [{
          "name": "openshift-sdn",
          "interface": "eth0",
          "ips": [
              "10.131.1.200"
          ],
          "default": true,
          "dns": {}
      }]
    openshift.io/scc: anyuid
  creationTimestamp: "2022-07-25T05:57:42Z"
  generateName: timescaledb-
  labels:
    app.kubernetes.io/instance: proxy
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    controller-revision-hash: timescaledb-6f464b577d
    role: master
    statefulset.kubernetes.io/pod-name: timescaledb-0
    zone: secure
spec:
  containers:
  - env:
    - name: BITNAMI_DEBUG
      value: "false"
    - name: POSTGRESQL_PORT_NUMBER
      value: "5432"
    - name: POSTGRESQL_VOLUME_DIR
      value: /bitnami/postgresql
    - name: PGDATA
      value: /bitnami/postgresql/data
    - name: POSTGRES_USER
      value: postgres
    - name: POSTGRES_PASSWORD
      valueFrom:
        secretKeyRef:
          key: postgresql-password
          name: timescaledb
    - name: POSTGRES_DB
      value: postgres
    image: docker.io/timescale/timescaledb:2.0.1-pg12
    imagePullPolicy: IfNotPresent
    livenessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        - exec pg_isready -U "postgres" -d "postgres" -h 127.0.0.1 -p 5432
      failureThreshold: 6
      initialDelaySeconds: 30
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 5
    name: timescaledb
    ports:
    - containerPort: 5432
      name: tcp-postgresql
      protocol: TCP
    readinessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        - |
          pg_isready -U "postgres" -d "postgres" -h 127.0.0.1 -p 5432
      failureThreshold: 6
      initialDelaySeconds: 5
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 5
    resources:
      requests:
        cpu: 250m
        memory: 256Mi
    securityContext:
      capabilities:
        drop:
        - MKNOD
      runAsUser: 1000760000
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /bitnami/postgresql
      name: data
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-drznf
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  hostname: timescaledb-0
  imagePullSecrets:
  - name: default-dockercfg-mqzgg
  initContainers:
  - command:
    - /bin/sh
    - -c
    - |
      mkdir -p /bitnami/postgresql/data
      chmod 700 /bitnami/postgresql/data
      find /bitnami/postgresql -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
        xargs chown -R 1000760000:1000760000
    image: docker.io/bitnami/minideb:buster
    imagePullPolicy: Always
    name: init-chmod-data
    resources:
      requests:
        cpu: 250m
        memory: 256Mi
    securityContext:
      capabilities:
        drop:
        - MKNOD
      runAsUser: 1000760000
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /bitnami/postgresql
      name: data
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-drznf
      readOnly: true
  nodeName: ip-10-0-254-49.us-east-2.compute.internal
  nodeSelector:
    type: cloudpak
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext:
    fsGroup: 1000760000
    seLinuxOptions:
      level: s0:c28,c2
  serviceAccount: default
  serviceAccountName: default
  subdomain: timescaledb-headless
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  - effect: NoSchedule
    key: node.kubernetes.io/memory-pressure
    operator: Exists
  volumes:
  - name: data
    persistentVolumeClaim:
      claimName: data-timescaledb-0   <-------- use pv here
  - name: kube-api-access-drznf
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
      - configMap:
          items:
          - key: service-ca.crt
            path: service-ca.crt
          name: openshift-service-ca.crt
```