### PR TITLE
[OM-88553]: Integration test for pod pv affinity rules

### DIFF
--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -10,6 +10,7 @@ import (
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -424,6 +425,7 @@ func depSingleContainerWithResources(namespace, claimName string, replicas int32
 			},
 		}
 	}
+
 	if withGCLabel {
 		addGCLabelDep(&dep)
 	}
@@ -704,6 +706,60 @@ func createVolumeClaim(client kubeclientset.Interface, namespace, storageClassNa
 
 }
 
+func createPV(client kubeclientset.Interface, namespace, storageClassName string) (*corev1.PersistentVolume, error) {
+	quantity, _ := resource.ParseQuantity("5Gi")
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-pv-",
+			Namespace:    namespace,
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: quantity,
+			},
+			//VolumeMode: Default is FileSystem
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				Local: &corev1.LocalVolumeSource{
+					Path: "/opt",
+				},
+			},
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+			StorageClassName:              storageClassName,
+			NodeAffinity: &corev1.VolumeNodeAffinity{
+				Required: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      "kubernetes.io/hostname",
+									Operator: "In",
+									Values:   []string{"kind-worker"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	var newPV *corev1.PersistentVolume
+	var errInternal error
+	if err := wait.PollImmediate(framework.PollInterval, framework.TestContext.SingleCallTimeout, func() (bool, error) {
+		newPV, errInternal = client.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})
+		if errInternal != nil {
+			glog.Errorf("Unexpected error while creating PV for test: %v", errInternal)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, err
+	}
+	return newPV, nil
+}
+
 func createDeployment(client kubeclientset.Interface, dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 	var newDep *appsv1.Deployment
 	var errInternal error
@@ -734,6 +790,30 @@ func createReplicaSet(client kubeclientset.Interface, rs *appsv1.ReplicaSet) (*a
 		return nil, err
 	}
 	return newRS, nil
+}
+
+func createStorageClass(client kubeclientset.Interface) (*storagev1.StorageClass, error) {
+	storageC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "pod-with-pv-affinity-",
+		},
+		Provisioner: "kubernetes.io/no-provisioner",
+	}
+	var localStorage *storagev1.StorageClass
+	var errInternal error
+	if err := wait.PollImmediate(framework.PollInterval, framework.TestContext.SingleCallTimeout, func() (bool, error) {
+		localStorage, errInternal = client.StorageV1().StorageClasses().Create(context.TODO(), storageC, metav1.CreateOptions{})
+		if errInternal != nil {
+			glog.Errorf("Unexpected error while creating PVC for test: %v", errInternal)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return localStorage, nil
+
 }
 
 func waitForDeployment(client kubeclientset.Interface, depName, namespace string) (*appsv1.Deployment, error) {


### PR DESCRIPTION
Intent
Integration test to honor the nodeAffinity on the PVs of the pod if the pod has the PV attached when making a move action decision. Kubeturbo will add VMPM_ACCESS commodity for the pv affinity rules in Pod CommodityBoughtList. This test case validates whether the `CommodityBoughtList` in `entitydto` for the `pod` has `VMPM_ACCESS` with the correct  key (Example, `"kubernetes.io/hostname"`)
Background
https://vmturbo.atlassian.net/browse/OM-83584

Implementation
Creation of storage class with `Provisioner: "kubernetes.io/no-provisioner"`
Creation of PV with local path, affinity `key:value` as `kubernetes.io/hostname:kind-worker` and above storage class
Create a PVC with the storage class created
Create a deployment with volume and created PVC
Validate creation of test resources
Validate whether VMPM_ACCESS with correct key is present in the pod entitydto CommodityBoughtList 

Test Done
Full integration test run
<img width="1792" alt="Screen Shot 2022-09-16 at 8 02 43 AM" src="https://user-images.githubusercontent.com/22046780/190658147-d9844e0f-f83e-402a-b3c2-f977ad955f7f.png">
