### PR TITLE
[OM-92467]: Update kubeturbo-operator base image to v1.25 to remediate vulnerability reported during synk scan

### DIFF
--- a/deploy/kubeturbo-operator/Dockerfile
+++ b/deploy/kubeturbo-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v1.22
+FROM quay.io/operator-framework/helm-operator:v1.25
 
 # Required OpenShift Labels
 LABEL name="Kubeturbo Operator" \


### PR DESCRIPTION
Intent
Remediate the vulnerability in kubeturbo-operator that was reported by synk scan related to libksba package in RH OS

Background
With the current kubeturbo-operator base image v1.22, there was a critical vulnerability on libska package that was reported by synk scan. This vulnerability was fixed under the operator-framework/helm-operator with version 1.25


Testing
Run docker scan on the local image that was created with kubeturbo-operator image version of 1.25, this change has remediated the critical vulnerability that was reported earlier by synk