### PR TITLE
Honor the region/zone lable of the node when moving a pod that has PV attached

### DIFF
--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -416,6 +416,8 @@ func (worker *k8sDiscoveryWorker) buildPodDTOs(currTask *task.Task) ([]*proto.En
 		WithNameSpaceUIDMap(cluster.NamespaceUIDMap).
 		// Pod to volume map
 		WithPodToVolumesMap(cluster.PodToVolumesMap).
+		// Node Name to KubeNode map
+		WithNodeNameToNodeMap(cluster.NodeMap).
 		// Running pods
 		WithRunningPods(currTask.RunningPodList()).
 		// Pending pods

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -33,6 +33,14 @@ const (
 	// This gate will enable discovery of gitops pipeline applications and
 	// the action execution based on the same.
 	GitopsApps featuregate.Feature = "GitopsApps"
+
+	// owner: @kevinwang
+	// alpha:
+	//
+	// Honor the region/zone labels of the node.
+	// This gate will enable honorinig the labels topology.kubernetes.io/region and "topology.kubernetes.io/zone
+	// of the node which the pod is currently running on
+	HonorRegionZoneLabels featuregate.Feature = "HonorRegionZoneLabels"
 )
 
 func init() {
@@ -47,7 +55,8 @@ func init() {
 // Ref: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 // Note: We use the config to feed the values, not the command line params.
 var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PersistentVolumes: {Default: true, PreRelease: featuregate.Beta},
-	ThrottlingMetrics: {Default: true, PreRelease: featuregate.Beta},
-	GitopsApps:        {Default: false, PreRelease: featuregate.Alpha},
+	PersistentVolumes:     {Default: true, PreRelease: featuregate.Beta},
+	ThrottlingMetrics:     {Default: true, PreRelease: featuregate.Beta},
+	GitopsApps:            {Default: false, PreRelease: featuregate.Alpha},
+	HonorRegionZoneLabels: {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
# Intent
To honor the region/zone label(`topology.kubernetes.io/zone` and `topology.kubernetes.io/region`) when moving a pod that has any PV attached

# Background
https://vmturbo.atlassian.net/browse/OM-83584

# Implementation
The labels are presented as the `label` commodity in the kubeturo. When kubeturbo build the node DTOs, it's actually creating the `label` commodity for every label on that node, it also includes these two region/zone related labels. Based on this, the implementation is to have kubeturbo create new `label` commodity when it found the pod has PV attached and also the node the pods is currently running on has a zone/region label.

# Test Done
## Prepare the environment
1. Create a Fyre cluster with 3 master nodes and 3 worker nodes
```
[root@IBM-PF3888SM deploykubeturbo]# k get nodes
NAME                             STATUS   ROLES    AGE     VERSION
master0.brutes.cp.fyre.ibm.com   Ready    master   5h38m   v1.21.11+6b3cbdd
master1.brutes.cp.fyre.ibm.com   Ready    master   5h38m   v1.21.11+6b3cbdd
master2.brutes.cp.fyre.ibm.com   Ready    master   5h38m   v1.21.11+6b3cbdd
worker0.brutes.cp.fyre.ibm.com   Ready    worker   5h30m   v1.21.11+6b3cbdd
worker1.brutes.cp.fyre.ibm.com   Ready    worker   5h30m   v1.21.11+6b3cbdd
worker2.brutes.cp.fyre.ibm.com   Ready    worker   5h29m   v1.21.11+6b3cbdd
```
2. Label `worker0` with `xxx=yyy` and `topology.kubernetes.io/zone=us-east-1`, label `worker1` with `topology.kubernetes.io/zone=us-east-1` and label `worker2` with `topology.kubernetes.io/zone=us-west-1`. Basically we're trying to put `worker0` and `worker1` in the same zone and put `worker2` in a different one. 
```
[root@IBM-PF3888SM deploykubeturbo]# k get nodes --show-labels worker0.brutes.cp.fyre.ibm.com  worker1.brutes.cp.fyre.ibm.com  worker2.brutes.cp.fyre.ibm.com 
NAME                             STATUS   ROLES    AGE     VERSION            LABELS
worker0.brutes.cp.fyre.ibm.com   Ready    worker   5h33m   v1.21.11+6b3cbdd   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,disktype=ssd,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker0.brutes.cp.fyre.ibm.com,kubernetes.io/os=linux,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhcos,topology.kubernetes.io/zone=us-east-1,xxx=yy
worker1.brutes.cp.fyre.ibm.com   Ready    worker   5h33m   v1.21.11+6b3cbdd   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,disktype=ssd,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker1.brutes.cp.fyre.ibm.com,kubernetes.io/os=linux,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhcos,topology.kubernetes.io/zone=us-east-1
worker2.brutes.cp.fyre.ibm.com   Ready    worker   5h32m   v1.21.11+6b3cbdd   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,disktype=ssd,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker2.brutes.cp.fyre.ibm.com,kubernetes.io/os=linux,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhcos,topology.kubernetes.io/zone=us-west-1

```
3. Setup [LovalVolume](https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/persistent_storage_local.html)` by creating a StorageClass, a PV and PVC
```
[root@IBM-PF3888SM zonetest]# k get storageclasses.storage.k8s.io local-storage -o yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2022-08-25T14:52:08Z"
  name: local-storage
  resourceVersion: "49890"
  uid: 05cf668c-87ce-4c58-b08e-c564c4226693
provisioner: kubernetes.io/no-provisioner
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
```
```
[root@IBM-PF3888SM zonetest]# k get pv example-pv -o yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/bound-by-controller: "yes"
  creationTimestamp: "2022-08-25T19:23:17Z"
  finalizers:
  - kubernetes.io/pv-protection
  name: example-pv
  resourceVersion: "149405"
  uid: f95858fc-764e-4417-bbd1-e76f82eb2b66
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: test-move-pvc
    namespace: default
    resourceVersion: "148433"
    uid: e3158aa6-79d3-49e8-ad1a-c40938a60bd6
  local:
    path: /opt
  persistentVolumeReclaimPolicy: Delete
  storageClassName: local-storage
  volumeMode: Filesystem
status:
  phase: Bound
```
```
[root@IBM-PF3888SM zonetest]# k get pvc test-move-pvc  -o yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/no-provisioner
  creationTimestamp: "2022-08-25T19:23:21Z"
  finalizers:
  - kubernetes.io/pvc-protection
  name: test-move-pvc
  namespace: default
  resourceVersion: "149408"
  uid: e3158aa6-79d3-49e8-ad1a-c40938a60bd6
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Mi
  storageClassName: local-storage
  volumeMode: Filesystem
  volumeName: example-pv
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound
````
4. Create a deployment mounting the PVC and set `nodeSelector` to `xxx=yyy`
```
[root@IBM-PF3888SM deploykubeturbo]# k get deployment nginx-deployment  -o yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
  creationTimestamp: "2022-08-29T18:56:00Z"
  generation: 1
  labels:
    app: nginx
  name: nginx-deployment
  namespace: default
  resourceVersion: "145446"
  uid: f130f5d9-0b4c-454f-8470-ec539d280878
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: nginx
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      annotations:
        openshift.io/scc: restricted
      creationTimestamp: null
      labels:
        app: nginx
    spec:
      containers:
      - env:
        - name: RUN_TYPE
          value: cpu
        - name: CPU_PERCENT
          value: "100"
        image: beekman9527/cpumemload:latest
        imagePullPolicy: Always
        name: nginx
        resources:
          limits:
            cpu: 1510m
          requests:
            cpu: 10m
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /mnt
          name: pxvol
      dnsPolicy: ClusterFirst
      imagePullSecrets:
      - name: turboregistrykey
      - name: turbocred
      nodeSelector:
        xxx: yyy   <---------- add this selector for the convenience of triggering a move action
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
      volumes:
      - name: pxvol
        persistentVolumeClaim:
          claimName: test-move-pvc
```
5. Make sure the pod is running on `worker0` and its PVC is bound
```
[root@IBM-PF3888SM deploykubeturbo]# k get pods -o wide
NAME                                READY   STATUS    RESTARTS   AGE   IP             NODE                             NOMINATED NODE   READINESS GATES
kubeturbo-kw-114-77f68c9978-l2wtx   1/1     Running   0          81m   10.254.18.88   worker0.brutes.cp.fyre.ibm.com   <none>           <none>
nginx-deployment-66fcf88df9-dmqfg   1/1     Running   0          59m   10.254.18.97   worker0.brutes.cp.fyre.ibm.com   <none>           <none>

```
```
[root@IBM-PF3888SM zonetest]# k get pvc
NAME            STATUS   VOLUME       CAPACITY   ACCESS MODES   STORAGECLASS    AGE
test-move-pvc   Bound    example-pv   1Gi        RWO            local-storage   22m```
```

## Case 1
**1. Label `worker2` with `xxx=yyy` and remove this label from `worker0`**
```
[root@IBM-PF3888SM deploykubeturbo]# k get nodes --show-labels worker0.brutes.cp.fyre.ibm.com  worker1.brutes.cp.fyre.ibm.com  worker2.brutes.cp.fyre.ibm.com 
NAME                             STATUS   ROLES    AGE     VERSION            LABELS
worker0.brutes.cp.fyre.ibm.com   Ready    worker   5h48m   v1.21.11+6b3cbdd   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,disktype=ssd,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker0.brutes.cp.fyre.ibm.com,kubernetes.io/os=linux,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhcos,topology.kubernetes.io/zone=us-east-1
worker1.brutes.cp.fyre.ibm.com   Ready    worker   5h48m   v1.21.11+6b3cbdd   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,disktype=ssd,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker1.brutes.cp.fyre.ibm.com,kubernetes.io/os=linux,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhcos,topology.kubernetes.io/zone=us-east-1
worker2.brutes.cp.fyre.ibm.com   Ready    worker   5h47m   v1.21.11+6b3cbdd   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,disktype=ssd,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker2.brutes.cp.fyre.ibm.com,kubernetes.io/os=linux,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhcos,topology.kubernetes.io/zone=us-west-1,xxx=yyy

```

**2. Because `xxx=yyy` has been moved to `worker2` from `worker0`, before this code change, it should generate a move action for this pod, but in fact,  there is no move action generated,  the reason is the pod has a PV attached and is running on `worker0` which has zone label pointing to `us-east-1`, but `worker2` doesn't have that label, its zone label is pointing to `us-west-1`. As we're honoring this label, there is no move action for this, instead we get a reconfigure action**
![image](https://user-images.githubusercontent.com/61252360/187283822-297f8f6e-fcea-4944-8aaa-11abf31ee74c.png)


**3. Remove the label `xxx=yyy` from `worker2` and label it to `worker1`, we can see a move action is generated, as  `worker1` is in the same zone as the `worker0`**
![image](https://user-images.githubusercontent.com/61252360/187284612-08d9c88e-77c2-4d2a-9090-987a43b95cf1.png)





