### PR TITLE
add controllable patched field value

### DIFF
--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -95,7 +95,9 @@ var (
 	path                       = "path"
 	ActionEligibilityField     = "actionEligibility"
 	providerPolicyPath         = "providerPolicy"
+	consumerPolicyPath         = "consumerPolicy"
 	availableForPlacementField = "availableForPlacement"
+	controllableField          = "controllable"
 	powerStateField            = "powerState"
 )
 
@@ -238,6 +240,7 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 
 	mergedEntityMetadataBuilder.PatchField(ActionEligibilityField, []string{})
 	mergedEntityMetadataBuilder.PatchField(availableForPlacementField, []string{providerPolicyPath})
+	mergedEntityMetadataBuilder.PatchField(controllableField, []string{consumerPolicyPath})
 	// Set up matching criteria based on stitching type
 	switch f.stitchingPropertyType {
 	case stitching.UUID:

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -237,7 +237,6 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 		builder.PropertyResizable: {},
 	}
 	mergedEntityMetadataBuilder := builder.NewMergedEntityMetadataBuilder()
-
 	mergedEntityMetadataBuilder.PatchField(ActionEligibilityField, []string{})
 	mergedEntityMetadataBuilder.PatchField(availableForPlacementField, []string{providerPolicyPath})
 	mergedEntityMetadataBuilder.PatchField(controllableField, []string{consumerPolicyPath})


### PR DESCRIPTION
Ticket: https://vmturbo.atlassian.net/browse/OM-87209

Problem:
In Stitched environment pods were unable to be migrated to Google Cloud clusters and causing pod move failures. This was happening because the Google Cloud probe was setting the `controllable` field on the `ConsumerPolicy` as false, when it needed to be true. 

Fix:
This change will override the value coming from the cloud probe, making pod moves to the GKE cluster available.

Setup:
- add a GKE configuration target 

Testing:
- pull down kubeturbo
- run `export KUBETURBO_VERSION=8.6.4-SNAPSHOT`
- `make build`
- run `cd build; DOCKER_BUILDKIT=1 docker build -t <Docker Hub account name>/kubeturbo .`
- publish to your DockerHub account
- create a configmap and deployment pointed toward the same GKE cluster and deploy kubeturbo using the image you published to your docker hub. The image value should look something like this: `<account name>/kubeturbo:<image version>`
- going through the migrate container workload attempt to migrate a pod from a non-GKE cluster to the GKE cluster and notice that the move succeeds.
