### PR TITLE
[OM-92710]: Support temporary namespace quota resizing

### DIFF
--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -148,7 +148,7 @@ func (h *ActionHandler) registerActionExecutors() {
 	containerResizer := executor.NewContainerResizer(ae, c.kubeletClient, c.sccAllowedSet)
 	h.actionExecutors[turboActionContainerResize] = containerResizer
 
-	controllerResizer := executor.NewWorkloadControllerResizer(ae, c.kubeletClient, c.sccAllowedSet)
+	controllerResizer := executor.NewWorkloadControllerResizer(ae, c.kubeletClient, c.sccAllowedSet, h.lockMap)
 	h.actionExecutors[turboActionControllerResize] = controllerResizer
 
 	// Only register the actions when API client is non-nil and cluster-api is available.

--- a/pkg/action/executor/constants.go
+++ b/pkg/action/executor/constants.go
@@ -10,9 +10,10 @@ const (
 	// Default number of Retries for waiting for Pod to be ready during action execution
 	DefaultWaitForPodThreshold = 55
 
-	DefaultRetrySleepInterval = time.Second * 3
-	DefaultRetryShortTimeout  = time.Second * 20
-	DefaultRetryTimeout       = time.Second * 120
+	DefaultRetrySleepInterval       = time.Second * 3
+	DefaultRetryShortTimeout        = time.Second * 20
+	DefaultRetryTimeout             = time.Second * 120
+	DefaultWaitReplicaToBeScheduled = time.Minute * 10
 
 	defaultWaitLockTimeOut = time.Second * 300
 	defaultWaitLockSleep   = time.Second * 10

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -53,6 +53,12 @@ const (
 	// Pagination support for list API calls to API server querying workload controllers
 	// Without this feature gate the whole list is requested in a single list API call.
 	GoMemLimit featuregate.Feature = "GoMemLimit"
+	// AllowIncreaseNsQuota4Resizing owner: @kevinwang
+	// alpha:
+	//
+	// This gate will enable the temporary namespace quota increase when
+	// kubeturbo execute a resize action on a workload controller
+	AllowIncreaseNsQuota4Resizing featuregate.Feature = "AllowIncreaseNsQuota4Resizing"
 )
 
 func init() {
@@ -67,9 +73,10 @@ func init() {
 // Ref: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 // Note: We use the config to feed the values, not the command line params.
 var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PersistentVolumes:      {Default: true, PreRelease: featuregate.Beta},
-	ThrottlingMetrics:      {Default: true, PreRelease: featuregate.Beta},
-	GitopsApps:             {Default: false, PreRelease: featuregate.Alpha},
-	HonorAzLabelPvAffinity: {Default: true, PreRelease: featuregate.Alpha},
-	GoMemLimit:             {Default: true, PreRelease: featuregate.Alpha},
+	PersistentVolumes:             {Default: true, PreRelease: featuregate.Beta},
+	ThrottlingMetrics:             {Default: true, PreRelease: featuregate.Beta},
+	GitopsApps:                    {Default: false, PreRelease: featuregate.Alpha},
+	HonorAzLabelPvAffinity:        {Default: true, PreRelease: featuregate.Alpha},
+	GoMemLimit:                    {Default: true, PreRelease: featuregate.Alpha},
+	AllowIncreaseNsQuota4Resizing: {Default: true, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
# Intent
Better support the execution of the resizing action on a workload controller when there is namespece quota set in the current namespace.

# Background
We already support namespace resource quota resize action based on the resize action of the workload  controller, but if the new namespace quota still can’t accommodate  the new replicas and the old replicas at the same time, the new pod can't even be created with a limited quota. As the "RollingUpdate"  is the default value for `updateStrategy`, it's likely to have a moment that there are the both old and new replicas running at the same time. 

# Implementation
Temporally increase the quota according to the the replica, the new replica spec and revert it back after making sure the new replicas  get scheduled well. 

# Test Done

## Case 1: Manual test on deployment
**1. Create a deployment and a namespace quota , the quota is greater than the one that is suggested by turbo resize action, but less than the one that's needed by having both old and new replica running together**
```
apiVersion: v1
kind: Namespace
metadata:
  name: quotatest-single-container
---
apiVersion: v1
kind: ResourceQuota
metadata:
  name: quotatest-single-container
  namespace: quotatest-single-container
spec:
  hard:
    limits.cpu: "220m"
    limits.memory: "220Mi" <----- can't accommodate a new replica as the old two have taken 200Mi
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cpu-resize-up
  namespace: quotatest-single-container
spec:
  replicas: 2
  selector:
    matchLabels:
      app: cpu-resize-up
  template:
    metadata:
      name: cpu-resize-up
      labels:
        app: cpu-resize-up
    spec:
      containers:
        - name: cpu-load
          image: beekman9527/cpumemload:latest
          resources:
            limits:
              cpu: "10m"
              memory: "100Mi"
          env:
            - name: RUN_TYPE
              value: cpu
            - name: CPU_PERCENT
              value: "100"
```
**2. Check the quota form the cmd line**
```
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get pods
NAME                             READY   STATUS    RESTARTS   AGE
cpu-resize-up-6674c5c975-phqd5   1/1     Running   0          59m
cpu-resize-up-6674c5c975-rv954   1/1     Running   0          59m
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get resourcequotas 
NAME                         AGE   REQUEST   LIMIT
quotatest-single-container   59m             limits.cpu: 20m/220m, limits.memory: 200Mi/220Mi
```
**3. Execute the resize action from UI**
![image](https://user-images.githubusercontent.com/61252360/202536848-9e8b5c3d-bb2e-4aec-80c3-acd07e5a0090.png)


**4. Check the pods and the quota increase**
```
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get resourcequotas 
NAME                         AGE   REQUEST   LIMIT
quotatest-single-container   65m             limits.cpu: 120m/220m, limits.memory: 300Mi/420Mi
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get pods
NAME                             READY   STATUS        RESTARTS   AGE
cpu-resize-up-6674c5c975-phqd5   1/1     Terminating   0          65m
cpu-resize-up-6674c5c975-rv954   1/1     Terminating   0          65m
cpu-resize-up-f9454947c-h9565    1/1     Running       0          15s
cpu-resize-up-f9454947c-k527w    1/1     Running       0          10s
```
**5. Check if the quota is reverted**
```
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get resourcequotas 
NAME                         AGE   REQUEST   LIMIT
quotatest-single-container   66m             limits.cpu: 200m/220m, limits.memory: 200Mi/220Mi
```
## Case 2: Manual test on daemonset
**1. Create a daemonset and a namespace quota , the quota is greater than the one that is suggested by turbo resize action, but less than the one that's needed by having both old and new replica running together**
```
apiVersion: v1
kind: Namespace
metadata:
  name: quotatest-single-container2
---
apiVersion: v1
kind: ResourceQuota
metadata:
  name: quotatest-single-container2
  namespace: quotatest-single-container2
spec:
  hard:
    limits.cpu: "330m"
    limits.memory: "330Mi"
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: cpu-resize-up2
  namespace: quotatest-single-container2
spec:
  selector:
    matchLabels:
      app: cpu-resize-up
  template:
    metadata:
      name: cpu-resize-up
      labels:
        app: cpu-resize-up
    spec:
      containers:
        - name: cpu-load
          image: beekman9527/cpumemload:latest
          resources:
            limits:
              cpu: "10m"
              memory: "100Mi"
          env:
            - name: RUN_TYPE
              value: cpu
            - name: CPU_PERCENT
              value: "100"
```
**2. Check the quota from the cmd line**
```
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get ds
NAME             DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
cpu-resize-up2   3         3         3       3            3           <none>          71m
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get resourcequotas 
NAME                          AGE   REQUEST   LIMIT
quotatest-single-container2   71m             limits.cpu: 30m/330m, limits.memory: 300Mi/330Mi
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get pods
NAME                   READY   STATUS    RESTARTS   AGE
cpu-resize-up2-2dpdg   1/1     Running   0          71m
cpu-resize-up2-bvl49   1/1     Running   0          71m
cpu-resize-up2-xn9pf   1/1     Running   0          71m
```
**3.Execute the resize action from UI**
![image](https://user-images.githubusercontent.com/61252360/202539766-f5963d2a-c410-4987-a9ca-e4804aacb5fd.png)

**4. Check the pods and the quota increase**
```
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get resourcequotas 
NAME                          AGE   REQUEST   LIMIT
quotatest-single-container2   18m             limits.cpu: 30m/730m, limits.memory: 300Mi/730Mi
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get pods 
NAME                   READY   STATUS    RESTARTS   AGE
cpu-resize-up2-4nqmh   1/1     Running   0          7s
cpu-resize-up2-5sc4r   1/1     Running   0          49s
cpu-resize-up2-7nmsl   1/1     Running   0          87s
```
**5. Check if the quota is reverted**
```
[root@api.ocp4kev.cp.fyre.ibm.com ~]# k get resourcequotas 
NAME                          AGE   REQUEST   LIMIT
quotatest-single-container2   21m             limits.cpu: 300m/330m, limits.memory: 300Mi/330Mi
```



