### PR TITLE
[OM-90331] Introduce limit on the number of resources returned on workload controller list API calls

### DIFF
--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -22,9 +22,11 @@ import (
 
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	"github.com/turbonomic/kubeturbo/pkg/features"
 	"github.com/turbonomic/kubeturbo/pkg/turbostore"
 	commonutil "github.com/turbonomic/kubeturbo/pkg/util"
 	policyv1alpha1 "github.com/turbonomic/turbo-crd/api/v1alpha1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 const (
@@ -281,6 +283,11 @@ func (s *ClusterScraper) GetAllEndpoints() ([]*api.Endpoints, error) {
 }
 
 func (s *ClusterScraper) GetResources(resource schema.GroupVersionResource) ([]unstructured.Unstructured, error) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.PaginateAPICalls) {
+		list, err := s.DynamicClient.Resource(resource).Namespace(api.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		return list.Items, err
+	}
+
 	items := []unstructured.Unstructured{}
 	continueList := ""
 	// TODO: Is there a possibility of this loop never exiting?

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -33,6 +33,8 @@ const (
 	machineSetNodePoolPrefix = "machineset"
 	// Expiration of cached pod controller info.
 	defaultCacheTTL = 12 * time.Hour
+	// Number of max items we query in each workload controller list API calls
+	defaultMaxListQueryItems = 400
 )
 
 var (
@@ -53,7 +55,7 @@ type ClusterScraperInterface interface {
 	GetKubernetesServiceID() (svcID string, err error)
 	GetAllPVs() ([]*api.PersistentVolume, error)
 	GetAllPVCs() ([]*api.PersistentVolumeClaim, error)
-	GetResources(resource schema.GroupVersionResource) (*unstructured.UnstructuredList, error)
+	GetResources(resource schema.GroupVersionResource) ([]unstructured.Unstructured, error)
 	GetMachineSetToNodeUIDsMap(nodes []*api.Node) map[string][]string
 	GetAllTurboSLOScalings() ([]policyv1alpha1.SLOHorizontalScale, error)
 	GetAllTurboPolicyBindings() ([]policyv1alpha1.PolicyBinding, error)
@@ -278,8 +280,25 @@ func (s *ClusterScraper) GetAllEndpoints() ([]*api.Endpoints, error) {
 	return s.GetEndpoints(api.NamespaceAll, listOption)
 }
 
-func (s *ClusterScraper) GetResources(resource schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
-	return s.DynamicClient.Resource(resource).Namespace(api.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+func (s *ClusterScraper) GetResources(resource schema.GroupVersionResource) ([]unstructured.Unstructured, error) {
+	items := []unstructured.Unstructured{}
+	continueList := ""
+	// TODO: Is there a possibility of this loop never exiting?
+	// The documentation states that the APIs reliably return correct values for continue
+	for {
+		listOptions := metav1.ListOptions{Limit: int64(defaultMaxListQueryItems), Continue: continueList}
+		listItems, err := s.DynamicClient.Resource(resource).Namespace(api.NamespaceAll).List(context.TODO(), listOptions)
+		if err != nil {
+			return items, err
+		}
+		items = append(items, listItems.Items...)
+		if listItems.GetContinue() == "" {
+			break
+		}
+		continueList = listItems.GetContinue()
+	}
+
+	return items, nil
 }
 
 func (s *ClusterScraper) GetKubernetesServiceID() (svcID string, err error) {

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -367,8 +367,8 @@ func (s *MockClusterScrapper) GetAllPVCs() ([]*v1.PersistentVolumeClaim, error) 
 	return nil, fmt.Errorf("GetAllPVCs Not implemented")
 }
 
-func (s *MockClusterScrapper) GetResources(schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
-	return &unstructured.UnstructuredList{}, nil
+func (s *MockClusterScrapper) GetResources(schema.GroupVersionResource) ([]unstructured.Unstructured, error) {
+	return []unstructured.Unstructured{}, nil
 }
 
 func (s *MockClusterScrapper) GetMachineSetToNodeUIDsMap(nodes []*v1.Node) map[string][]string {

--- a/pkg/discovery/processor/controller_processor.go
+++ b/pkg/discovery/processor/controller_processor.go
@@ -88,7 +88,7 @@ func (cp *ControllerProcessor) cacheAllControllers() {
 	}
 	controllerMap := make(map[string]*repository.K8sController)
 	for _, controller := range supportedControllers {
-		list, err := cp.ClusterInfoScraper.GetResources(controller)
+		items, err := cp.ClusterInfoScraper.GetResources(controller)
 		if err != nil {
 			if apierrors.IsNotFound(err) && strings.Contains(err.Error(), "the server could not find the requested resource") {
 				glog.V(3).Infof("Resource %v not found ", controller.Resource)
@@ -97,7 +97,7 @@ func (cp *ControllerProcessor) cacheAllControllers() {
 			}
 			continue
 		}
-		for _, item := range list.Items {
+		for _, item := range items {
 			uid := string(item.GetUID())
 			kind := item.GetKind()
 			name := item.GetName()

--- a/pkg/discovery/util/const.go
+++ b/pkg/discovery/util/const.go
@@ -14,6 +14,7 @@ const (
 	BASE2UNIT float64 = 1 << (10 * iota)
 	BASE2KILO
 	BASE2MEGA
+	BASE2GIGA
 	// Add more when needed
 )
 
@@ -50,6 +51,10 @@ func Base2BytesToKilobytes(val float64) float64 {
 
 func Base2BytesToMegabytes(val float64) float64 {
 	return val / BASE2MEGA
+}
+
+func Base2BytesToGigabytes(val float64) float64 {
+	return val / BASE2GIGA
 }
 
 func Base2MegabytesToBytes(val float64) float64 {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -49,6 +49,13 @@ const (
 	// This gate enables Go runtime soft memory limit as explained in
 	// https://pkg.go.dev/runtime/debug#SetMemoryLimit
 	GoMemLimit featuregate.Feature = "GoMemLimit"
+
+	// PaginateAPICalls owner: @irfanurehman
+	// alpha:
+	//
+	// Pagination support for list API calls to API server querying workload controllers
+	// Without this feature gate the whole list is requested in a single list API call.
+	PaginateAPICalls featuregate.Feature = "PaginateAPICalls"
 )
 
 func init() {
@@ -68,4 +75,5 @@ var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	GitopsApps:             {Default: false, PreRelease: featuregate.Alpha},
 	HonorAzLabelPvAffinity: {Default: true, PreRelease: featuregate.Alpha},
 	GoMemLimit:             {Default: false, PreRelease: featuregate.Alpha},
+	PaginateAPICalls:       {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -42,20 +42,17 @@ const (
 	// of the node which the pod is currently running on and also enable honoring the PV affninity on a pod move
 	HonorAzLabelPvAffinity featuregate.Feature = "HonorAzLabelPvAffinity"
 
-	// GoMemLimit owner: @mengding
+	// MemoryOptimisations owner: @mengding @irfanurrehman
 	// alpha:
+	// This flag enables below optimisations
 	//
 	// Go runtime soft memory limit support
 	// This gate enables Go runtime soft memory limit as explained in
 	// https://pkg.go.dev/runtime/debug#SetMemoryLimit
-	GoMemLimit featuregate.Feature = "GoMemLimit"
-
-	// PaginateAPICalls owner: @irfanurehman
-	// alpha:
 	//
 	// Pagination support for list API calls to API server querying workload controllers
 	// Without this feature gate the whole list is requested in a single list API call.
-	PaginateAPICalls featuregate.Feature = "PaginateAPICalls"
+	MemoryOptimisations featuregate.Feature = "MemoryOptimisations"
 )
 
 func init() {
@@ -74,6 +71,5 @@ var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	ThrottlingMetrics:      {Default: true, PreRelease: featuregate.Beta},
 	GitopsApps:             {Default: false, PreRelease: featuregate.Alpha},
 	HonorAzLabelPvAffinity: {Default: true, PreRelease: featuregate.Alpha},
-	GoMemLimit:             {Default: false, PreRelease: featuregate.Alpha},
-	PaginateAPICalls:       {Default: false, PreRelease: featuregate.Alpha},
+	MemoryOptimisations:    {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -55,4 +55,23 @@ var (
 	K8sAPIJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1"}
 	// The API group under which CronJob are exposed by the k8s cluster
 	K8sAPICronJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1beta1"}
+
+	// Number of items that should be requested in each workload controller
+	// list API to ensure no OOMs occur.
+	// This value is calculated from cgroup MEMLIMIT using the below expression:
+	// 5000 * m; where m is memlimit in GB (5000 items per GB of memlimit)
+	// In our experiments we have observed that approximately 10k resources
+	// consume a GB of memory. This is along with other portions of discovery also
+	// allocating and freeing the memory in parallel.
+
+	// We leave half of the above buffer space being conservative and arrive at
+	// 5000 resources per 1GB of memory available for kubeturbos usage.
+	//
+	// In the absence of any MEMLIMIT set, we limit the number of resources requested in
+	// each call to fill up max of 8GB ie 40000 (=8*5000)
+	// This default is quite unlikelt to be used as Cgroup limit will always be available
+	// atleast on linux based systems. If the container limit is not set, cgroup limit will
+	// be available as nodes limit.
+	// This will be used for non linux systems, eg kubeturbo local run on mac.
+	ItemsPerListQuery = 40000
 )


### PR DESCRIPTION
**Intent**
Introduces optimisation to handle https://vmturbo.atlassian.net/browse/OM-90331

**Background**
We use `list` api calls for query all resources including the workload controller resources from api server in our discovery cycles. In large topologies, we have seen that the numbers per cluster can be in tens of thousands for each resource, especially replicasets, where multiple older copy of the resources exist to retain history over deployment updates. This optimisations uses max items as `400` per list api call to cap the size of the buffers allocated by k8s client per API call.

**Implementation**
Use `ListOptions` `Limit` field to limit the number of items returned per query for the workload controller `List` api calls

**Testing**
The number of entities returned with and without the change are same with relationships (parent, grandparent pf pods) intact.

With code from kubeturbo latest master
<img width="422" alt="image" src="https://user-images.githubusercontent.com/10027921/194561800-a8a275f6-11bf-41b3-954d-dda9db601669.png">

With updated code (2 new pods came into existence)
<img width="422" alt="image" src="https://user-images.githubusercontent.com/10027921/194561665-534b67ce-dbcb-4fbf-81df-27dd9b57d8c9.png">


