### PR TITLE
[OM-90331] Memory optimisations with updated feature flag name

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -131,6 +131,9 @@ type VMTServer struct {
 	// Garbage collection (leaked pods) interval config
 	GCIntervalMin int
 
+	// Number of workload controller items the list api call should request for
+	ItemsPerListQuery int
+
 	// The Openshift SCC list allowed for action execution
 	sccSupport []string
 
@@ -212,6 +215,7 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.DiscoverySamples, "discovery-samples", DefaultDiscoverySamples, "The number of resource usage data samples to be collected from kubelet in each full discovery cycle. This should be no larger than 60.")
 	fs.IntVar(&s.DiscoverySampleIntervalSec, "discovery-sample-interval", DefaultDiscoverySampleIntervalSec, "The discovery interval in seconds to collect additional resource usage data samples from kubelet. This should be no smaller than 10 seconds.")
 	fs.IntVar(&s.GCIntervalMin, "garbage-collection-interval", DefaultGCIntervalMin, "The garbage collection interval in minutes for possible leaked pods from actions failed because of kubeturbo restarts. Default value is 20 mins.")
+	fs.IntVar(&s.ItemsPerListQuery, "items-per-list-query", 0, "Number of workload controller items the list api call should request for.")
 	fs.StringSliceVar(&s.sccSupport, "scc-support", defaultSccSupport, "The SCC list allowed for executing pod actions, e.g., --scc-support=restricted,anyuid or --scc-support=* to allow all. Default allowed scc is [restricted].")
 	// So far we have noticed cluster api support only in openshift clusters and our implementation works only for openshift
 	// It thus makes sense to have openshifts machine api namespace as our default cluster api namespace
@@ -366,7 +370,7 @@ func (s *VMTServer) Run() {
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.GoMemLimit) {
-		glog.V(2).Info("GoMemLimit feature is enabled.")
+		glog.V(2).Info("Memory Optimisations are enabled.")
 		// Set Go runtime soft memory limit: https://pkg.go.dev/runtime/debug#SetMemoryLimit
 		// Set Go runtime soft memory limit through the AUTOMEMLIMIT environment variable.
 		// AUTOMEMLIMIT configures how much memory of the cgroup's memory limit should be set as Go runtime
@@ -377,8 +381,30 @@ func (s *VMTServer) Run() {
 		// AUTOMEMLIMIT_DEBUG environment variable enables debug logging of AUTOMEMLIMIT
 		_ = os.Setenv("AUTOMEMLIMIT_DEBUG", "true")
 		memlimit.SetGoMemLimitWithEnv()
+		if s.ItemsPerListQuery == 0 {
+			limit, err := memlimit.FromCgroup()
+			if err != nil {
+				// This is very unlikely because in absense of any limit set in container resources
+				// we will get the cgroup limit as the nodes available/usable memory limit
+				glog.Errorf("Error retrieving memory limit (%v): %v.", limit, err)
+			} else if limit == 0 {
+				// This is very unlikely because in absense of any limit set in container resources
+				// we will get the cgroup limit as the nodes available/usable memory limit
+				glog.Error("Limit found set to zero (0).")
+			} else {
+				glog.V(2).Infof("Cgroup memlimit is set as %v.", limit)
+				util.ItemsPerListQuery = calculateListAPIItemsCount(float64(limit))
+			}
+		} else {
+			if s.ItemsPerListQuery < 10 {
+				glog.Warningf("Arg --items-per-list-query is set too low (%v), capping it to a minimum of 10 items.", s.ItemsPerListQuery)
+				s.ItemsPerListQuery = 10
+			}
+			util.ItemsPerListQuery = s.ItemsPerListQuery
+		}
+		glog.V(2).Infof("List Query Items Count is set to %v.", util.ItemsPerListQuery)
 	} else {
-		glog.V(2).Info("GoMemLimit feature is not enabled.")
+		glog.V(2).Info("Memory Optimisations are not enabled.")
 	}
 
 	// Collect target and probe info such as master host, server version, probe container image, etc
@@ -507,6 +533,15 @@ func handleExit(disconnectFunc disconnectFromTurboFunc) { // k8sTAPService *kube
 			disconnectFunc()
 		}
 	}()
+}
+
+// The rational behind this calculation
+// Memory used in other areas approx = 500MB (conservatively).
+// heap-to-memory-limit ratio = 0.9
+//
+// ItemsPerListQuery = (mem_limit_gb * 0.9 - 0.5) * 5K
+func calculateListAPIItemsCount(memLimit float64) int {
+	return int(5000 * (nodeUtil.Base2BytesToGigabytes(memLimit)*0.9 - 0.5))
 }
 
 func discoverk8sAPIResourceGV(client *kubernetes.Clientset, resourceName string) (schema.GroupVersion, error) {

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -36,8 +36,6 @@ const (
 	machineSetNodePoolPrefix = "machineset"
 	// Expiration of cached pod controller info.
 	defaultCacheTTL = 12 * time.Hour
-	// Number of max items we query in each workload controller list API calls
-	defaultMaxListQueryItems = 400
 )
 
 var (
@@ -283,8 +281,11 @@ func (s *ClusterScraper) GetAllEndpoints() ([]*api.Endpoints, error) {
 }
 
 func (s *ClusterScraper) GetResources(resource schema.GroupVersionResource) ([]unstructured.Unstructured, error) {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.PaginateAPICalls) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.GoMemLimit) {
 		list, err := s.DynamicClient.Resource(resource).Namespace(api.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		if err != nil || list == nil {
+			return nil, err
+		}
 		return list.Items, err
 	}
 
@@ -293,7 +294,7 @@ func (s *ClusterScraper) GetResources(resource schema.GroupVersionResource) ([]u
 	// TODO: Is there a possibility of this loop never exiting?
 	// The documentation states that the APIs reliably return correct values for continue
 	for {
-		listOptions := metav1.ListOptions{Limit: int64(defaultMaxListQueryItems), Continue: continueList}
+		listOptions := metav1.ListOptions{Limit: int64(commonutil.ItemsPerListQuery), Continue: continueList}
 		listItems, err := s.DynamicClient.Resource(resource).Namespace(api.NamespaceAll).List(context.TODO(), listOptions)
 		if err != nil {
 			return items, err

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -367,8 +367,8 @@ func (s *MockClusterScrapper) GetAllPVCs() ([]*v1.PersistentVolumeClaim, error) 
 	return nil, fmt.Errorf("GetAllPVCs Not implemented")
 }
 
-func (s *MockClusterScrapper) GetResources(schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
-	return &unstructured.UnstructuredList{}, nil
+func (s *MockClusterScrapper) GetResources(schema.GroupVersionResource) ([]unstructured.Unstructured, error) {
+	return []unstructured.Unstructured{}, nil
 }
 
 func (s *MockClusterScrapper) GetMachineSetToNodesMap(nodes []*v1.Node) map[string][]*v1.Node {

--- a/pkg/discovery/processor/controller_processor.go
+++ b/pkg/discovery/processor/controller_processor.go
@@ -88,7 +88,7 @@ func (cp *ControllerProcessor) cacheAllControllers() {
 	}
 	controllerMap := make(map[string]*repository.K8sController)
 	for _, controller := range supportedControllers {
-		list, err := cp.ClusterInfoScraper.GetResources(controller)
+		items, err := cp.ClusterInfoScraper.GetResources(controller)
 		if err != nil {
 			if apierrors.IsNotFound(err) && strings.Contains(err.Error(), "the server could not find the requested resource") {
 				glog.V(3).Infof("Resource %v not found ", controller.Resource)
@@ -97,7 +97,7 @@ func (cp *ControllerProcessor) cacheAllControllers() {
 			}
 			continue
 		}
-		for _, item := range list.Items {
+		for _, item := range items {
 			uid := string(item.GetUID())
 			kind := item.GetKind()
 			name := item.GetName()

--- a/pkg/discovery/util/const.go
+++ b/pkg/discovery/util/const.go
@@ -14,6 +14,7 @@ const (
 	BASE2UNIT float64 = 1 << (10 * iota)
 	BASE2KILO
 	BASE2MEGA
+	BASE2GIGA
 	// Add more when needed
 )
 
@@ -50,6 +51,10 @@ func Base2BytesToKilobytes(val float64) float64 {
 
 func Base2BytesToMegabytes(val float64) float64 {
 	return val / BASE2MEGA
+}
+
+func Base2BytesToGigabytes(val float64) float64 {
+	return val / BASE2GIGA
 }
 
 func Base2MegabytesToBytes(val float64) float64 {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -49,6 +49,13 @@ const (
 	// This gate enables Go runtime soft memory limit as explained in
 	// https://pkg.go.dev/runtime/debug#SetMemoryLimit
 	GoMemLimit featuregate.Feature = "GoMemLimit"
+
+	// PaginateAPICalls owner: @irfanurehman
+	// alpha:
+	//
+	// Pagination support for list API calls to API server querying workload controllers
+	// Without this feature gate the whole list is requested in a single list API call.
+	PaginateAPICalls featuregate.Feature = "PaginateAPICalls"
 )
 
 func init() {
@@ -68,4 +75,5 @@ var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	GitopsApps:             {Default: false, PreRelease: featuregate.Alpha},
 	HonorAzLabelPvAffinity: {Default: true, PreRelease: featuregate.Alpha},
 	GoMemLimit:             {Default: false, PreRelease: featuregate.Alpha},
+	PaginateAPICalls:       {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -42,20 +42,17 @@ const (
 	// of the node which the pod is currently running on and also enable honoring the PV affninity on a pod move
 	HonorAzLabelPvAffinity featuregate.Feature = "HonorAzLabelPvAffinity"
 
-	// GoMemLimit owner: @mengding
+	// GoMemLimit (MemoryOptimisations) owner: @mengding @irfanurrehman
 	// alpha:
+	// This flag enables below optimisations
 	//
 	// Go runtime soft memory limit support
 	// This gate enables Go runtime soft memory limit as explained in
 	// https://pkg.go.dev/runtime/debug#SetMemoryLimit
-	GoMemLimit featuregate.Feature = "GoMemLimit"
-
-	// PaginateAPICalls owner: @irfanurehman
-	// alpha:
 	//
 	// Pagination support for list API calls to API server querying workload controllers
 	// Without this feature gate the whole list is requested in a single list API call.
-	PaginateAPICalls featuregate.Feature = "PaginateAPICalls"
+	GoMemLimit featuregate.Feature = "GoMemLimit"
 )
 
 func init() {
@@ -75,5 +72,4 @@ var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	GitopsApps:             {Default: false, PreRelease: featuregate.Alpha},
 	HonorAzLabelPvAffinity: {Default: true, PreRelease: featuregate.Alpha},
 	GoMemLimit:             {Default: false, PreRelease: featuregate.Alpha},
-	PaginateAPICalls:       {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -55,4 +55,17 @@ var (
 	K8sAPIJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1"}
 	// The API group under which CronJob are exposed by the k8s cluster
 	K8sAPICronJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1beta1"}
+
+	// Number of items that should be requested in each workload controller
+	// list API to ensure no OOMs occur.
+	// This value is calculated from cgroup MEMLIMIT using the below expression:
+	// (mem_limit_gb * 0.9 - 0.5) * 5K; where m is memlimit in GB
+	//
+	// In the absence of any MEMLIMIT set, we limit the number of resources requested in
+	// each call to fill up max of 8GB =(mem_limit_gb * 0.9 - 0.5) * 5000 = 33500
+	// This default is quite unlikely to be used as Cgroup limit will always be available
+	// atleast on linux based systems. If the container limit is not set, cgroup limit will
+	// be available as nodes limit.
+	// This will be used for non linux systems, eg kubeturbo local run on mac.
+	ItemsPerListQuery = 33500
 )


### PR DESCRIPTION
**Intent**
This is resubmitting the changes as merged in https://github.com/turbonomic/kubeturbo/pull/741 and later reverted by https://github.com/turbonomic/kubeturbo/pull/745. This was done to ensure correct feature flag compatibility and ensure that the changes go in the next release and not the current one.

The original PR introduces optimisations to handle https://vmturbo.atlassian.net/browse/OM-90331

**Background**
We use `list` api calls for query all resources including the workload controller resources from api server in our discovery cycles. In large topologies, we have seen that the numbers per cluster can be in tens of thousands for each resource, especially replicasets, where multiple older copy of the resources exist to retain history over deployment updates. This optimisations uses max items as `400` per list api call to cap the size of the buffers allocated by k8s client per API call.

**Implementation**
Use `ListOptions` `Limit` field to limit the number of items returned per query for the workload controller `List` api calls

**Testing**
The number of entities returned with and without the change are same with relationships (parent, grandparent pf pods) intact.

With code from kubeturbo latest master
<img width="422" alt="image" src="https://user-images.githubusercontent.com/10027921/194561800-a8a275f6-11bf-41b3-954d-dda9db601669.png">

With updated code (2 new pods came into existence)
<img width="422" alt="image" src="https://user-images.githubusercontent.com/10027921/194561665-534b67ce-dbcb-4fbf-81df-27dd9b57d8c9.png">


