### PR TITLE
[OM-93683] Fix security vulnerability CVE-2022-42898

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8
-MAINTAINER Enlin Xu <enlin.xu@turbonomic.com>
+MAINTAINER Turbonomic <turbodeploy@turbonomic.com>
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
@@ -14,11 +14,12 @@ LABEL name="Hybrid Cloud Container" \
       description="Hybrid Cloud Container leverages Turbonomic control platform, to assure the performance of micro-services running in OpenShift, as well as the efficiency of underlying infrastructure." \
 ### Required labels above - recommended below
       url="https://www.turbonomic.com" \
-      run='docker run -tdi --name ${NAME} vmturbo/kubeturbo:latest' \
       io.k8s.description="Hybrid Cloud Container will monitor and control the entire stack, from OpenShift down to your underlying infrastructure. " \
       io.k8s.display-name="Hybrid Cloud Container" \
       io.openshift.expose-services="" \
       io.openshift.tags="turbonomic,Hybrid Cloud Container"
+
+RUN dnf update -y krb5-libs
 
 ### Atomic Help File - Write in Markdown, it will be converted to man format at build time.
 ### https://github.com/projectatomic/container-best-practices/blob/master/creating/help.adoc

--- a/deploy/kubeturbo-operator/Dockerfile
+++ b/deploy/kubeturbo-operator/Dockerfile
@@ -1,4 +1,5 @@
 FROM quay.io/operator-framework/helm-operator:v1.25
+MAINTAINER Turbonomic <turbodeploy@turbonomic.com>
 
 # Required OpenShift Labels
 LABEL name="Kubeturbo Operator" \
@@ -9,11 +10,14 @@ LABEL name="Kubeturbo Operator" \
       description="This operator will deploy an instance of kubeturbo." \
 ### Required labels above - recommended below
       url="https://www.turbonomic.com" \
-      run='docker run -tdi --name ${NAME} turbonomic/kubeturbo-operator:8.6.1' \
       io.k8s.description="Turbonomic Workload Automation Platform simultaneously optimizes performance, compliance, and cost in real-time. Workloads are precisely resourced, automatically, to perform while satisfying business constraints.  " \
       io.k8s.display-name="Kubeturbo Operator" \
       io.openshift.expose-services="" \
       io.openshift.tags="turbonomic, Multicloud Container"
+
+USER root
+RUN microdnf update -y krb5-libs
+USER ${USER_UID}
 
 # Required Licenses
 COPY licenses /licenses

--- a/deploy/kubeturbo-operator/Makefile
+++ b/deploy/kubeturbo-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 8.6.1
+VERSION ?= 8.7.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")


### PR DESCRIPTION
This PR fixes [CVE-2022-42898](https://access.redhat.com/security/cve/CVE-2022-42898) by:

* Updating `krb5-libs` in `kubeturbo`  image
* Updating `krb5-libs` in `kubeturbo-operator` image