### PR TITLE
OM-93274 - Remove docker push image step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,6 @@ after_success:
         # Build and push the image
         cd build
         # Push the latest image built from master branch
-        docker buildx build --platform $PLATFORM_OS_ARCH_LIST --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME .
+        docker buildx build --platform $PLATFORM_OS_ARCH_LIST --label "git-version=$TRAVIS_COMMIT" .
       fi
     fi


### PR DESCRIPTION
**Intent**
Removal of docker push image step to docker repository in travis CI file as this step is not required after building the multi-arch manifest images. To publish multi-arch images to docker repository there is other jenkins script that's already in place


**Testing**
This was tested on local machine by following below steps:

- run make product from root folder, this builds multi-arch images
- run docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x --label "#label-name"  from build folder