### PR TITLE
[OM-91941] - Integration test failure fix during travis CI

### DIFF
--- a/pkg/kubeclient/cpufrequency.go
+++ b/pkg/kubeclient/cpufrequency.go
@@ -49,7 +49,7 @@ type iNodeCpuFrequencyGetter interface {
 
 // NodeCpuFrequencyGetter defines an abstract type with default methods and fields shared by all concrete types
 type NodeCpuFrequencyGetter struct {
-	mu              sync.Mutex
+	mu              *sync.Mutex
 	kubeClient      *kubernetes.Clientset
 	busyboxImage    string
 	imagePullSecret string
@@ -158,6 +158,7 @@ func NewNodeCpuFrequencyGetter(kubeClient *kubernetes.Clientset, busyboxImage, i
 		busyboxImage:    busyboxImage,
 		imagePullSecret: imagePullSecret,
 		backoffFailures: make(map[string]*backoffFailure),
+		mu:              &sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
This PR is to add lock on the map during update, since this is causing a race condition to have multiple routines accessing this map to update concurrently. This should fix the travis CI failures which are intermittently occurring