### PR TITLE
[OM-93814] Enable GoMemLimit feature by default

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -71,5 +71,5 @@ var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	ThrottlingMetrics:      {Default: true, PreRelease: featuregate.Beta},
 	GitopsApps:             {Default: false, PreRelease: featuregate.Alpha},
 	HonorAzLabelPvAffinity: {Default: true, PreRelease: featuregate.Alpha},
-	GoMemLimit:             {Default: false, PreRelease: featuregate.Alpha},
+	GoMemLimit:             {Default: true, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
## Tests

* Deploy the dev build:

```
I1205 16:54:08.025943       1 k8s_tap_service.go:111] FEATURE GATE: PersistentVolumes=true
I1205 16:54:08.025947       1 k8s_tap_service.go:111] FEATURE GATE: ThrottlingMetrics=true
I1205 16:54:08.025952       1 k8s_tap_service.go:111] FEATURE GATE: GitopsApps=false
I1205 16:54:08.025956       1 k8s_tap_service.go:111] FEATURE GATE: HonorAzLabelPvAffinity=true
I1205 16:54:08.025962       1 k8s_tap_service.go:111] FEATURE GATE: GoMemLimit=true
I1205 16:54:08.025972       1 kubeturbo_builder.go:377] Memory Optimisations are enabled.
```

* Sanity check on supply chain and actions