### PR TITLE
[OM-93468]: Fixed featureGates definition on CRD.

### DIFF
--- a/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
+++ b/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
@@ -99,12 +99,9 @@ spec:
                   type: string
             featureGates:
               type: object
-              description: Disable features
-              properties:
-                default:
-                  type: string
-                additionalProperties:
-                  type: boolean
+              description: Enable or disable features
+              additionalProperties:
+                type: boolean
             HANodeConfig:
               type: object
               description: Create HA placement policy for Node to Hypervisor by node role. Master is default

--- a/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
+++ b/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
@@ -101,9 +101,10 @@ spec:
               type: object
               description: Disable features
               properties:
-                disabledFeatures:
-                  description: Feature names
-                  type: string, quote
+                default:
+                  type: string
+                additionalProperties:
+                  type: boolean
             HANodeConfig:
               type: object
               description: Create HA placement policy for Node to Hypervisor by node role. Master is default


### PR DESCRIPTION
## Intent

Fix `featureGates` definition on the kubeturbo CRD.
Add logging for feature gate values.

## Background

We recently changed the way we structure the `featureGates` but forgot to update the CRD.

## Testing

Built custom kubeturbo Docker image on appliance to get new logging, then deployed a kubeturbo instance via the CRD and verified that the `featureGates` reflected what was defined in the CR.

```
I1130 22:17:29.675275       1 k8s_tap_service.go:111] FEATURE GATE: GitopsApps=true
I1130 22:17:29.675296       1 k8s_tap_service.go:111] FEATURE GATE: GoMemLimit=true
I1130 22:17:29.675314       1 k8s_tap_service.go:111] FEATURE GATE: HonorAzLabelPvAffinity=true
I1130 22:17:29.675342       1 k8s_tap_service.go:111] FEATURE GATE: PersistentVolumes=true
I1130 22:17:29.675363       1 k8s_tap_service.go:111] FEATURE GATE: ThrottlingMetrics=true
```