### PR TITLE
[OM-93635] Provide a feature flag to ignore processing affinities

### DIFF
--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -398,14 +398,18 @@ func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*prot
 	glog.V(2).Infof("There are totally %d entityDTOs.", len(result.EntityDTOs))
 
 	// affinity process
-	glog.V(2).Infof("Begin to process affinity.")
-	affinityProcessor, err := compliance.NewAffinityProcessor(clusterSummary)
-	if err != nil {
-		glog.Errorf("Failed during process affinity rules: %s", err)
+	if !utilfeature.DefaultFeatureGate.Enabled(features.IgnoreAffinities) {
+		glog.V(2).Infof("Begin to process affinity.")
+		affinityProcessor, err := compliance.NewAffinityProcessor(clusterSummary)
+		if err != nil {
+			glog.Errorf("Failed during process affinity rules: %s", err)
+		} else {
+			result.EntityDTOs = affinityProcessor.ProcessAffinityRules(result.EntityDTOs)
+		}
+		glog.V(2).Infof("Successfully processed affinity.")
 	} else {
-		result.EntityDTOs = affinityProcessor.ProcessAffinityRules(result.EntityDTOs)
+		glog.V(2).Infof("Ignoring affinities.")
 	}
-	glog.V(2).Infof("Successfully processed affinity.")
 
 	// Taint-toleration process to create access commodities
 	glog.V(2).Infof("Begin to process taints and tolerations")

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -59,6 +59,15 @@ const (
 	// This gate will enable the temporary namespace quota increase when
 	// kubeturbo execute a resize action on a workload controller
 	AllowIncreaseNsQuota4Resizing featuregate.Feature = "AllowIncreaseNsQuota4Resizing"
+	// IgnoreAffinities owner: @irfanurrehman
+	// alpha:
+	//
+	// This gate will simply ignore processing of affinities in the cluster.
+	// This is to try out temporarily disable processing of affinities to be able to
+	// try out a POV in a customer environment, which is held up because of inefficiency
+	// in out code, where affinity processing alone takes a really long time.
+	// https://vmturbo.atlassian.net/browse/OM-93635?focusedCommentId=771727
+	IgnoreAffinities featuregate.Feature = "IgnoreAffinities"
 )
 
 func init() {
@@ -79,4 +88,5 @@ var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	HonorAzLabelPvAffinity:        {Default: true, PreRelease: featuregate.Alpha},
 	GoMemLimit:                    {Default: true, PreRelease: featuregate.Alpha},
 	AllowIncreaseNsQuota4Resizing: {Default: true, PreRelease: featuregate.Alpha},
+	IgnoreAffinities:              {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
**Intent**
This is to provide a temporary option to ignore processing affinities during discovery of a k8s cluster.
This will help us validate our analysis of the root cause of https://vmturbo.atlassian.net/browse/OM-93635 and help progress the POV ahead.
