### PR TITLE
[OM-90703] Generate reconfigure action for NotReady node

### DIFF
--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -397,7 +397,7 @@ func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*prot
 	// Discovery worker for creating Group DTOs
 	entityGroupDiscoveryWorker := worker.Newk8sEntityGroupDiscoveryWorker(clusterSummary, targetID)
 	groupDTOs, _ := entityGroupDiscoveryWorker.Do(result.EntityGroups, result.SidecarContainerSpecs,
-		result.PodsWithVolumes, result.UnknownStateNodes)
+		result.PodsWithVolumes, result.NotReadyNodes)
 
 	glog.V(2).Infof("There are totally %d groups DTOs", len(groupDTOs))
 	if glog.V(4) {

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -132,7 +132,7 @@ type TaskResult struct {
 	podVolumeMetrics      []*repository.PodVolumeMetrics
 	sidecarContainerSpecs []string
 	podsWithVolumes       []string
-	unknownStateNodes     []string
+	notReadyNodes         []string
 }
 
 func NewTaskResult(workerID string, state TaskResultState) *TaskResult {
@@ -186,8 +186,8 @@ func (r *TaskResult) PodWithVolumes() []string {
 	return r.podsWithVolumes
 }
 
-func (r *TaskResult) UnknownStateNodes() []string {
-	return r.unknownStateNodes
+func (r *TaskResult) NotReadyNodes() []string {
+	return r.notReadyNodes
 }
 
 func (r *TaskResult) Err() error {
@@ -244,7 +244,7 @@ func (r *TaskResult) WithPodsWithVolumes(podsWithVolumes []string) *TaskResult {
 	return r
 }
 
-func (r *TaskResult) WithUnknownStateNodes(unknownStateNodes []string) *TaskResult {
-	r.unknownStateNodes = unknownStateNodes
+func (r *TaskResult) WithNotReadyNodes(notReadyNodes []string) *TaskResult {
+	r.notReadyNodes = notReadyNodes
 	return r
 }

--- a/pkg/discovery/worker/result_collector.go
+++ b/pkg/discovery/worker/result_collector.go
@@ -24,7 +24,7 @@ type DiscoveryResult struct {
 	PodEntitiesMap        map[string]*repository.KubePod
 	SidecarContainerSpecs []string
 	PodsWithVolumes       []string
-	UnknownStateNodes     []string
+	NotReadyNodes         []string
 	SuccessCount          int
 	ErrorCount            int
 }
@@ -76,7 +76,7 @@ func (rc *ResultCollector) Collect(count int) *DiscoveryResult {
 					result.ContainerSpecMetrics = append(result.ContainerSpecMetrics, taskResult.ContainerSpecMetrics()...)
 					result.SidecarContainerSpecs = append(result.SidecarContainerSpecs, taskResult.SidecarContainerSpecs()...)
 					result.PodsWithVolumes = append(result.PodsWithVolumes, taskResult.PodWithVolumes()...)
-					result.UnknownStateNodes = append(result.UnknownStateNodes, taskResult.UnknownStateNodes()...)
+					result.NotReadyNodes = append(result.NotReadyNodes, taskResult.NotReadyNodes()...)
 				}
 				wg.Done()
 			}

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -257,6 +257,8 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 
 	mergedEntityMetadataBuilder = mergedEntityMetadataBuilder.WithMergePropertiesStrategy(proto.MergedEntityMetadata_MERGE_IF_NOT_PRESENT)
 
+	boughtCommTypes := []proto.CommodityDTO_CommodityType{proto.CommodityDTO_CLUSTER}
+
 	return mergedEntityMetadataBuilder.
 		PatchSoldMetadata(proto.CommodityDTO_CLUSTER, fieldsCapactiy).
 		PatchSoldMetadata(proto.CommodityDTO_VMPM_ACCESS, fieldsCapactiy).
@@ -272,6 +274,7 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 		PatchSoldMetadata(proto.CommodityDTO_VMEM_REQUEST_QUOTA, fieldsUsedCapacity).
 		PatchSoldMetadata(proto.CommodityDTO_NUMBER_CONSUMERS, fieldsUsedCapacity).
 		PatchSoldMetadata(proto.CommodityDTO_VSTORAGE, fieldsUsedCapacity).
+		PatchBoughtList(proto.EntityDTO_CONTAINER_PLATFORM_CLUSTER, boughtCommTypes).
 		Build()
 }
 
@@ -289,7 +292,9 @@ func (f *SupplyChainFactory) buildNodeSupplyBuilder() (*proto.TemplateDTO, error
 		Sells(numPodNumConsumersTemplateComm). // sells to Pods
 		Sells(vStorageTemplateComm).           // sells to Pods
 		Sells(taintTemplateCommWithKey).
-		Sells(labelTemplateCommWithKey)
+		Sells(labelTemplateCommWithKey).
+		Provider(proto.EntityDTO_CONTAINER_PLATFORM_CLUSTER, proto.Provider_HOSTING).
+		Buys(clusterTemplateCommWithKey) // buys from cluster
 	// also sells Cluster to Pods
 
 	return nodeSupplyChainNodeBuilder.Create()


### PR DESCRIPTION
## Intention
Generate reconfigure action for nodes that are in **NotReady** status

## Implementation
Following market convention, for a node that is NotReady, we will do the following:
* Make that node buy a `Cluster` commodity with a key `Node-<uuid>-NotReady` from the Cluster entity
* The Cluster entity does **NOT** sell the same commodity
* Make sure the node is in **Active** state

With the above changes, market will be forced to generate a **Reconfigure** action for the node (changes on the server side are needed).

This PR also rename the existing UnknownStateNodes to NotReadyNodes. 

Note: This change is not hidden under a feature flag because without changes in the server, the newly created shopping list is not movable and Market will not run placement for this shopping list, and as a result no Reconfigure action will be generated.

## Test

![image](https://user-images.githubusercontent.com/10012486/194131550-d452826d-2521-4968-bb03-94de48166343.png)


![image](https://user-images.githubusercontent.com/10012486/194131189-87e8a535-ed3f-4ce0-a8ce-052007dfc002.png)


