### PR TITLE
[OM-90969]: Updated helm chart config maps to support new feature gates structure.

### DIFF
--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -19,13 +19,7 @@ data:
         }
       },
       {{- if .Values.featureGates }}
-      "featureGates": {
-        {{$first := true}}
-        {{- range $key, $val := .Values.featureGates }}
-        {{- if $first}}{{$first = false}}{{else}},{{- end}}
-        {{ $key | quote }}: {{ $val }}
-        {{- end }}
-      },
+      "featureGates": {{ .Values.featureGates | toJson }},
       {{- end }}
       "HANodeConfig": {
         "nodeRoles": [{{ .Values.HANodeConfig.nodeRoles }}]

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -20,8 +20,12 @@ data:
       },
       {{- if .Values.featureGates }}
       "featureGates": {
-        "disabledFeatures": [{{ .Values.featureGates.disabledFeatures }}]
-      }
+        {{$first := true}}
+        {{- range $key, $val := .Values.featureGates }}
+        {{- if $first}}{{$first = false}}{{else}},{{- end}}
+        {{ $key | quote }}: {{ $val }}
+        {{- end }}
+      },
       {{- end }}
       "HANodeConfig": {
         "nodeRoles": [{{ .Values.HANodeConfig.nodeRoles }}]

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -73,6 +73,16 @@ HANodeConfig:
 #   namespace: ""
 #   workloadController: ""
 
+# The featureGates property defines a map of string-to-boolean values that provides users with a mechanism 
+# to enable # features that are disabled by default. For a list of supported feature gates, see 
+# https://github.com/turbonomic/kubeturbo/blob/master/pkg/features/features.go
+# featureGates:
+#   PersistentVolumes: true
+#   ThrottlingMetrics: false
+#   HonorAzLabelPvAffinity: true
+#   GitopsApps: false
+#   GoMemLimit: true
+
 args:
   # logging level
   logginglevel: 2

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -74,14 +74,14 @@ HANodeConfig:
 #   workloadController: ""
 
 # The featureGates property defines a map of string-to-boolean values that provides users with a mechanism 
-# to enable # features that are disabled by default. For a list of supported feature gates, see 
+# to enable/disable features. For a list of supported feature gates, see 
 # https://github.com/turbonomic/kubeturbo/blob/master/pkg/features/features.go
 # featureGates:
-#   PersistentVolumes: true
-#   ThrottlingMetrics: false
-#   HonorAzLabelPvAffinity: true
-#   GitopsApps: false
-#   GoMemLimit: true
+#   PersistentVolumes: true (default: true)
+#   ThrottlingMetrics: false (default: true)
+#   HonorAzLabelPvAffinity: true (default: false)
+#   GitopsApps: false (default: true)
+#   GoMemLimit: true (default: false)
 
 args:
   # logging level

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -20,8 +20,12 @@ data:
       },
       {{- if .Values.featureGates }}
       "featureGates": {
-        "disabledFeatures": [{{ .Values.featureGates.disabledFeatures }}]
-      }
+        {{$first := true}}
+        {{- range $key, $val := .Values.featureGates }}
+        {{- if $first}}{{$first = false}}{{else}},{{-end}}
+        {{ $key | quote }}: {{ $val }}
+        {{- end }}
+      },
       {{- end }}
       "HANodeConfig": {
         "nodeRoles": [{{ .Values.HANodeConfig.nodeRoles }}]

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -19,13 +19,7 @@ data:
         }
       },
       {{- if .Values.featureGates }}
-      "featureGates": {
-        {{$first := true}}
-        {{- range $key, $val := .Values.featureGates }}
-        {{- if $first}}{{$first = false}}{{else}},{{-end}}
-        {{ $key | quote }}: {{ $val }}
-        {{- end }}
-      },
+      "featureGates": "featureGates": {{ .Values.featureGates | toJson }},
       {{- end }}
       "HANodeConfig": {
         "nodeRoles": [{{ .Values.HANodeConfig.nodeRoles }}]

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -73,6 +73,16 @@ HANodeConfig:
 #   namespace: ""
 #   workloadController: ""
 
+# The featureGates property defines a map of string-to-boolean values that provides users with a mechanism 
+# to enable # features that are disabled by default. For a list of supported feature gates, see 
+# https://github.com/turbonomic/kubeturbo/blob/master/pkg/features/features.go
+# featureGates:
+#   PersistentVolumes: true
+#   ThrottlingMetrics: false
+#   HonorAzLabelPvAffinity: true
+#   GitopsApps: false
+#   GoMemLimit: true
+
 args:
   # logging level
   logginglevel: 2

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -74,14 +74,14 @@ HANodeConfig:
 #   workloadController: ""
 
 # The featureGates property defines a map of string-to-boolean values that provides users with a mechanism 
-# to enable # features that are disabled by default. For a list of supported feature gates, see 
+# to enable/disable features. For a list of supported feature gates, see 
 # https://github.com/turbonomic/kubeturbo/blob/master/pkg/features/features.go
 # featureGates:
-#   PersistentVolumes: true
-#   ThrottlingMetrics: false
-#   HonorAzLabelPvAffinity: true
-#   GitopsApps: false
-#   GoMemLimit: true
+#   PersistentVolumes: true (default: true)
+#   ThrottlingMetrics: false (default: true)
+#   HonorAzLabelPvAffinity: true (default: false)
+#   GitopsApps: false (default: true)
+#   GoMemLimit: true (default: false)
 
 args:
   # logging level

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -156,7 +156,12 @@ func readK8sTAPServiceSpec(path string) (*K8sTAPServiceSpec, error) {
 	var spec K8sTAPServiceSpec
 	err := json.Unmarshal(file, &spec)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshall error :%v", err.Error())
+		switch typeErr := err.(type) {
+		case *json.UnmarshalTypeError:
+			return nil, fmt.Errorf("error processing configuration property '%v':%v", typeErr.Field, typeErr.Error())
+		default:
+			return nil, fmt.Errorf("error processing configuration: %v", err.Error())
+		}
 	}
 	return &spec, nil
 }


### PR DESCRIPTION
## Intent
Update helm chart and operator to support new feature gates structure.

## Background
We recently changed how feature gates are structured in the configuration which made the un-configurable via helm or the operator. This aims to fix that.

## Testing
Tested against appliance with valid and invalid configurations.

When a syntax occurs reading the configuration, we will now produce an error similar to the following: 
```
F1108 10:03:13.589145   77578 kubeturbo_builder.go:358] Failed to generate correct TAP config: error processing configuration: invalid character 'T' looking for beginning of value
```

When we fail to unmarshal the configuration, we will not produce an error with the following format: 
```
F1108 10:03:39.703458   77672 kubeturbo_builder.go:358] Failed to generate correct TAP config: error processing configuration property 'featureGates':json: cannot unmarshal string into Go struct field K8sTAPServiceSpec.featureGates of type bool
```

When an unexpected feature gate is provided, kubeturbo will crash with the following error (this logic remains unchanged): 
```
F1108 10:16:37.840194   79450 kubeturbo_builder.go:364] Invalid Feature Gates: unrecognized feature gate: InvalidFeatureGate
```