### PR TITLE
[OM-90501]: Rename the feature gate and make it support PV affinity

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -404,7 +404,7 @@ func (builder *podEntityDTOBuilder) getPodCommoditiesBought(
 
 	// Label commodities
 	// To honor the region/zone label on th node that the pod is running on if the pod has any PV attached
-	if utilfeature.DefaultFeatureGate.Enabled(features.HonorRegionZoneLabels) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.HonorAzLabelPvAffinity) {
 		var anerr error
 		commoditiesBought, anerr = builder.getRegionZoneLabelCommodity(pod, commoditiesBought)
 		if anerr != nil {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -38,9 +38,9 @@ const (
 	// alpha:
 	//
 	// Honor the region/zone labels of the node.
-	// This gate will enable honorinig the labels topology.kubernetes.io/region and "topology.kubernetes.io/zone
-	// of the node which the pod is currently running on
-	HonorRegionZoneLabels featuregate.Feature = "HonorRegionZoneLabels"
+	// This gate will enable honorinig the labels topology.kubernetes.io/region and topology.kubernetes.io/zone
+	// of the node which the pod is currently running on and also enable honoring the PV affninity on a pod move
+	HonorAzLabelPvAffinity featuregate.Feature = "HonorAzLabelPvAffinity"
 
 	// GoMemLimit owner: @mengding
 	// alpha:
@@ -63,9 +63,9 @@ func init() {
 // Ref: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 // Note: We use the config to feed the values, not the command line params.
 var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PersistentVolumes:     {Default: true, PreRelease: featuregate.Beta},
-	ThrottlingMetrics:     {Default: true, PreRelease: featuregate.Beta},
-	GitopsApps:            {Default: false, PreRelease: featuregate.Alpha},
-	HonorRegionZoneLabels: {Default: true, PreRelease: featuregate.Alpha},
-	GoMemLimit:            {Default: false, PreRelease: featuregate.Alpha},
+	PersistentVolumes:      {Default: true, PreRelease: featuregate.Beta},
+	ThrottlingMetrics:      {Default: true, PreRelease: featuregate.Beta},
+	GitopsApps:             {Default: false, PreRelease: featuregate.Alpha},
+	HonorAzLabelPvAffinity: {Default: true, PreRelease: featuregate.Alpha},
+	GoMemLimit:             {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -35,6 +35,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
 	"github.com/turbonomic/kubeturbo/test/integration/framework"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 /*
@@ -274,6 +275,14 @@ var _ = Describe("Discover Cluster", func() {
 
 			var nodeNameForPod string
 			var podFullName string
+
+			// Enable the feature gate
+			honorAzPvFlag := make(map[string]bool)
+			honorAzPvFlag["HonorAzLabelPvAffinity"] = true
+			err := utilfeature.DefaultMutableFeatureGate.SetFromMap(honorAzPvFlag)
+			if err != nil {
+				glog.Fatalf("Invalid Feature Gates: %v", err)
+			}
 
 			//Add Storage Class
 			newStorage, err := createStorageClass(kubeClient)


### PR DESCRIPTION
# Intent
To change the name of the feature gate to `HonorAzLabelPvAffinity` and make it also support honoring PV affinity when moving a pod. 

# Test Done
1. Build the integration test binary
2. Run the PV affinity test on the local by setting the flag to `true`
```
[root@localvm kubeturbo]# ./build/integration.test -k8s-kubeconfig=$HOME/.kube/kind.config -k8s-context=kind-kind  -ginkgo.focus="discovering pod with pv having affinity rules"
I1003 15:48:51.170967   48166 integration_test.go:52] Starting integration run on Ginkgo node 1
Running Suite: Kubeturbo integration suite
==========================================
Random Seed: 1664826531
Will run 1 of 28 specs

SSSSSSSI1003 15:48:51.228325   48166 k8s_discovery_client.go:63] Number of discovery workers: 10.
I1003 15:48:51.228389   48166 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:48:51.228425   48166 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:48:51.228468   48166 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:48:51.228494   48166 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:48:51.228523   48166 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:48:51.228553   48166 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:48:51.228575   48166 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:48:51.228596   48166 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:48:51.228625   48166 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:48:51.228654   48166 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:48:51.228699   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229054   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229076   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229098   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229118   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229154   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229176   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229204   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229251   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229272   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229293   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229322   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229345   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229367   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229396   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229424   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229467   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229492   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229518   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:48:51.229550   48166 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
W1003 15:48:53.785104   48166 business_app_processor.go:79] Failed to list applications from app.k8s.io/v1beta1: the server could not find the requested resource
W1003 15:48:53.785574   48166 turbo_policy_processor.go:28] Failed to list SLOHorizontalScales: no kind is registered for the type v1alpha1.SLOHorizontalScaleList in scheme "k8s.io/client-go/kubernetes/scheme/register.go:74".
W1003 15:48:53.787716   48166 operator_resource_mapping.go:97] No OperatorResourceMapping CR discovered: failed to get OperatorResourceMapping CRs: the server could not find the requested resource. Create operator-resource-mapping CR to control Operator managed resources.
I1003 15:48:53.790431   48166 kubelet_client.go:314] Node kind-worker3 is running with linux/amd64.
I1003 15:48:53.791121   48166 kubelet_client.go:314] Node kind-worker2 is running with linux/amd64.
I1003 15:48:53.791353   48166 kubelet_client.go:314] Node kind-control-plane is running with linux/amd64.
I1003 15:48:53.791562   48166 kubelet_client.go:314] Node kind-worker is running with linux/amd64.
W1003 15:48:53.817642   48166 kubelet_client.go:333] Failed to get CPU frequency for node kind-worker from kubelet: the server could not find the requested resource. Will try job based getter.
W1003 15:48:53.819189   48166 kubelet_client.go:333] Failed to get CPU frequency for node kind-worker2 from kubelet: the server could not find the requested resource. Will try job based getter.
E1003 15:48:53.826661   48166 kubelet_client.go:397] Failed to get CPU frequency from job on node kind-worker: error creating cpufreq job for node: kind-worker: Job.batch "kubeturbo-cpufreq-1e6l6t5odioj4" is invalid: spec.template.spec.containers[0].image: Required value.
W1003 15:48:53.827755   48166 kubelet_client.go:333] Failed to get CPU frequency for node kind-control-plane from kubelet: the server could not find the requested resource. Will try job based getter.
W1003 15:48:53.828227   48166 kubelet_client.go:333] Failed to get CPU frequency for node kind-worker3 from kubelet: the server could not find the requested resource. Will try job based getter.
E1003 15:48:53.831361   48166 kubelet_client.go:397] Failed to get CPU frequency from job on node kind-worker2: error creating cpufreq job for node: kind-worker2: Job.batch "kubeturbo-cpufreq-1e6l6t5of1ihu" is invalid: spec.template.spec.containers[0].image: Required value.
E1003 15:48:53.834757   48166 kubelet_client.go:397] Failed to get CPU frequency from job on node kind-control-plane: error creating cpufreq job for node: kind-control-plane: Job.batch "kubeturbo-cpufreq-1e6l6t5on6bhq" is invalid: spec.template.spec.containers[0].image: Required value.
E1003 15:48:53.834757   48166 kubelet_client.go:397] Failed to get CPU frequency from job on node kind-worker3: error creating cpufreq job for node: kind-worker3: Job.batch "kubeturbo-cpufreq-1e6l6t5onkl5n" is invalid: spec.template.spec.containers[0].image: Required value.
W1003 15:48:54.097546   48166 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-5qcm6/test-x88rs-696cf77fc7-l6nl5 mounted pod-move-test from volume test-pv-s8wds: missing metrics Used
W1003 15:48:54.097706   48166 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-dn99h/test-sv4j7-5dcd66c8fc-xvskg mounted pod-move-test from volume test-pv-kb7rc: missing metrics Used
W1003 15:48:54.097762   48166 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-mnvs9/test-62g6f-855b9fc9f6-ftvz5 mounted pod-move-test from volume test-pv-48q87: missing metrics Used
W1003 15:48:54.097814   48166 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-rz5v6/test-9dj2m-68f6857d49-jbdv8 mounted pod-move-test from volume test-pv-8252w: missing metrics Used
W1003 15:48:54.097864   48166 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-sbkvx/test-7cw7z-55457946dc-vxgbb mounted pod-move-test from volume test-pv-rtflt: missing metrics Used
E1003 15:48:54.207807   48166 namespace_discovery_worker.go:75] Missing quota metrics for namespace default
E1003 15:48:54.207864   48166 namespace_discovery_worker.go:75] Missing quota metrics for namespace kube-node-lease
E1003 15:48:54.207885   48166 namespace_discovery_worker.go:75] Missing quota metrics for namespace kube-public
I1003 15:48:54.208196   48166 container_spec_discovery_worker.go:53] ContainerSpec will aggregate Containers utilization data by 'all utilization data strategy'
I1003 15:48:54.208220   48166 container_spec_discovery_worker.go:61] ContainerSpec will aggregate Containers usage data by 'average usage data strategy'
•SSSSSSSSSSSSSSSSSSSS
Ran 1 of 28 Specs in 3.027 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 27 Skipped
PASS
```

3. Run the PV affinity test on the local by setting the flag to `false`
```
[root@localvm kubeturbo]# make integration
go test -c -o build/integration.test ./test/integration
[root@localvm kubeturbo]# ./build/integration.test -k8s-kubeconfig=$HOME/.kube/kind.config -k8s-context=kind-kind  -ginkgo.focus="discovering pod with pv having affinity rules"
I1003 15:50:31.301686   48950 integration_test.go:52] Starting integration run on Ginkgo node 1
Running Suite: Kubeturbo integration suite
==========================================
Random Seed: 1664826631
Will run 1 of 28 specs

SSSSSSSSSSSI1003 15:50:31.386555   48950 k8s_discovery_client.go:63] Number of discovery workers: 10.
I1003 15:50:31.386612   48950 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:50:31.386645   48950 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:50:31.386676   48950 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:50:31.386699   48950 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:50:31.386724   48950 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:50:31.386741   48950 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:50:31.386758   48950 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:50:31.386776   48950 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:50:31.386793   48950 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:50:31.386826   48950 k8s_discovery_worker.go:50] Discovery timeout is 3m0s
I1003 15:50:31.386860   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.386880   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.386899   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387045   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387071   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387088   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387110   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387128   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387157   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387174   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387191   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387219   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387237   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387253   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387270   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387287   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387315   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387336   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387353   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
I1003 15:50:31.387380   48950 k8s_discovery_worker.go:50] Discovery timeout is 1m0s
W1003 15:50:34.045539   48950 business_app_processor.go:79] Failed to list applications from app.k8s.io/v1beta1: the server could not find the requested resource
W1003 15:50:34.046474   48950 turbo_policy_processor.go:28] Failed to list SLOHorizontalScales: no kind is registered for the type v1alpha1.SLOHorizontalScaleList in scheme "k8s.io/client-go/kubernetes/scheme/register.go:74".
W1003 15:50:34.048035   48950 operator_resource_mapping.go:97] No OperatorResourceMapping CR discovered: failed to get OperatorResourceMapping CRs: the server could not find the requested resource. Create operator-resource-mapping CR to control Operator managed resources.
I1003 15:50:34.051382   48950 kubelet_client.go:314] Node kind-worker3 is running with linux/amd64.
I1003 15:50:34.051693   48950 kubelet_client.go:314] Node kind-control-plane is running with linux/amd64.
I1003 15:50:34.051891   48950 kubelet_client.go:314] Node kind-worker is running with linux/amd64.
I1003 15:50:34.052443   48950 kubelet_client.go:314] Node kind-worker2 is running with linux/amd64.
W1003 15:50:34.073252   48950 kubelet_client.go:333] Failed to get CPU frequency for node kind-worker2 from kubelet: the server could not find the requested resource. Will try job based getter.
W1003 15:50:34.073860   48950 kubelet_client.go:333] Failed to get CPU frequency for node kind-worker3 from kubelet: the server could not find the requested resource. Will try job based getter.
E1003 15:50:34.083402   48950 kubelet_client.go:397] Failed to get CPU frequency from job on node kind-worker2: error creating cpufreq job for node: kind-worker2: Job.batch "kubeturbo-cpufreq-1e6l70348orrc" is invalid: spec.template.spec.containers[0].image: Required value.
W1003 15:50:34.084341   48950 kubelet_client.go:333] Failed to get CPU frequency for node kind-worker from kubelet: the server could not find the requested resource. Will try job based getter.
E1003 15:50:34.084853   48950 kubelet_client.go:397] Failed to get CPU frequency from job on node kind-worker3: error creating cpufreq job for node: kind-worker3: Job.batch "kubeturbo-cpufreq-1e6l70349b5g5" is invalid: spec.template.spec.containers[0].image: Required value.
W1003 15:50:34.085332   48950 kubelet_client.go:333] Failed to get CPU frequency for node kind-control-plane from kubelet: the server could not find the requested resource. Will try job based getter.
E1003 15:50:34.091582   48950 kubelet_client.go:397] Failed to get CPU frequency from job on node kind-control-plane: error creating cpufreq job for node: kind-control-plane: Job.batch "kubeturbo-cpufreq-1e6l7034k8mrg" is invalid: spec.template.spec.containers[0].image: Required value.
E1003 15:50:34.092056   48950 kubelet_client.go:397] Failed to get CPU frequency from job on node kind-worker: error creating cpufreq job for node: kind-worker: Job.batch "kubeturbo-cpufreq-1e6l7034janf8" is invalid: spec.template.spec.containers[0].image: Required value.
W1003 15:50:34.329363   48950 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-4lvxk/test-qcvjq-986b74d87-q54qq mounted pod-move-test from volume test-pv-9kptr: missing metrics Used
W1003 15:50:34.329444   48950 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-5qcm6/test-x88rs-696cf77fc7-l6nl5 mounted pod-move-test from volume test-pv-s8wds: missing metrics Used
W1003 15:50:34.329486   48950 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-dn99h/test-sv4j7-5dcd66c8fc-xvskg mounted pod-move-test from volume test-pv-kb7rc: missing metrics Used
W1003 15:50:34.329525   48950 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-mnvs9/test-62g6f-855b9fc9f6-ftvz5 mounted pod-move-test from volume test-pv-48q87: missing metrics Used
W1003 15:50:34.329565   48950 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-rz5v6/test-9dj2m-68f6857d49-jbdv8 mounted pod-move-test from volume test-pv-8252w: missing metrics Used
W1003 15:50:34.329669   48950 pod_entity_dto_builder.go:467] Cannot build commodity StorageAmount bought by pod kubeturbo-test-discovery-test-sbkvx/test-7cw7z-55457946dc-vxgbb mounted pod-move-test from volume test-pv-rtflt: missing metrics Used
E1003 15:50:34.378126   48950 namespace_discovery_worker.go:75] Missing quota metrics for namespace default
E1003 15:50:34.378274   48950 namespace_discovery_worker.go:75] Missing quota metrics for namespace kube-node-lease
E1003 15:50:34.378290   48950 namespace_discovery_worker.go:75] Missing quota metrics for namespace kube-public
I1003 15:50:34.378440   48950 container_spec_discovery_worker.go:53] ContainerSpec will aggregate Containers utilization data by 'all utilization data strategy'
I1003 15:50:34.378461   48950 container_spec_discovery_worker.go:61] ContainerSpec will aggregate Containers usage data by 'average usage data strategy'
STEP: Reading cluster configuration
Oct  3 15:50:31.318: INFO: >>> kubeConfig: /root/.kube/kind.config
Oct  3 15:50:31.327: INFO: >>> kubeContext: kind-kind
STEP: Creating a namespace to execute the test in
STEP: Created test namespace kubeturbo-test-discovery-test-4lvxk
Oct  3 15:50:34.378: INFO: PV affinity is not honored

------------------------------
• Failure [3.060 seconds]
Discover Cluster
/opt/git/kubeturbo/test/integration/discovery.go:70
  discovering pod with pv having affinity rules
  /opt/git/kubeturbo/test/integration/discovery.go:273
    discovering with pv with affinity rules [It]
    /opt/git/kubeturbo/test/integration/discovery.go:274

    Oct  3 15:50:34.378: PV affinity is not honored

    /opt/git/kubeturbo/test/integration/discovery.go:320
------------------------------
SSSSSSSSSSSSSSSS

Summarizing 1 Failure:

[Fail] Discover Cluster discovering pod with pv having affinity rules [It] discovering with pv with affinity rules 
/opt/git/kubeturbo/test/integration/discovery.go:320

Ran 1 of 28 Specs in 3.064 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 27 Skipped
--- FAIL: TestIntegration (3.08s)
FAIL
```
