### PR TITLE
[OM-93059] Improve the calculation of number of items per query

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/KimMachineGun/automemlimit/memlimit"
 	set "github.com/deckarep/golang-set"
 	"github.com/golang/glog"
 	clusterclient "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
@@ -37,6 +36,7 @@ import (
 	kubeturbo "github.com/turbonomic/kubeturbo/pkg"
 	"github.com/turbonomic/kubeturbo/pkg/action/executor"
 	"github.com/turbonomic/kubeturbo/pkg/action/executor/gitops"
+	"github.com/turbonomic/kubeturbo/pkg/discovery/processor"
 	nodeUtil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/worker"
 	agg "github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation"
@@ -375,38 +375,25 @@ func (s *VMTServer) Run() {
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.GoMemLimit) {
 		glog.V(2).Info("Memory Optimisations are enabled.")
-		// Set Go runtime soft memory limit: https://pkg.go.dev/runtime/debug#SetMemoryLimit
-		// Set Go runtime soft memory limit through the AUTOMEMLIMIT environment variable.
-		// AUTOMEMLIMIT configures how much memory of the cgroup's memory limit should be set as Go runtime
-		// soft memory limit in the half-open range (0.0,1.0].
-		// If AUTOMEMLIMIT is not set, it defaults to 0.9. This means 10% is the headroom for memory sources
-		// that the Go runtime is unaware of and unable to control.
-		// If GOMEMLIMIT environment variable is already set or AUTOMEMLIMIT=off, this function does nothing.
 		// AUTOMEMLIMIT_DEBUG environment variable enables debug logging of AUTOMEMLIMIT
+		// GoMemLimit will be set during the start of each discovery, see K8sDiscoveryClient.Discover,
+		// as memory limit may change overtime
 		_ = os.Setenv("AUTOMEMLIMIT_DEBUG", "true")
-		memlimit.SetGoMemLimitWithEnv()
-		if s.ItemsPerListQuery == 0 {
-			limit, err := memlimit.FromCgroup()
-			if err != nil {
-				// This is very unlikely because in absense of any limit set in container resources
-				// we will get the cgroup limit as the nodes available/usable memory limit
-				glog.Errorf("Error retrieving memory limit (%v): %v.", limit, err)
-			} else if limit == 0 {
-				// This is very unlikely because in absense of any limit set in container resources
-				// we will get the cgroup limit as the nodes available/usable memory limit
-				glog.Error("Limit found set to zero (0).")
-			} else {
-				glog.V(2).Infof("Cgroup memlimit is set as %v.", limit)
-				util.ItemsPerListQuery = calculateListAPIItemsCount(float64(limit))
+		if s.ItemsPerListQuery != 0 {
+			// Perform sanity check on user specified value of itemsPerListQuery
+			if s.ItemsPerListQuery < 0 {
+				// Negative values are invalid, set to DefaultItemsPerListQuery
+				glog.Warningf("Argument --items-per-list-query is invalid (%v), setting it to the default value of %d.",
+					s.ItemsPerListQuery, int(processor.DefaultItemsPerListQuery))
+				s.ItemsPerListQuery = int(processor.DefaultItemsPerListQuery)
+			} else if s.ItemsPerListQuery < processor.DefaultItemsPerGBMemory {
+				// Values set too low will be reset to DefaultItemsPerGBMemory
+				glog.Warningf("Argument --items-per-list-query is set too low (%v), setting it to a minimum value of %v.",
+					s.ItemsPerListQuery, processor.DefaultItemsPerGBMemory)
+				s.ItemsPerListQuery = processor.DefaultItemsPerGBMemory
 			}
-		} else {
-			if s.ItemsPerListQuery < 10 {
-				glog.Warningf("Arg --items-per-list-query is set too low (%v), capping it to a minimum of 10 items.", s.ItemsPerListQuery)
-				s.ItemsPerListQuery = 10
-			}
-			util.ItemsPerListQuery = s.ItemsPerListQuery
+			glog.V(2).Infof("Set items per list query to the user specified value: %v.", s.ItemsPerListQuery)
 		}
-		glog.V(2).Infof("List Query Items Count is set to %v.", util.ItemsPerListQuery)
 	} else {
 		glog.V(2).Info("Memory Optimisations are not enabled.")
 	}
@@ -457,7 +444,8 @@ func (s *VMTServer) Run() {
 		WithQuotaUpdateConfig(s.UpdateQuotaToAllowMoves).
 		WithClusterAPIEnabled(clusterAPIEnabled).
 		WithReadinessRetryThreshold(s.readinessRetryThreshold).
-		WithClusterKeyInjected(s.ClusterKeyInjected)
+		WithClusterKeyInjected(s.ClusterKeyInjected).
+		WithItemsPerListQuery(s.ItemsPerListQuery)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.GitopsApps) {
 		vmtConfig.WithGitConfig(s.gitConfig)
@@ -538,15 +526,6 @@ func handleExit(disconnectFunc disconnectFromTurboFunc) { // k8sTAPService *kube
 			disconnectFunc()
 		}
 	}()
-}
-
-// The rational behind this calculation
-// Memory used in other areas approx = 500MB (conservatively).
-// heap-to-memory-limit ratio = 0.9
-//
-// ItemsPerListQuery = (mem_limit_gb * 0.9 - 0.5) * 5K
-func calculateListAPIItemsCount(memLimit float64) int {
-	return int(5000 * (nodeUtil.Base2BytesToGigabytes(memLimit)*0.9 - 0.5))
 }
 
 func discoverk8sAPIResourceGV(client *kubernetes.Clientset, resourceName string) (schema.GroupVersion, error) {

--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -381,18 +381,19 @@ func (s *VMTServer) Run() {
 		_ = os.Setenv("AUTOMEMLIMIT_DEBUG", "true")
 		if s.ItemsPerListQuery != 0 {
 			// Perform sanity check on user specified value of itemsPerListQuery
-			if s.ItemsPerListQuery < 0 {
-				// Negative values are invalid, set to DefaultItemsPerListQuery
-				glog.Warningf("Argument --items-per-list-query is invalid (%v), setting it to the default value of %d.",
-					s.ItemsPerListQuery, int(processor.DefaultItemsPerListQuery))
-				s.ItemsPerListQuery = int(processor.DefaultItemsPerListQuery)
-			} else if s.ItemsPerListQuery < processor.DefaultItemsPerGBMemory {
-				// Values set too low will be reset to DefaultItemsPerGBMemory
-				glog.Warningf("Argument --items-per-list-query is set too low (%v), setting it to a minimum value of %v.",
-					s.ItemsPerListQuery, processor.DefaultItemsPerGBMemory)
+			if s.ItemsPerListQuery < processor.DefaultItemsPerGBMemory {
+				var errMsg string
+				if s.ItemsPerListQuery < 0 {
+					errMsg = "negative"
+				} else {
+					errMsg = "set too low"
+				}
+				glog.Warningf("Argument --items-per-list-query is %s (%v). Setting it to the default value of %d.",
+					errMsg, s.ItemsPerListQuery, processor.DefaultItemsPerGBMemory)
 				s.ItemsPerListQuery = processor.DefaultItemsPerGBMemory
+			} else {
+				glog.V(2).Infof("Set items per list API call to the user specified value: %v.", s.ItemsPerListQuery)
 			}
-			glog.V(2).Infof("Set items per list query to the user specified value: %v.", s.ItemsPerListQuery)
 		}
 	} else {
 		glog.V(2).Info("Memory Optimisations are not enabled.")

--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -5,7 +5,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/golang/glog"
+	sdkprobe "github.com/turbonomic/turbo-go-sdk/pkg/probe"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/configs"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
@@ -18,10 +23,6 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/registration"
 	"github.com/turbonomic/kubeturbo/pkg/resourcemapping"
 	kubeturboversion "github.com/turbonomic/kubeturbo/version"
-	sdkprobe "github.com/turbonomic/turbo-go-sdk/pkg/probe"
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 const (
@@ -49,13 +50,16 @@ type DiscoveryClientConfig struct {
 	// ORMClient builds operator resource mapping templates fetched from OperatorResourceMapping CR so that action
 	// execution client will be able to execute action on operator-managed resources based on resource mapping templates.
 	OrmClient *resourcemapping.ORMClient
+	// Number of workload controller items the list api call should request for
+	itemsPerListQuery int
 }
 
 func NewDiscoveryConfig(probeConfig *configs.ProbeConfig,
 	targetConfig *configs.K8sTargetConfig, ValidationWorkers int,
 	ValidationTimeoutSec int, containerUtilizationDataAggStrategy,
 	containerUsageDataAggStrategy string, ormClient *resourcemapping.ORMClient,
-	discoveryWorkers, discoveryTimeoutMin, discoverySamples, discoverySampleIntervalSec int) *DiscoveryClientConfig {
+	discoveryWorkers, discoveryTimeoutMin, discoverySamples,
+	discoverySampleIntervalSec, itemsPerListQuery int) *DiscoveryClientConfig {
 	if discoveryWorkers < minDiscoveryWorker {
 		glog.Warningf("Invalid number of discovery workers %v, set it to %v.",
 			discoveryWorkers, minDiscoveryWorker)
@@ -85,6 +89,7 @@ func NewDiscoveryConfig(probeConfig *configs.ProbeConfig,
 		DiscoveryTimeoutSec:                 discoveryTimeoutMin,
 		DiscoverySamples:                    discoverySamples,
 		DiscoverySampleIntervalSec:          discoverySampleIntervalSec,
+		itemsPerListQuery:                   itemsPerListQuery,
 	}
 }
 
@@ -94,7 +99,7 @@ func (config *DiscoveryClientConfig) WithClusterKeyInjected(clusterKeyInjected s
 	return config
 }
 
-// Implements the go sdk discovery client interface
+// K8sDiscoveryClient defines the go sdk discovery client interface
 type K8sDiscoveryClient struct {
 	Config                 *DiscoveryClientConfig
 	k8sClusterScraper      *cluster.ClusterScraper
@@ -110,7 +115,7 @@ func NewK8sDiscoveryClient(config *DiscoveryClientConfig) *K8sDiscoveryClient {
 
 	// for discovery tasks
 	clusterProcessor := processor.NewClusterProcessor(k8sClusterScraper, config.probeConfig.NodeClient,
-		config.ValidationWorkers, config.ValidationTimeoutSec)
+		config.ValidationWorkers, config.ValidationTimeoutSec, config.itemsPerListQuery)
 
 	globalEntityMetricSink := metrics.NewEntityMetricSink().WithMaxMetricPointsSize(config.DiscoverySamples)
 
@@ -251,6 +256,19 @@ func (dc *K8sDiscoveryClient) Discover(
 
 	glog.V(2).Infof("Discovering kubernetes cluster...")
 
+	if utilfeature.DefaultFeatureGate.Enabled(features.GoMemLimit) {
+		// Set Go runtime soft memory limit: https://pkg.go.dev/runtime/debug#SetMemoryLimit
+		// Set Go runtime soft memory limit through the AUTOMEMLIMIT environment variable.
+		// AUTOMEMLIMIT configures how much memory of the cgroup's memory limit should be set as Go runtime
+		// soft memory limit in the half-open range (0.0,1.0].
+		// If AUTOMEMLIMIT is not set, it defaults to 0.9. This means 10% is the headroom for memory sources
+		// that the Go runtime is unaware of and unable to control.
+		// If GOMEMLIMIT environment variable is already set or AUTOMEMLIMIT=off, this function does nothing.
+		// Set GoMemLimit during each discovery as memory limit may change over time (when in-place resource
+		// update is enabled).
+		memlimit.SetGoMemLimitWithEnv()
+	}
+
 	discoveryResponse = &proto.DiscoveryResponse{}
 
 	var targetID string
@@ -284,9 +302,7 @@ func (dc *K8sDiscoveryClient) Discover(
 	return
 }
 
-/*
-The actual discovery work is done here.
-*/
+// DiscoverWithNewFramework performs the actual discovery.
 func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*proto.EntityDTO, []*proto.GroupDTO, error) {
 	// CREATE CLUSTER, NODES, NAMESPACES, QUOTAS, SERVICES HERE
 	clusterSummary, err := dc.clusterProcessor.DiscoverCluster()

--- a/pkg/discovery/processor/cluster_processor_test.go
+++ b/pkg/discovery/processor/cluster_processor_test.go
@@ -371,6 +371,10 @@ func (s *MockClusterScrapper) GetResources(schema.GroupVersionResource) ([]unstr
 	return []unstructured.Unstructured{}, nil
 }
 
+func (s *MockClusterScrapper) GetResourcesPaginated(schema.GroupVersionResource, int) ([]unstructured.Unstructured, error) {
+	return []unstructured.Unstructured{}, nil
+}
+
 func (s *MockClusterScrapper) GetMachineSetToNodesMap(nodes []*v1.Node) map[string][]*v1.Node {
 	return make(map[string][]*v1.Node)
 }

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -208,7 +208,7 @@ func NewKubernetesTAPService(config *Config) (*K8sTAPService, error) {
 	discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, config.tapSpec.K8sTargetConfig,
 		config.ValidationWorkers, config.ValidationTimeoutSec, config.containerUtilizationDataAggStrategy,
 		config.containerUsageDataAggStrategy, config.ORMClient, config.DiscoveryWorkers, config.DiscoveryTimeoutSec,
-		config.DiscoverySamples, config.DiscoverySampleIntervalSec)
+		config.DiscoverySamples, config.DiscoverySampleIntervalSec, config.ItemsPerListQuery)
 
 	if config.clusterKeyInjected != "" {
 		discoveryClientConfig = discoveryClientConfig.WithClusterKeyInjected(config.clusterKeyInjected)

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -58,6 +58,9 @@ type Config struct {
 	clusterKeyInjected      string
 	readinessRetryThreshold int
 	gitConfig               gitops.GitConfig
+
+	// Number of workload controller items the list api call should request for
+	ItemsPerListQuery int
 }
 
 func NewVMTConfig2() *Config {
@@ -205,5 +208,10 @@ func (c *Config) WithReadinessRetryThreshold(readinessRetryThreshold int) *Confi
 
 func (c *Config) WithGitConfig(gitConfig gitops.GitConfig) *Config {
 	c.gitConfig = gitConfig
+	return c
+}
+
+func (c *Config) WithItemsPerListQuery(itemsPerListQuery int) *Config {
+	c.ItemsPerListQuery = itemsPerListQuery
 	return c
 }

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -55,17 +55,4 @@ var (
 	K8sAPIJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1"}
 	// The API group under which CronJob are exposed by the k8s cluster
 	K8sAPICronJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1beta1"}
-
-	// Number of items that should be requested in each workload controller
-	// list API to ensure no OOMs occur.
-	// This value is calculated from cgroup MEMLIMIT using the below expression:
-	// (mem_limit_gb * 0.9 - 0.5) * 5K; where m is memlimit in GB
-	//
-	// In the absence of any MEMLIMIT set, we limit the number of resources requested in
-	// each call to fill up max of 8GB =(mem_limit_gb * 0.9 - 0.5) * 5000 = 33500
-	// This default is quite unlikely to be used as Cgroup limit will always be available
-	// atleast on linux based systems. If the container limit is not set, cgroup limit will
-	// be available as nodes limit.
-	// This will be used for non linux systems, eg kubeturbo local run on mac.
-	ItemsPerListQuery = 33500
 )

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -106,7 +106,7 @@ var _ = Describe("Discover Cluster", func() {
 			discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, nil, app.DefaultValidationWorkers,
 				app.DefaultValidationTimeout, aggregation.DefaultContainerUtilizationDataAggStrategy,
 				aggregation.DefaultContainerUsageDataAggStrategy, ormClient, app.DefaultDiscoveryWorkers, app.DefaultDiscoveryTimeoutSec,
-				app.DefaultDiscoverySamples, app.DefaultDiscoverySampleIntervalSec)
+				app.DefaultDiscoverySamples, app.DefaultDiscoverySampleIntervalSec, 0)
 
 			// Kubernetes Probe Discovery Client
 			discoveryClient = discovery.NewK8sDiscoveryClient(discoveryClientConfig)

--- a/test/integration/orm_action_execution.go
+++ b/test/integration/orm_action_execution.go
@@ -98,7 +98,7 @@ var _ = Describe("Action Executor ", func() {
 			discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, nil, app.DefaultValidationWorkers,
 				app.DefaultValidationTimeout, aggregation.DefaultContainerUtilizationDataAggStrategy,
 				aggregation.DefaultContainerUsageDataAggStrategy, ormClient, app.DefaultDiscoveryWorkers, app.DefaultDiscoveryTimeoutSec,
-				app.DefaultDiscoverySamples, app.DefaultDiscoverySampleIntervalSec)
+				app.DefaultDiscoverySamples, app.DefaultDiscoverySampleIntervalSec, 0)
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
 				cluster.NewClusterScraper(kubeClient, dynamicClient, nil, false, nil, ""),
 				[]string{"*"}, ormClient, false, true, 60, gitops.GitConfig{}, "test-cluster-id")


### PR DESCRIPTION
## Goal
This PR improves the calculation of number of items per query based on the research done by @chlam4 . According to the investigation, the ideal number of items per query depends on both memory limit of `kubeturbo`, and also the number of pods running in the cluster.

## Implementation
Currently, the items per query is calculated at `kubeturbo` startup time, and never changes afterwards. This needs to be changed because:
* The number of pods in the cluster changes over time.
* The memory limit of `kubeturbo` may also change over time when in-place pod resource update is enabled

As a result, the following logic is implemented:
* During `kubeturbo` startup time, only do sanity check of the command line argument `--items-per-list-query`:
  * If the value is negative, set it to `DefaultItemsPerGBMemory`
  * If the value is too low (i.e., below `DefaultItemsPerGBMemory`), set it to `DefaultItemsPerGBMemory`
* At the start of each main discovery `K8sDiscoveryClient.Discover`:
  * Set `GoMemLimit` based on the current memory limit 
* During `ClusterProcessor.DiscoverCluster`:
  * Calculate items per query based on memory limit and the number pods in the cluster
  * The result will be passed to `ControllerProcessor` which performs paginated query through `ClusterInfoScraper.GetResourcesPaginated` using the result as the page size 

## Test
* Deployed `kubeturbo` dev build in GKE, OCP 4.8 in AWS without memory limit set
  * In GKE:
    `I1125 15:59:36.437826       1 cluster_processor.go:228] Set items per list query to 5678 based on memory limit of 2.84 GB and pod count of 100.`
  * In OCP 4.8 in AWS:
    `I1125 15:48:13.028831       1 cluster_processor.go:228] Set items per list query to 126557 based on memory limit of 29.95 GB and pod count of 997.`
 
* Deployed `kubeturbo` dev build in OCP 4.8 in AWS with memory limit set to a low number of 1.2GB
 
 ```
I1129 19:57:47.159190       1 cluster_processor.go:193] Discovering cluster with 7 nodes and 1001 pods.
W1129 19:57:47.160248       1 cluster_processor.go:200] Cannot calculate items per list API call: the memory limit of kubeturbo 1.20 GB is too low to calculate a reasonable number of items per list API call. Kubeturbo may run into OOM. Consider increasing the memory limit of kubeturbo to at least 2.93 GB.
I1129 19:57:47.160270       1 cluster_processor.go:201] Set items per list API call to the default value of 5000.
  ```
* Deployed `kubeturbo` dev build in AKS. The error in the log is irrelevant to this issue, and has been address in [this](https://github.com/KimMachineGun/automemlimit/pull/2) PR.

```
W1129 19:57:45.893731       1 cluster_processor.go:200] Cannot calculate items per list API call: error retrieving memory limit (0): open /sys/fs/cgroup/memory/memory.memsw.usage_in_bytes: no such file or directory.
I1129 19:57:45.893831       1 cluster_processor.go:201] Set items per list API call to the default value of 5000.
```