### PR TITLE
[OM-88834]: Update turbo-go-sdk vendor with changes from PR 141

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20220914191815-14796bf3cddd
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20220921150744-f1925181c839
 )
 
 // k8s and relevant dependencies

--- a/go.sum
+++ b/go.sum
@@ -859,8 +859,8 @@ github.com/turbonomic/turbo-api v0.0.0-20220725155952-ec41db73695d h1:msuY0XieGE
 github.com/turbonomic/turbo-api v0.0.0-20220725155952-ec41db73695d/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec h1:AmQY0cCtDy28QkzPcyHNjMmY54agR87FPZ5EluG7ChY=
 github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec/go.mod h1:yUpUS3CIq74nyG/OmIYFu4Uw8eKg5om58cOk2dz4xMA=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20220914191815-14796bf3cddd h1:tr0ZizVQQuKBhS9r6pK/CvlMoRTWHtyISjh6CuZxQMQ=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20220914191815-14796bf3cddd/go.mod h1:KK+4Lb4OSx+R+6YkeTEspcuJGX/2RMaw1ImhwEtNsM0=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20220921150744-f1925181c839 h1:qc3YNax4s2d+dVSYCiLOBZDUNNnfyAkp+PUoNm3gl54=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20220921150744-f1925181c839/go.mod h1:KK+4Lb4OSx+R+6YkeTEspcuJGX/2RMaw1ImhwEtNsM0=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -139,6 +139,7 @@ func loadClientIdSecretFromSecret(tapSpec *K8sTAPServiceSpec) error {
 
 	tapSpec.ClientId = strings.TrimSpace(string(clientId))
 	tapSpec.ClientSecret = strings.TrimSpace(string(clientSecret))
+	glog.V(4).Infof("Obtained credentials to set up secure probe communication")
 	return nil
 }
 

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/probe/probe_registration.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/probe/probe_registration.go
@@ -167,5 +167,6 @@ type IActionMergePolicyProvider interface {
 }
 
 type ISecureProbeTargetProvider interface {
+	GetTargetIdentifier() string
 	GetSecureProbeTarget() *proto.ProbeTargetInfo
 }

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/probe/turbo_probe.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/probe/turbo_probe.go
@@ -271,9 +271,11 @@ func (theProbe *TurboProbe) GetProbeInfo() (*proto.ProbeInfo, error) {
 		probeInfoBuilder.WithActionMergePolicySet(registrationClient.GetActionMergePolicy())
 	}
 
-	// 9. default secure target
+	// 9. default secure target - only if the target identifier is provided
 	if registrationClient.ISecureProbeTargetProvider != nil {
-		probeInfoBuilder.WithSecureTarget(registrationClient.GetSecureProbeTarget())
+		if len(registrationClient.GetTargetIdentifier()) > 0 {
+			probeInfoBuilder.WithSecureTarget(registrationClient.GetSecureProbeTarget())
+		}
 	}
 
 	probeInfo := probeInfoBuilder.Create()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/turbonomic/turbo-api/pkg/client
 # github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec
 ## explicit
 github.com/turbonomic/turbo-crd/api/v1alpha1
-# github.com/turbonomic/turbo-go-sdk v0.0.0-20220914191815-14796bf3cddd
+# github.com/turbonomic/turbo-go-sdk v0.0.0-20220921150744-f1925181c839
 ## explicit
 github.com/turbonomic/turbo-go-sdk/pkg
 github.com/turbonomic/turbo-go-sdk/pkg/builder


### PR DESCRIPTION
Update `turbo-go-sdk` vendor with changes from https://github.com/turbonomic/turbo-go-sdk/pull/141