### PR TITLE
OM-92056 Integration test for static pod analysis settings

### DIFF
--- a/hack/create_kind_cluster.sh
+++ b/hack/create_kind_cluster.sh
@@ -53,4 +53,8 @@ echo "Creating kind cluster"
 create-cluster
 ${kubectl_path} config use-context kind-kind
 
+
+docker cp ./test/config/static-web.yaml kind-worker2:/etc/kubernetes/manifests/
+docker cp ./test/config/static-web.yaml kind-worker3:/etc/kubernetes/manifests/
+
 echo "Cluster creation complete."

--- a/test/config/static-web.yaml
+++ b/test/config/static-web.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: static-web
+  labels:
+    role: myrole
+spec:
+  containers:
+    - name: web
+      image: nginx
+      ports:
+        - name: web
+          containerPort: 80
+          protocol: TCP

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -210,7 +210,7 @@ var _ = Describe("Discover Cluster", func() {
 
 		It("NotReady nodes should be listed in the NotReady node group", func() {
 
-			notReadyGroup := getNotReadyNodeGroup(groups)
+			notReadyGroup := getGroup(groups, "NotReady-Nodes-")
 			if notReadyGroup == nil {
 				framework.Failf("Could not find NotReady Node group")
 			}
@@ -412,6 +412,125 @@ var _ = Describe("Discover Cluster", func() {
 		})
 	})
 
+	Describe("test mirror pods", func() {
+		testName := "discovery-integration-test"
+		mirrorpod_prefix := "static-web"
+		var entities []*proto.EntityDTO = nil
+		//var groups []*proto.GroupDTO = nil
+		var delNode *corev1.Node
+		var err error
+
+		It("validate dameon settings true for multiple nodepools in a cluster with all nodes havings static pod in the pool", func() {
+
+			// Create AKS and GKE nodepools with one node in each
+			_, err = updateNodeWithLabel(kubeClient, util.NodePoolGKE, "MirrorPodTestGKE", "kind-worker2")
+			if err != nil {
+				framework.Failf("Error in updating the nodepool label")
+			}
+			_, err = updateNodeWithLabel(kubeClient, util.NodePoolAKS, "MirrorPodTestAKS", "kind-worker3")
+			if err != nil {
+				framework.Failf("Error in updating the nodepool label")
+			}
+			entityDTOs, _, Err := discoveryClient.DiscoverWithNewFramework(testName)
+			if Err != nil {
+				framework.Failf(Err.Error())
+			}
+
+			for _, entityDTO := range entityDTOs {
+				if *entityDTO.EntityType == proto.EntityDTO_CONTAINER_POD &&
+					strings.Contains(*entityDTO.DisplayName, mirrorpod_prefix) {
+					entities = append(entities, entityDTO)
+				}
+			}
+			//Validate daemon: true in ConsumerPolicy for pods
+			for _, entity := range entities {
+				if *entity.ConsumerPolicy.Daemon != true {
+					framework.Failf("Daemon set settings for %v mirror pod is false ", entity.DisplayName)
+				}
+			}
+			//groups = groupDTOs
+		})
+
+		It("validate dameon settings true when all nodes in nodepool has static pod", func() {
+
+			// Create GKE nodepools with two nodes
+			entities = nil
+			_, err = updateNodeWithLabel(kubeClient, util.NodePoolGKE, "MirrorPodTestGKE", "kind-worker2")
+			if err != nil {
+				framework.Failf("Error in updating the nodepool label")
+			}
+			_, err = updateNodeWithLabel(kubeClient, util.NodePoolGKE, "MirrorPodTestGKE", "kind-worker3")
+			if err != nil {
+				framework.Failf("Error in updating the nodepool label")
+			}
+			entityDTOs, _, Err := discoveryClient.DiscoverWithNewFramework(testName)
+			if Err != nil {
+				framework.Failf(Err.Error())
+			}
+
+			for _, entityDTO := range entityDTOs {
+				if *entityDTO.EntityType == proto.EntityDTO_CONTAINER_POD &&
+					strings.Contains(*entityDTO.DisplayName, mirrorpod_prefix) {
+					entities = append(entities, entityDTO)
+				}
+			}
+			//Validate daemon: true for nodepool with 2 nodes
+			for _, entity := range entities {
+				if *entity.ConsumerPolicy.Daemon != true {
+					framework.Failf("Daemon set settings for %v mirror pod is false ", entity.DisplayName)
+				}
+			}
+
+		})
+		It("validate daemon settings false for a nodepool with not all nodes having staic pods", func() {
+
+			// Create GKE nodepools with two nodes
+			entities = nil
+			_, err = updateNodeWithLabel(kubeClient, util.NodePoolGKE, "MirrorPodTestGKE", "kind-worker2")
+			if err != nil {
+				framework.Failf("Error in updating the nodepool label")
+			}
+			_, err = updateNodeWithLabel(kubeClient, util.NodePoolGKE, "MirrorPodTestGKE", "kind-worker")
+			if err != nil {
+				framework.Failf("Error in updating the nodepool label")
+			}
+			entityDTOs, _, Err := discoveryClient.DiscoverWithNewFramework(testName)
+			if Err != nil {
+				framework.Failf(Err.Error())
+			}
+
+			for _, entityDTO := range entityDTOs {
+				if *entityDTO.EntityType == proto.EntityDTO_CONTAINER_POD &&
+					strings.Contains(*entityDTO.DisplayName, mirrorpod_prefix) {
+					entities = append(entities, entityDTO)
+				}
+			}
+			//Validate daemon:false as not all nodes in nodepool have static pods
+			for _, entity := range entities {
+				if *entity.ConsumerPolicy.Daemon == true {
+					framework.Failf("Daemon set for %v mirror pod should be false as not all the nodes in the nodepool has static pod ", entity.DisplayName)
+				}
+			}
+
+		})
+
+		AfterEach(func() {
+			delNode = getNodewithNodeName("kind-worker2", kubeClient)
+			_ = deleteLabelsFromNode(delNode, util.NodePoolGKE, kubeClient)
+
+			delNode = getNodewithNodeName("kind-worker3", kubeClient)
+			_ = deleteLabelsFromNode(delNode, util.NodePoolAKS, kubeClient)
+
+			delNode = getNodewithNodeName("kind-worker3", kubeClient)
+			_ = deleteLabelsFromNode(delNode, util.NodePoolGKE, kubeClient)
+
+			delNode = getNodewithNodeName("kind-worker", kubeClient)
+			_ = deleteLabelsFromNode(delNode, util.NodePoolGKE, kubeClient)
+
+		})
+
+	})
+
 	// TODO: this particular Describe is currently used as the teardown for this
 	// whole test (not the suite).
 	// This will work only if run sequentially. Find a better way to do this.
@@ -441,7 +560,7 @@ func updateNodeWithLabel(kubeClient *kubeclientset.Clientset, labelKey string,
 	nodeToUpdate.Labels[labelKey] = labelValue //Label node w
 	nodeToUpdate, err = kubeClient.CoreV1().Nodes().Update(context.TODO(), nodeToUpdate, metav1.UpdateOptions{})
 	if err != nil {
-		framework.Failf("Failed to update node %s with zone label: %s %s", nodeToUpdate, labelKey+":"+labelValue, err)
+		framework.Failf("Failed to update node %s with label: %s %s", nodeToUpdate, labelKey+":"+labelValue, err)
 	}
 	return nodeToUpdate, err
 }
@@ -627,16 +746,16 @@ func getNotReadyNode(entities []*proto.EntityDTO) *proto.EntityDTO {
 	return notReadyNode
 }
 
-func getNotReadyNodeGroup(groups []*proto.GroupDTO) *proto.GroupDTO {
-	notReadyNodeGroup := findOneGroup(groups, func(group *proto.GroupDTO) bool {
-		return strings.Contains(group.GetGroupName(), "NotReady-Nodes-")
+func getGroup(groups []*proto.GroupDTO, groupName string) *proto.GroupDTO {
+	reqGroup := findOneGroup(groups, func(group *proto.GroupDTO) bool {
+		return strings.Contains(group.GetGroupName(), groupName)
 	})
 
-	if notReadyNodeGroup != nil {
-		framework.Logf("Successfully found NotReady Node Group")
+	if reqGroup != nil {
+		framework.Logf("Successfully found Group %s", groupName)
 	}
 
-	return notReadyNodeGroup
+	return reqGroup
 }
 
 func validateNumbers(entityDTOs []*proto.EntityDTO, groupDTOs []*proto.GroupDTO, totalEntities, totalGroups int) {

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -416,7 +416,6 @@ var _ = Describe("Discover Cluster", func() {
 		testName := "discovery-integration-test"
 		mirrorpod_prefix := "static-web"
 		var entities []*proto.EntityDTO = nil
-		//var groups []*proto.GroupDTO = nil
 		var delNode *corev1.Node
 		var err error
 


### PR DESCRIPTION
References
https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/

Background:
Created static pod by adding the staic pod yaml like in [link](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/) to the nodes while creating kind cluster as part of test setup.
With [PR](https://github.com/turbonomic/kubeturbo/pull/743) kubeturbo will identify static pod and mark daemon as true if all nodes in the nodepool have static pod.

Testing:
Added test cases 

- Multiple nodepools having static pods in all nodes. Expedted dameon:true for the pod and 1 mirror group 
- One nodepool with multiple nodes, all have static pods Expected dameon:true and 1 mirror group
- Nodepool with some nodes not having static pos Expected dameon:false and 1 mirror group