### PR TITLE
[OM-91918]: Pulled in turbo-go-sdk changes that decrease the ping interval to 30 seconds.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20221010221617-9853850521da
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20221114162847-7ef7b8aa0887
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -869,6 +869,8 @@ github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec h1:AmQY0cCtDy
 github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec/go.mod h1:yUpUS3CIq74nyG/OmIYFu4Uw8eKg5om58cOk2dz4xMA=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20221010221617-9853850521da h1:n9mvr4uGIMuTMXMY7sZZRenj4WBTqbU0K275TUR6Ykg=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20221010221617-9853850521da/go.mod h1:RWvXz62oL7Yhkw+WRdDRdOEZSsm8f0vR3xvsgSU9ohM=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20221114162847-7ef7b8aa0887 h1:fhRj83T3M+duhrM8NXR3I0M23dDbIK+eUIBYDx4kIIo=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20221114162847-7ef7b8aa0887/go.mod h1:RWvXz62oL7Yhkw+WRdDRdOEZSsm8f0vR3xvsgSU9ohM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
@@ -23,7 +23,7 @@ const (
 	handshakeTimeout                 = 60 * time.Second
 	wsReadLimit                      = 33554432 // 32 MB
 	writeWaitTimeout                 = 120 * time.Second
-	pingPeriod                       = 60 * time.Second
+	pingPeriod                       = 30 * time.Second
 )
 
 type TransportStatus string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -250,7 +250,7 @@ github.com/turbonomic/turbo-api/pkg/client
 # github.com/turbonomic/turbo-crd v0.0.0-20220630232025-77ff549647ec
 ## explicit; go 1.17
 github.com/turbonomic/turbo-crd/api/v1alpha1
-# github.com/turbonomic/turbo-go-sdk v0.0.0-20221010221617-9853850521da
+# github.com/turbonomic/turbo-go-sdk v0.0.0-20221114162847-7ef7b8aa0887
 ## explicit; go 1.13
 github.com/turbonomic/turbo-go-sdk/pkg
 github.com/turbonomic/turbo-go-sdk/pkg/builder


### PR DESCRIPTION
## Intent
Pull in [turbo-go-sdk changes](https://github.com/turbonomic/turbo-go-sdk/pull/143) that decrease the ping interval from 60 to 30 seconds.

## Background
Default load balancers will typically implement a 60 second timeout. If there is no activity detected, the connection will be closed. This poses a potential issue in that the secure WebSocket communication created by Kubeturbo can potentially be closed due to exceeding that default timeout when our ping interval is set to the same value.

## Testing
Debugged kubeturbo locally and verified that the ping is triggered every 30 seconds.

```
I1114 11:44:58.285635   56305 client_websocket_transport.go:165] begin to send Ping message
I1114 11:44:58.313641   56305 client_websocket_transport.go:335] Received pong msg
I1114 11:45:28.284977   56305 client_websocket_transport.go:165] begin to send Ping message
I1114 11:45:28.417169   56305 client_websocket_transport.go:335] Received pong msg
I1114 11:45:58.285729   56305 client_websocket_transport.go:165] begin to send Ping message
I1114 11:45:58.342297   56305 client_websocket_transport.go:335] Received pong msg
```
