### PR TITLE
[OM-92054]: create static pod group

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -83,7 +83,7 @@ func NewPodEntityDTOBuilder(sink *metrics.EntityMetricSink, stitchingManager *st
 		namespaceUIDMap:      make(map[string]string),
 		podToVolumesMap:      make(map[string][]repository.MountedVolume),
 		nodeNameToNodeMap:    make(map[string]*repository.KubeNode),
-		MirrorPodToDaemonMap: make(map[string]bool),
+		mirrorPodToDaemonMap: make(map[string]bool),
 	}
 }
 

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -72,7 +72,7 @@ type podEntityDTOBuilder struct {
 	nodeNameToNodeMap    map[string]*repository.KubeNode
 	runningPods          []*api.Pod
 	pendingPods          []*api.Pod
-	staticPodToDaemonMap map[string]bool
+	mirrorPodToDaemonMap map[string]bool
 }
 
 func NewPodEntityDTOBuilder(sink *metrics.EntityMetricSink, stitchingManager *stitching.StitchingManager) *podEntityDTOBuilder {
@@ -83,7 +83,7 @@ func NewPodEntityDTOBuilder(sink *metrics.EntityMetricSink, stitchingManager *st
 		namespaceUIDMap:      make(map[string]string),
 		podToVolumesMap:      make(map[string][]repository.MountedVolume),
 		nodeNameToNodeMap:    make(map[string]*repository.KubeNode),
-		staticPodToDaemonMap: make(map[string]bool),
+		MirrorPodToDaemonMap: make(map[string]bool),
 	}
 }
 
@@ -117,35 +117,42 @@ func (builder *podEntityDTOBuilder) WithPendingPods(pendingPods []*api.Pod) *pod
 	return builder
 }
 
-func (builder *podEntityDTOBuilder) WithStaticPodToDaemonMap(staticPodToDaemonMap map[string]bool) *podEntityDTOBuilder {
-	builder.staticPodToDaemonMap = staticPodToDaemonMap
+func (builder *podEntityDTOBuilder) WithMirrorPodToDaemonMap(mirrorPodToDaemonMap map[string]bool) *podEntityDTOBuilder {
+	builder.mirrorPodToDaemonMap = mirrorPodToDaemonMap
 	return builder
 }
 
-func (builder *podEntityDTOBuilder) BuildEntityDTOs() ([]*proto.EntityDTO, []*proto.EntityDTO, []string) {
+func (builder *podEntityDTOBuilder) BuildEntityDTOs() ([]*proto.EntityDTO, []*proto.EntityDTO, []string, []string) {
 	glog.V(3).Infof("Building DTOs for running pods...")
-	runningPodDTOs, runningPodsWithVolumes := builder.buildDTOs(
+	runningPodDTOs, runningPodsWithVolumes, runningMirrorPodUids := builder.buildDTOs(
 		builder.runningPods, runningPodResCommTypeSold, runningPodResCommTypeBoughtFromNode)
 	glog.V(3).Infof("Built %d running pod DTOs.", len(runningPodDTOs))
 	glog.V(3).Infof("Building DTOs for pending pods...")
-	pendingPodDTOs, pendingPodsWithVolumes := builder.buildDTOs(
+	pendingPodDTOs, pendingPodsWithVolumes, pendingMirrorPodUids := builder.buildDTOs(
 		builder.pendingPods, pendingPodResCommTypeSold, pendingPodResCommTypeBoughtFromNode)
 	glog.V(3).Infof("Built %d pending pod DTOs.", len(pendingPodDTOs))
 	podsWithVolumes := append(runningPodsWithVolumes, pendingPodsWithVolumes...)
-	return runningPodDTOs, pendingPodDTOs, podsWithVolumes
+	mirrorPodUids := append(runningMirrorPodUids, pendingMirrorPodUids...)
+	return runningPodDTOs, pendingPodDTOs, podsWithVolumes, mirrorPodUids
 }
 
 // Build entityDTOs based on the given pod list.
 func (builder *podEntityDTOBuilder) buildDTOs(pods []*api.Pod, resCommTypeSold,
-	resCommTypeBoughtFromNode []metrics.ResourceType) ([]*proto.EntityDTO, []string) {
+	resCommTypeBoughtFromNode []metrics.ResourceType) ([]*proto.EntityDTO, []string, []string) {
 	var result []*proto.EntityDTO
 	var podsWithVolumes []string
+	var mirrorPodUids []string
 	for _, pod := range pods {
 		// id.
 		podID := string(pod.UID)
 		entityDTOBuilder := sdkbuilder.NewEntityDTOBuilder(proto.EntityDTO_CONTAINER_POD, podID)
 		// determine if the pod is a daemon set pod as that determines the eligibility of the pod for different actions
-		daemon := util.Daemon(pod) || builder.staticPodToDaemonMap[podID]
+		mirrorPodDaemon, hasKey := builder.mirrorPodToDaemonMap[podID]
+		daemon := util.Daemon(pod) || mirrorPodDaemon
+		if hasKey {
+			mirrorPodUids = append(mirrorPodUids, podID)
+		}
+
 		// display name.
 		displayName := util.GetPodClusterID(pod)
 		entityDTOBuilder.DisplayName(displayName)
@@ -299,7 +306,7 @@ func (builder *podEntityDTOBuilder) buildDTOs(pods []*api.Pod, resCommTypeSold,
 		}
 	}
 
-	return result, podsWithVolumes
+	return result, podsWithVolumes, mirrorPodUids
 }
 
 func (builder *podEntityDTOBuilder) isContainerMetricsAvailable(pod *api.Pod) bool {

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -397,7 +397,7 @@ func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*prot
 	// Discovery worker for creating Group DTOs
 	entityGroupDiscoveryWorker := worker.Newk8sEntityGroupDiscoveryWorker(clusterSummary, targetID)
 	groupDTOs, _ := entityGroupDiscoveryWorker.Do(result.EntityGroups, result.SidecarContainerSpecs,
-		result.PodsWithVolumes, result.NotReadyNodes)
+		result.PodsWithVolumes, result.NotReadyNodes, result.MirrorPodUids)
 
 	glog.V(2).Infof("There are totally %d groups DTOs", len(groupDTOs))
 	if glog.V(4) {

--- a/pkg/discovery/repository/kube_cluster_test.go
+++ b/pkg/discovery/repository/kube_cluster_test.go
@@ -291,7 +291,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 						},
 					},
 					Pods: []*v1.Pod{
-						// static pod apart of daemon set
+						// mirror pod apart of daemon set
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node",
@@ -307,7 +307,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 								},
 							},
 						},
-						// static pod not apart of daemon set
+						// mirror pod not apart of daemon set
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node",
@@ -323,7 +323,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 								},
 							},
 						},
-						// not a static pod
+						// not a mirror pod
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node",
@@ -339,7 +339,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 								},
 							},
 						},
-						// static pod apart of daemon set
+						// mirror pod apart of daemon set
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node2",
@@ -404,7 +404,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 						},
 					},
 					Pods: []*v1.Pod{
-						// static pod apart of daemon set
+						// mirror pod apart of daemon set
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node",
@@ -420,7 +420,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 								},
 							},
 						},
-						// static pod apart of different daemon set
+						// mirror pod apart of different daemon set
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node2",
@@ -436,7 +436,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 								},
 							},
 						},
-						// not a static pod
+						// not a mirror pod
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node3",
@@ -452,7 +452,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 								},
 							},
 						},
-						// static pod apart of daemon set
+						// mirror pod apart of daemon set
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node3",
@@ -468,7 +468,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 								},
 							},
 						},
-						// static pod apart of different daemon set
+						// mirror pod apart of different daemon set
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node4",
@@ -484,7 +484,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 								},
 							},
 						},
-						// static pod not apart of different daemon set
+						// mirror pod not apart of different daemon set
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node",
@@ -500,7 +500,7 @@ func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 								},
 							},
 						},
-						// static pod not apart of different daemon set
+						// mirror pod not apart of different daemon set
 						{
 							Spec: v1.PodSpec{
 								NodeName: "test-node2",

--- a/pkg/discovery/repository/kube_cluster_test.go
+++ b/pkg/discovery/repository/kube_cluster_test.go
@@ -224,7 +224,7 @@ type ClusterResultSummary struct {
 	Result map[string]bool
 }
 
-func TestComputeStaticPodToDaemonMap(t *testing.T) {
+func TestComputeMirrorPodToDaemonMap(t *testing.T) {
 
 	clusterSummaries := []struct {
 		s      *ClusterSummary
@@ -531,8 +531,8 @@ func TestComputeStaticPodToDaemonMap(t *testing.T) {
 	}
 
 	for _, sum := range clusterSummaries {
-		sum.s.computeStaticPodToDaemonMap()
-		assert.Equal(t, sum.result, sum.s.StaticPodToDaemonMap)
+		sum.s.computeMirrorPodToDaemonMap()
+		assert.Equal(t, sum.result, sum.s.MirrorPodToDaemonMap)
 	}
 
 }

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -133,6 +133,7 @@ type TaskResult struct {
 	sidecarContainerSpecs []string
 	podsWithVolumes       []string
 	notReadyNodes         []string
+	mirrorPodUids         []string
 }
 
 func NewTaskResult(workerID string, state TaskResultState) *TaskResult {
@@ -188,6 +189,10 @@ func (r *TaskResult) PodWithVolumes() []string {
 
 func (r *TaskResult) NotReadyNodes() []string {
 	return r.notReadyNodes
+}
+
+func (r *TaskResult) mirrorPodUids() []string {
+	return r.mirrorPodUids
 }
 
 func (r *TaskResult) Err() error {
@@ -246,5 +251,10 @@ func (r *TaskResult) WithPodsWithVolumes(podsWithVolumes []string) *TaskResult {
 
 func (r *TaskResult) WithNotReadyNodes(notReadyNodes []string) *TaskResult {
 	r.notReadyNodes = notReadyNodes
+	return r
+}
+
+func (r *TaskResult) WithMirrorPodUids(mirrorPodUids []string) *TaskResult {
+	r.mirrorPodUids = mirrorPodUids
 	return r
 }

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -191,7 +191,7 @@ func (r *TaskResult) NotReadyNodes() []string {
 	return r.notReadyNodes
 }
 
-func (r *TaskResult) mirrorPodUids() []string {
+func (r *TaskResult) MirrorPodUids() []string {
 	return r.mirrorPodUids
 }
 

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -127,7 +127,7 @@ func GetMirrorPodPrefixToNodeNames(pods []*api.Pod) map[string]sets.String {
 		}
 	}
 
-	glog.V(3).Infof("Found %+v static pod prefix keys.", len(prefixToNodeNames))
+	glog.V(3).Infof("Found %+v mirror pod prefix keys.", len(prefixToNodeNames))
 	glog.V(4).Info(prefixToNodeNames)
 	return prefixToNodeNames
 }

--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -196,7 +196,7 @@ func (worker *k8sEntityGroupDiscoveryWorker) buildMirrorPodGroup(mirrorPodUids [
 	groupDTO, err := group.StaticRegularGroup(fmt.Sprintf("Mirror-Pods-%s", worker.targetId)).
 		OfType(proto.EntityDTO_CONTAINER_POD).
 		WithEntities(mirrorPodUids).
-		WithDisplayName("Mirror Pods").
+		WithDisplayName("Mirror Pods " + worker.targetId).
 		Build()
 
 	if err != nil {

--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -196,7 +196,7 @@ func (worker *k8sEntityGroupDiscoveryWorker) buildMirrorPodGroup(mirrorPodUids [
 	groupDTO, err := group.StaticRegularGroup(fmt.Sprintf("Mirror-Pods-%s", worker.targetId)).
 		OfType(proto.EntityDTO_CONTAINER_POD).
 		WithEntities(mirrorPodUids).
-		WithDisplayName(fmt.Sprintf("All Mirror Pods of [%s]", worker.targetId)).
+		WithDisplayName("Mirror Pods").
 		Build()
 
 	if err != nil {

--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -51,7 +51,7 @@ func Newk8sEntityGroupDiscoveryWorker(cluster *repository.ClusterSummary,
 // It merges the group members belonging to the same group but discovered by different discovery workers.
 // Then it creates DTOs for the pod/container groups to be sent to the server.
 func (worker *k8sEntityGroupDiscoveryWorker) Do(entityGroupList []*repository.EntityGroup,
-	sidecarContainerSpecs, podsWithVolumes []string, notReadyNodes []string) ([]*proto.GroupDTO, error) {
+	sidecarContainerSpecs, podsWithVolumes []string, notReadyNodes []string, mirrorPodUids []string) ([]*proto.GroupDTO, error) {
 
 	var groupDTOs []*proto.GroupDTO
 
@@ -112,6 +112,8 @@ func (worker *k8sEntityGroupDiscoveryWorker) Do(entityGroupList []*repository.En
 	groupDTOs = append(groupDTOs, worker.buildPodsWithVolumesGroup(podsWithVolumes)...)
 
 	groupDTOs = append(groupDTOs, worker.buildNotReadyNodesGroup(notReadyNodes)...)
+
+	groupDTOs = append(groupDTOs, worker.buildMirrorPodGroup(mirrorPodUids)...)
 
 	// Create dynamic groups for discovered Turbo policies
 	groupDTOs = append(groupDTOs, worker.BuildTurboPolicyDTOsFromPolicyBindings()...)
@@ -184,6 +186,24 @@ func (worker *k8sEntityGroupDiscoveryWorker) buildPodsWithVolumesGroup(podsWithV
 	groupsDTOs = append(groupsDTOs, groupDTO)
 
 	return groupsDTOs
+}
+
+func (worker *k8sEntityGroupDiscoveryWorker) buildMirrorPodGroup(mirrorPodUids []string) []*proto.GroupDTO {
+	if len(mirrorPodUids) <= 0 {
+		return []*proto.GroupDTO{}
+	}
+
+	groupDTO, err := group.StaticRegularGroup(fmt.Sprintf("Mirror-Pods-%s", worker.targetId)).
+		OfType(proto.EntityDTO_CONTAINER_POD).
+		WithEntities(mirrorPodUids).
+		WithDisplayName(fmt.Sprintf("All Mirror Pods of [%s]", worker.targetId)).
+		Build()
+
+	if err != nil {
+		glog.Errorf("Error creating group of mirror pods for target [%s]. Error: %v", worker.targetId, err)
+	}
+
+	return []*proto.GroupDTO{groupDTO}
 }
 
 func (worker *k8sEntityGroupDiscoveryWorker) buildNotReadyNodesGroup(notReadyNodes []string) []*proto.GroupDTO {

--- a/pkg/discovery/worker/group_discovery_worker.go
+++ b/pkg/discovery/worker/group_discovery_worker.go
@@ -190,7 +190,7 @@ func (worker *k8sEntityGroupDiscoveryWorker) buildPodsWithVolumesGroup(podsWithV
 
 func (worker *k8sEntityGroupDiscoveryWorker) buildMirrorPodGroup(mirrorPodUids []string) []*proto.GroupDTO {
 	if len(mirrorPodUids) <= 0 {
-		return []*proto.GroupDTO{}
+		return nil
 	}
 
 	groupDTO, err := group.StaticRegularGroup(fmt.Sprintf("Mirror-Pods-%s", worker.targetId)).
@@ -201,6 +201,7 @@ func (worker *k8sEntityGroupDiscoveryWorker) buildMirrorPodGroup(mirrorPodUids [
 
 	if err != nil {
 		glog.Errorf("Error creating group of mirror pods for target [%s]. Error: %v", worker.targetId, err)
+		return nil
 	}
 
 	return []*proto.GroupDTO{groupDTO}

--- a/pkg/discovery/worker/group_discovery_worker_test.go
+++ b/pkg/discovery/worker/group_discovery_worker_test.go
@@ -15,7 +15,7 @@ func TestBuildMirrorPodGroup(t *testing.T) {
 		cluster:  &repository.ClusterSummary{},
 	}
 
-	displayName := "Mirror Pods"
+	displayName := "Mirror Pods target_id"
 	entityType := proto.EntityDTO_CONTAINER_POD
 	ids := []string{
 		"id1",

--- a/pkg/discovery/worker/group_discovery_worker_test.go
+++ b/pkg/discovery/worker/group_discovery_worker_test.go
@@ -1,0 +1,66 @@
+package worker
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+func TestBuildMirrorPodGroup(t *testing.T) {
+	worker := &k8sEntityGroupDiscoveryWorker{
+		id:       "test_id",
+		targetId: "target_id",
+		cluster:  &repository.ClusterSummary{},
+	}
+
+	displayName := "Mirror Pods"
+	entityType := proto.EntityDTO_CONTAINER_POD
+	ids := []string{
+		"id1",
+		"id2",
+	}
+	groupName := "Mirror-Pods-target_id"
+
+	tests := []struct {
+		uids     []string
+		expected []*proto.GroupDTO
+	}{
+		{
+			uids:     []string{},
+			expected: []*proto.GroupDTO{},
+		},
+		{
+			uids: ids,
+			expected: []*proto.GroupDTO{
+				newGroup(entityType, &displayName, ids, groupName, proto.GroupDTO_REGULAR, false),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		groupDTOs := worker.buildMirrorPodGroup(test.uids)
+		if !reflect.DeepEqual(test.expected, groupDTOs) {
+			t.Errorf("%s Failed. wanted: %++v, got: %++v", t.Name(), test.expected, groupDTOs)
+		}
+	}
+
+}
+
+func newGroup(entType proto.EntityDTO_EntityType, name *string, list []string, groupName string, groupT proto.GroupDTO_GroupType, resizing bool) *proto.GroupDTO {
+	return &proto.GroupDTO{
+		EntityType:  &entType,
+		DisplayName: name,
+		Info: &proto.GroupDTO_GroupName{
+			GroupName: groupName,
+		},
+		GroupType:            &groupT,
+		IsConsistentResizing: &resizing,
+		Members: &proto.GroupDTO_MemberList{
+			MemberList: &proto.GroupDTO_MembersList{
+				Member: list,
+			},
+		},
+	}
+}

--- a/pkg/discovery/worker/group_discovery_worker_test.go
+++ b/pkg/discovery/worker/group_discovery_worker_test.go
@@ -29,7 +29,7 @@ func TestBuildMirrorPodGroup(t *testing.T) {
 	}{
 		{
 			uids:     []string{},
-			expected: []*proto.GroupDTO{},
+			expected: nil,
 		},
 		{
 			uids: ids,

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -287,7 +287,7 @@ func (worker *k8sDiscoveryWorker) executeTask(currTask *task.Task) *task.TaskRes
 	entityGroups := NewGroupMetricsCollector(worker, currTask).CollectGroupMetrics()
 
 	// Build DTOs after getting the metrics
-	entityDTOs, podEntities, sidecarContainerSpecs, podsWithVolumes, notReadyNodes := worker.buildEntityDTOs(currTask)
+	entityDTOs, podEntities, sidecarContainerSpecs, podsWithVolumes, notReadyNodes, mirrorPodUids := worker.buildEntityDTOs(currTask)
 
 	// Uncomment this to dump the topology to a file for later use by the unit tests
 	// util.DumpTopology(currTask, "test-topology.dat")
@@ -314,7 +314,9 @@ func (worker *k8sDiscoveryWorker) executeTask(currTask *task.Task) *task.TaskRes
 		// List of pods with volumes
 		WithPodsWithVolumes(podsWithVolumes).
 		// List of NotReady nodes
-		WithNotReadyNodes(notReadyNodes)
+		WithNotReadyNodes(notReadyNodes).
+		// list of mirror pod UIDs
+		WithMirrorPodUids(mirrorPodUids)
 }
 
 func (worker *k8sDiscoveryWorker) addPodQuotaMetrics(podMetricsCollection PodMetricsByNodeAndNamespace) {
@@ -347,7 +349,7 @@ func (worker *k8sDiscoveryWorker) addPodQuotaMetrics(podMetricsCollection PodMet
 }
 
 func (worker *k8sDiscoveryWorker) buildEntityDTOs(currTask *task.Task) ([]*proto.EntityDTO,
-	[]*repository.KubePod, []string, []string, []string) {
+	[]*repository.KubePod, []string, []string, []string, []string) {
 	var entityDTOs []*proto.EntityDTO
 	var notReadyNodes []string
 	// Build entity DTOs for nodes
@@ -355,14 +357,14 @@ func (worker *k8sDiscoveryWorker) buildEntityDTOs(currTask *task.Task) ([]*proto
 
 	glog.V(3).Infof("Worker %s built %d node DTOs.", worker.id, len(nodeDTOs))
 	if len(nodeDTOs) == 0 {
-		return nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil
 	}
 	entityDTOs = append(entityDTOs, nodeDTOs...)
 	// Build entity DTOs for pods
-	podDTOs, runningPods, podWithVolumes := worker.buildPodDTOs(currTask)
+	podDTOs, runningPods, podWithVolumes, mirrorPodUids := worker.buildPodDTOs(currTask)
 	glog.V(3).Infof("Worker %s built %d pod DTOs.", worker.id, len(podDTOs))
 	if len(podDTOs) == 0 {
-		return entityDTOs, nil, nil, nil, nil
+		return entityDTOs, nil, nil, nil, nil, nil
 	}
 	entityDTOs = append(entityDTOs, podDTOs...)
 	// Build entity DTOs for containers from running pods
@@ -378,7 +380,7 @@ func (worker *k8sDiscoveryWorker) buildEntityDTOs(currTask *task.Task) ([]*proto
 		entityDTOs = append(entityDTOs, appEntityDTOs...)
 	}
 	glog.V(2).Infof("Worker %s built %d entity DTOs in total.", worker.id, len(entityDTOs))
-	return entityDTOs, podEntities, sidecarContainerSpecs, podWithVolumes, notReadyNodes
+	return entityDTOs, podEntities, sidecarContainerSpecs, podWithVolumes, notReadyNodes, mirrorPodUids
 }
 
 func (worker *k8sDiscoveryWorker) buildNodeDTOs(nodes []*api.Node) ([]*proto.EntityDTO, []string) {
@@ -397,15 +399,15 @@ func (worker *k8sDiscoveryWorker) buildNodeDTOs(nodes []*api.Node) ([]*proto.Ent
 }
 
 // Build DTOs for running pods
-func (worker *k8sDiscoveryWorker) buildPodDTOs(currTask *task.Task) ([]*proto.EntityDTO, []*api.Pod, []string) {
+func (worker *k8sDiscoveryWorker) buildPodDTOs(currTask *task.Task) ([]*proto.EntityDTO, []*api.Pod, []string, []string) {
 	glog.V(3).Infof("Worker %s received %d pods.", worker.id, len(currTask.PodList()))
 	cluster := currTask.Cluster()
 	if cluster == nil {
 		// This should not happen, guard anyway
 		glog.Errorf("Failed to build pod DTOs: cluster summary object is null for worker %s", worker.id)
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
-	runningPodDTOs, pendingPodDTOs, podsWithVolumes := dtofactory.
+	runningPodDTOs, pendingPodDTOs, podsWithVolumes, mirrorPodUids := dtofactory.
 		NewPodEntityDTOBuilder(worker.sink, worker.stitchingManager).
 		// Node providers
 		WithNodeNameUIDMap(cluster.NodeNameUIDMap).
@@ -419,8 +421,8 @@ func (worker *k8sDiscoveryWorker) buildPodDTOs(currTask *task.Task) ([]*proto.En
 		WithRunningPods(currTask.RunningPodList()).
 		// Pending pods
 		WithPendingPods(currTask.PendingPodList()).
-		// map of static pods to daemon flags
-		WithStaticPodToDaemonMap(cluster.StaticPodToDaemonMap).
+		// map of mirror pods to daemon flags
+		WithMirrorPodToDaemonMap(cluster.MirrorPodToDaemonMap).
 		BuildEntityDTOs()
 
 	var podDTOs []*proto.EntityDTO
@@ -434,7 +436,7 @@ func (worker *k8sDiscoveryWorker) buildPodDTOs(currTask *task.Task) ([]*proto.En
 	if len(pendingPodDTOs) > 0 {
 		podDTOs = append(podDTOs, pendingPodDTOs...)
 	}
-	return podDTOs, runningPods, podsWithVolumes
+	return podDTOs, runningPods, podsWithVolumes, mirrorPodUids
 }
 
 // Build DTOs for containers

--- a/pkg/discovery/worker/k8s_discovery_worker_test.go
+++ b/pkg/discovery/worker/k8s_discovery_worker_test.go
@@ -31,7 +31,7 @@ func TestBuildDTOsWithMissingMetrics(t *testing.T) {
 
 	currTask := task.NewTask().WithNode(node).WithPods([]*api.Pod{pod})
 
-	entityDtos, kubePods, _, _, _ := worker.buildEntityDTOs(currTask)
+	entityDtos, kubePods, _, _, _, _ := worker.buildEntityDTOs(currTask)
 	if len(entityDtos) != 0 || len(kubePods) != 0 {
 		// Nothing is built
 		t.Errorf("Error while building DTOs")

--- a/pkg/discovery/worker/result_collector.go
+++ b/pkg/discovery/worker/result_collector.go
@@ -25,6 +25,7 @@ type DiscoveryResult struct {
 	SidecarContainerSpecs []string
 	PodsWithVolumes       []string
 	NotReadyNodes         []string
+	MirrorPodUids         []string
 	SuccessCount          int
 	ErrorCount            int
 }
@@ -76,6 +77,7 @@ func (rc *ResultCollector) Collect(count int) *DiscoveryResult {
 					result.ContainerSpecMetrics = append(result.ContainerSpecMetrics, taskResult.ContainerSpecMetrics()...)
 					result.SidecarContainerSpecs = append(result.SidecarContainerSpecs, taskResult.SidecarContainerSpecs()...)
 					result.PodsWithVolumes = append(result.PodsWithVolumes, taskResult.PodWithVolumes()...)
+					result.MirrorPodUids = append(result.MirrorPodUids, taskResult.MirrorPodUids()...)
 					result.NotReadyNodes = append(result.NotReadyNodes, taskResult.NotReadyNodes()...)
 				}
 				wg.Done()


### PR DESCRIPTION
# description 
  We need a way to easily identify all mirror pods within a cluster in order to identify the static pods.
Issue: https://vmturbo.atlassian.net/browse/OM-92054


# What Changed
- created mirror pod group for display in the UI
- renamed the staticPodToDaemonMap to mirrorPodToDaemonMap

# Testing
- Deploy this version of the kubeturbo operator to any cluster with static nodes.
  - if your cluster does not have any static nodes use the k8 documentation for creating a static pod https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/
  
- ensure there should be a suspend action for VMs that implement a daemon set with static pods
- ensure that the group for mirror pods exists
<img width="2454" alt="Screen Shot 2022-11-01 at 4 36 02 PM" src="https://user-images.githubusercontent.com/8473487/199335865-7d6b8bcb-0130-4f5a-8ed8-80ce5bc0997f.png">
<img width="2399" alt="Screen Shot 2022-11-01 at 4 45 04 PM" src="https://user-images.githubusercontent.com/8473487/199337388-6f655b9b-cec1-4434-b697-64fad1b2de4b.png">
