### PR TITLE
[OM-94865] Add timing information to discovery stages for benchmarking

### DIFF
--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -310,10 +310,12 @@ func (dc *K8sDiscoveryClient) Discover(
 // DiscoverWithNewFramework performs the actual discovery.
 func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*proto.EntityDTO, []*proto.GroupDTO, error) {
 	// CREATE CLUSTER, NODES, NAMESPACES, QUOTAS, SERVICES HERE
+	start := time.Now()
 	clusterSummary, err := dc.clusterProcessor.DiscoverCluster()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to process cluster: %v", err)
 	}
+	glog.V(3).Infof("Discovering cluster resources took %s", time.Since(start))
 
 	// Cache operatorResourceSpecMap in ormClient
 	numCRs := dc.Config.OrmClient.CacheORMSpecMap()
@@ -328,17 +330,20 @@ func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*prot
 	// Stops scheduling dispatcher to assign sampling discovery tasks.
 	dc.samplingDispatcher.FinishSampling()
 
+	start = time.Now()
 	// Discover pods and create DTOs for nodes, namespaces, controllers, pods, containers, application.
 	// Merge collected usage data samples from globalEntityMetricSink into the metric sink of each individual discovery worker.
 	// Collect the kubePod, kubeNamespace metrics, groups and kubeControllers from all the discovery workers.
 	taskCount := dc.dispatcher.Dispatch(nodes, clusterSummary)
 	result := dc.resultCollector.Collect(taskCount)
+	glog.V(3).Infof("Collection and processing of metrics from node kubelets took %s", time.Since(start))
 
 	// Clear globalEntityMetricSink cache after collecting full discovery results
 	dc.globalEntityMetricSink.ClearCache()
 	// Reschedule dispatch sampling discovery tasks for newly discovered nodes
 	dc.samplingDispatcher.ScheduleDispatch(nodes)
 
+	start = time.Now()
 	// Namespace discovery worker to create namespace DTOs
 	stitchType := dc.Config.probeConfig.StitchingPropertyType
 	namespacesDiscoveryWorker := worker.Newk8sNamespaceDiscoveryWorker(clusterSummary, stitchType)
@@ -401,10 +406,12 @@ func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*prot
 	result.EntityDTOs = append(result.EntityDTOs, businessAppEntityDTOBuilderEntityDTOs...)
 
 	glog.V(2).Infof("There are totally %d entityDTOs.", len(result.EntityDTOs))
+	glog.V(3).Infof("Postprocessing and aggregatig DTOs took %s", time.Since(start))
 
 	// affinity process
 	if !utilfeature.DefaultFeatureGate.Enabled(features.IgnoreAffinities) {
 		glog.V(2).Infof("Begin to process affinity.")
+		start := time.Now()
 		affinityProcessor, err := compliance.NewAffinityProcessor(clusterSummary)
 		if err != nil {
 			glog.Errorf("Failed during process affinity rules: %s", err)
@@ -412,18 +419,21 @@ func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*prot
 			result.EntityDTOs = affinityProcessor.ProcessAffinityRules(result.EntityDTOs)
 		}
 		glog.V(2).Infof("Successfully processed affinity.")
+		glog.V(3).Infof("Processing affinities took %s", time.Since(start))
 	} else {
 		glog.V(2).Infof("Ignoring affinities.")
 	}
 
 	// Taint-toleration process to create access commodities
 	glog.V(2).Infof("Begin to process taints and tolerations")
+	start = time.Now()
 	taintTolerationProcessor, err := compliance.NewTaintTolerationProcessor(clusterSummary)
 	if err != nil {
 		glog.Errorf("Failed during process taints and tolerations: %v", err)
 	} else {
 		// Add access commodities to entity DOTs based on the taint-toleration rules
 		taintTolerationProcessor.Process(result.EntityDTOs)
+		glog.V(3).Infof("Processing taints took %s", time.Since(start))
 	}
 
 	glog.V(2).Infof("Successfully processed taints and tolerations.")

--- a/pkg/discovery/worker/compliance/affinity_helper.go
+++ b/pkg/discovery/worker/compliance/affinity_helper.go
@@ -66,6 +66,7 @@ func nodeMatchesNodeSelectorTerms(node *api.Node, nodeSelectorTerms []api.NodeSe
 //----------------------------------------- Pod Affinity -------------------------------------------------------
 
 func interPodAffinityMatches(pod *api.Pod, node *api.Node, allPodsNodesMap map[*api.Pod]*api.Node) bool {
+	// This is to find out the topology key based antiaffinity, eg pods from same domain
 	if !satisfiesExistingPodsAntiAffinity(pod, node, allPodsNodesMap) {
 		return false
 	}

--- a/pkg/discovery/worker/compliance/affinity_processor_test.go
+++ b/pkg/discovery/worker/compliance/affinity_processor_test.go
@@ -3,6 +3,7 @@ package compliance
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,6 +111,7 @@ func TestProcessAffinityPerPod(t *testing.T) {
 		},
 	}
 
+	start := time.Now()
 	for i, item := range table {
 		entityDTOs := generateAllBasicEntityDTOs(item.nodes, item.pods)
 		ap := newAffinityProcessorForTest(item.nodes, item.pods, item.pod2PvMap)
@@ -168,6 +170,9 @@ func TestProcessAffinityPerPod(t *testing.T) {
 			}
 		}
 	}
+
+	elapsed := time.Since(start)
+	t.Logf("processing affinities took %s", elapsed)
 }
 
 // Check if a seller sells all the accessCommodities of the given type.
@@ -409,9 +414,8 @@ func newAffinityProcessorForTest(allNodes []*api.Node, allPods []*api.Pod, pod2P
 	return &AffinityProcessor{
 		ComplianceProcessor: NewComplianceProcessor(),
 		commManager:         NewAffinityCommodityManager(),
-
-		nodes:           allNodes,
-		pods:            allPods,
-		podToVolumesMap: pod2PVs,
+		nodes:               allNodes,
+		pods:                allPods,
+		podToVolumesMap:     pod2PVs,
 	}
 }


### PR DESCRIPTION
This update adds timing information to various stages of discovery, specifically for affinity and antiaffinity processing to be able to benchmark the same in test environments