### PR TITLE
Honor the nodeAffinity of the PV for the pod which has PV attached

### DIFF
--- a/pkg/discovery/worker/compliance/affinity_helper.go
+++ b/pkg/discovery/worker/compliance/affinity_helper.go
@@ -18,17 +18,6 @@ import (
 
 //----------------------------------------- Node Affinity -------------------------------------------------------
 
-func matchesNodeSelector(pod *api.Pod, node *api.Node) bool {
-	// Check if node.Labels match pod.Spec.NodeSelector.
-	if len(pod.Spec.NodeSelector) > 0 {
-		selector := labels.SelectorFromSet(pod.Spec.NodeSelector)
-		if !selector.Matches(labels.Set(node.Labels)) {
-			return false
-		}
-	}
-	return true
-}
-
 // The pod can only schedule onto nodes that satisfy requirements in both NodeAffinity and nodeSelector.
 func matchesNodeAffinity(pod *api.Pod, node *api.Node) bool {
 	nodeAffinityMatches := true
@@ -46,6 +35,14 @@ func matchesNodeAffinity(pod *api.Pod, node *api.Node) bool {
 			glog.V(10).Infof("Match for RequiredDuringSchedulingIgnoredDuringExecution node selector terms %+v", nodeSelectorTerms)
 			nodeAffinityMatches = nodeAffinityMatches && nodeMatchesNodeSelectorTerms(node, nodeSelectorTerms)
 		}
+	}
+	return nodeAffinityMatches
+}
+
+func matchesPvNodeAffinity(pvNodeAffinitySelectorTerms []api.NodeSelectorTerm, node *api.Node) bool {
+	nodeAffinityMatches := true
+	if len(pvNodeAffinitySelectorTerms) > 0 {
+		nodeAffinityMatches = nodeMatchesNodeSelectorTerms(node, pvNodeAffinitySelectorTerms)
 	}
 	return nodeAffinityMatches
 }


### PR DESCRIPTION
# Intent
To honor the `nodeAffinity` on the PVs of the pod if the pod has the PV attached when making a `move` action decision

# Background
https://vmturbo.atlassian.net/browse/OM-83584

# Implementation
When `affinity processor` process the affinity rule, it not only check the pod's `nodeAffinity`, it also checks the affinity rule of the PVs which is attached to the pod. if the PVs have any `nodeAffinity` rule, `affinity processor` will do the similar thing as processing the pod `nodeAfffinity` rule, it will create a `VMPM_ACCESS` commodity with key and hash for pod and the node to indicate the pod can be accommodated by the node.

# Test Done
## Prepare the environment
1. Create a Fyre cluster with 3 master nodes and 3 worker nodes
```
[root@IBM-PF3888SM zonetest]# k get nodes
NAME                           STATUS   ROLES    AGE    VERSION
master0.abut.cp.fyre.ibm.com   Ready    master   6h8m   v1.21.11+6b3cbdd
master1.abut.cp.fyre.ibm.com   Ready    master   6h8m   v1.21.11+6b3cbdd
master2.abut.cp.fyre.ibm.com   Ready    master   6h8m   v1.21.11+6b3cbdd
worker0.abut.cp.fyre.ibm.com   Ready    worker   6h1m   v1.21.11+6b3cbdd
worker1.abut.cp.fyre.ibm.com   Ready    worker   6h1m   v1.21.11+6b3cbdd
worker2.abut.cp.fyre.ibm.com   Ready    worker   6h1m   v1.21.11+6b3cbdd
```
2. Label `worker0` with `xxx=yyy` and `disktype=ssd`
```
[root@IBM-PF3888SM zonetest]# k get nodes --show-labels  worker0.abut.cp.fyre.ibm.com 
NAME                           STATUS   ROLES    AGE   VERSION            LABELS
worker0.abut.cp.fyre.ibm.com   Ready    worker   10h   v1.21.11+6b3cbdd   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,disktype=ssd,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker0.abut.cp.fyre.ibm.com,kubernetes.io/os=linux,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhcos,topology.kubernetes.io/zone=us-east-zone,xxx=yyy

```
3. Setup [LovalVolume](https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/persistent_storage_local.html)` by creating a StorageClass, a PV and PVC
```
[root@IBM-PF3888SM zonetest]# k get storageclasses.storage.k8s.io local-storage -o yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2022-08-25T14:52:08Z"
  name: local-storage
  resourceVersion: "49890"
  uid: 05cf668c-87ce-4c58-b08e-c564c4226693
provisioner: kubernetes.io/no-provisioner
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
```
```
[root@IBM-PF3888SM zonetest]# k get pv example-pv -o yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/bound-by-controller: "yes"
  creationTimestamp: "2022-08-25T19:23:17Z"
  finalizers:
  - kubernetes.io/pv-protection
  name: example-pv
  resourceVersion: "149405"
  uid: f95858fc-764e-4417-bbd1-e76f82eb2b66
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: test-move-pvc
    namespace: default
    resourceVersion: "148433"
    uid: e3158aa6-79d3-49e8-ad1a-c40938a60bd6
  local:
    path: /opt
  nodeAffinity: <----------specify the nodeAffinity to match the nodes with the label disktype=ssd
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: disktype  
          operator: In
          values:
          - ssd
  persistentVolumeReclaimPolicy: Delete
  storageClassName: local-storage
  volumeMode: Filesystem
status:
  phase: Bound
```
```
[root@IBM-PF3888SM zonetest]# k get pvc test-move-pvc  -o yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/no-provisioner
  creationTimestamp: "2022-08-25T19:23:21Z"
  finalizers:
  - kubernetes.io/pvc-protection
  name: test-move-pvc
  namespace: default
  resourceVersion: "149408"
  uid: e3158aa6-79d3-49e8-ad1a-c40938a60bd6
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Mi
  storageClassName: local-storage   <------ use the local-storage storageclass
  volumeMode: Filesystem
  volumeName: example-pv
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound
````
4. Create a deployment mounting the PVC and set `nodeSelector` to `xxx=yyy`
```
[root@IBM-PF3888SM zonetest]# k get deploy nginx-deployment -o yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
  creationTimestamp: "2022-08-25T19:23:28Z"
  generation: 1
  labels:
    app: nginx
  name: nginx-deployment
  namespace: default
  resourceVersion: "149471"
  uid: 8944a1ac-9d01-4445-90f3-a5898dacb1ae
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: nginx
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      annotations:
        openshift.io/scc: restricted
      creationTimestamp: null
      labels:
        app: nginx
    spec:
      containers:
      - env:
        - name: RUN_TYPE
          value: cpu
        - name: CPU_PERCENT
          value: "100"
        image: nginx
        imagePullPolicy: Always
        name: nginx
        resources:
          limits:
            cpu: 1510m
          requests:
            cpu: 10m
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /mnt
          name: pxvol
      dnsPolicy: ClusterFirst
      imagePullSecrets:
      - name: turboregistrykey
      - name: turbocred
      nodeSelector:
        xxx: yyy   <-------------- use labelSelector to choose worker0
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
      volumes:
      - name: pxvol
        persistentVolumeClaim:
          claimName: test-move-pvc    <------ use the PVC which is corresponding to the PV created above
```
5. Make sure the pod is running and its PVC is bound
```
[root@IBM-PF3888SM zonetest]# k get pods 
NAME                                READY   STATUS    RESTARTS   AGE
kubeturbo-kw-114-66c9477494-h76h6   1/1     Running   0          84m
nginx-deployment-7cf9c5f8b8-br5fz   1/1     Running   0          21m
```
```
[root@IBM-PF3888SM zonetest]# k get pvc
NAME            STATUS   VOLUME       CAPACITY   ACCESS MODES   STORAGECLASS    AGE
test-move-pvc   Bound    example-pv   1Gi        RWO            local-storage   22m```
```

## Case 1
**1. Label `worker1` with `xxx=yyy` and remove this label from `worker0`**
```
[root@IBM-PF3888SM zonetest]# k get nodes --show-labels worker0.abut.cp.fyre.ibm.com  worker1.abut.cp.fyre.ibm.com 
NAME                           STATUS   ROLES    AGE   VERSION            LABELS
worker0.abut.cp.fyre.ibm.com   Ready    worker   10h   v1.21.11+6b3cbdd   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,disktype=ssd,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker0.abut.cp.fyre.ibm.com,kubernetes.io/os=linux,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhcos,topology.kubernetes.io/zone=us-east-zone
worker1.abut.cp.fyre.ibm.com   Ready    worker   10h   v1.21.11+6b3cbdd   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker1.abut.cp.fyre.ibm.com,kubernetes.io/os=linux,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhcos,topology.kubernetes.io/zone=us-east-zone,xxx=yyy

```

**2. Because `xxx=yyy` has been moved to `worker1` from `worker0`, before this code change, it should generate a move action for this pod, but in fact,  there is no move action generated,  the reason is `worker1` doesn't match the `nodeAffinity` of the PV, only `worker0` has the label `disktype=ssd` which matches the `nodeAffinity` of the PV**
![image](https://user-images.githubusercontent.com/61252360/186790018-47693564-f941-4946-b171-3391d90677d6.png)

**3. Label `worker1` with  `disktype=ssd`  which will match the `nodeAffinity` of the PV, and then we could see the `move` action is generated on `worker1`**
![image](https://user-images.githubusercontent.com/61252360/186790277-683d5759-ca41-45e7-9629-60464622a909.png)
![image](https://user-images.githubusercontent.com/61252360/186790698-5a3c1b4c-4a9d-4901-8375-495c168e2242.png)




