### PR TITLE
OM-89959 integration test to honor zone/region label

### DIFF
--- a/hack/create_kind_cluster.sh
+++ b/hack/create_kind_cluster.sh
@@ -52,6 +52,5 @@ EOF
 echo "Creating kind cluster"
 create-cluster
 ${kubectl_path} config use-context kind-kind
-${kubectl_path} label node kind-worker foo=bar
 
 echo "Cluster creation complete."

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -318,7 +318,7 @@ var _ = Describe("Discover Cluster", func() {
 			podFullName = namespace + "/" + pod.Name
 		})
 
-		It("discovering with pv with affinity rules", func() {
+		It("discovering pod with pv with affinity rules when feature gate is default(true)", func() {
 
 			//Use Caase 1 : Validate whether VMPM_ACCESS is present in the pod commodity bought list
 			//and no OTHER node has VMPM_ACCESS commodity in sold list with feature gate default value
@@ -353,7 +353,7 @@ var _ = Describe("Discover Cluster", func() {
 
 		})
 
-		It("discovering with pv with affinity rules with featureGate disabled", func() {
+		It("discovering pod with pv with affinity rules with featureGate disabled", func() {
 
 			// Disable  the feature gate
 			honorAzPvFlag := make(map[string]bool)
@@ -376,7 +376,7 @@ var _ = Describe("Discover Cluster", func() {
 			podNode = deleteLabelsFromNode(delNode, "foo", kubeClient)
 		})
 
-		It("pod with pv to honor zone label when feature gate is default(false)", func() {
+		It("pod with pv to honor zone label when feature gate is disabled", func() {
 
 			//Use Case 3 : Test zone label in node and featureGate value false
 
@@ -398,10 +398,10 @@ var _ = Describe("Discover Cluster", func() {
 
 			//Verify zone/region label in the commodity list
 			if validateBuyerSellerCommodity(podEntityDTO, nodeEntityDTO, nodeName, proto.CommodityDTO_LABEL, commodityZoneValue) {
-				framework.Failf("Zone label in node for pod with PV is not honored")
+				framework.Failf("Zone label in node for pod with PV is considered even if featureGate is disabled")
 			}
 			if validateBuyerSellerCommodity(podEntityDTO, nodeEntityDTO, nodeName, proto.CommodityDTO_LABEL, commodityRegionValue) {
-				framework.Failf("Region label in node for pod with PV is not honored")
+				framework.Failf("Region label in node for pod with PV is considered even if featureGate is diabledd")
 			}
 
 		})


### PR DESCRIPTION
Intent
Integration test to honor the zone/region label in a node for the pod with pv moves. Kubeturbo will add LABEL commodity in the pod CommodityBoughtList. This test case validates whether the CommodityBoughtList in entitydto for the pod has LABEL with the correct key:value pair (Example, "topology.kubernetes.io/zone=us-west-2", "topology.kubernetes.io/region=us-west-2")

Background
https://vmturbo.atlassian.net/browse/OM-88552

Implementation
Create a PVC with the storage class created
Create a deployment with volume and through created PVC
Validate creation of test resources
Validate whether LABEL commodity with correct key=value is present in the pod entitydto CommodityBoughtList
Validate no other node has the added label values

Added two test cases, one to validate presence of required commodities with featuregate enabled(default) and second validates the absence of commodities with featureGate disabled.

Tested full build
<img width="1471" alt="Screen Shot 2022-09-30 at 7 21 28 AM" src="https://user-images.githubusercontent.com/22046780/193279354-5b88c71b-4641-478d-8a8b-fd446e0cf079.png">

