### PR TITLE
[OM-94666] Prevent slice bounds out of range when reversing UUIDs

### DIFF
--- a/pkg/discovery/stitching/node_uuid.go
+++ b/pkg/discovery/stitching/node_uuid.go
@@ -266,7 +266,7 @@ func (v *vsphereNodeUUIDGetter) GetUUID(node *api.Node) (string, error) {
 func reverseUuid(oid string) (string, error) {
 	parts := strings.Split(oid, uuidSeparator)
 	if len(parts) != 5 {
-		return "", fmt.Errorf("Split failed")
+		return "", fmt.Errorf("split failed")
 	}
 
 	var buf bytes.Buffer
@@ -274,6 +274,11 @@ func reverseUuid(oid string) (string, error) {
 	//1. reverse the first 3 segments
 	for i := 0; i < 3; i++ {
 		seg := parts[i]
+		if len(seg)%2 != 0 {
+			errorMessage := fmt.Sprintf("invalid UUID segment of odd length found [%v] for uuid %v", seg, oid)
+			glog.V(2).Infof(errorMessage)
+			return "", fmt.Errorf(errorMessage)
+		}
 		for end := len(seg); end > 0; end -= 2 {
 			buf.WriteString(seg[end-2 : end])
 		}

--- a/pkg/discovery/stitching/node_uuid.go
+++ b/pkg/discovery/stitching/node_uuid.go
@@ -276,7 +276,7 @@ func reverseUuid(oid string) (string, error) {
 		seg := parts[i]
 		if len(seg)%2 != 0 {
 			errorMessage := fmt.Sprintf("invalid UUID segment of odd length found [%v] for uuid %v", seg, oid)
-			glog.V(2).Infof(errorMessage)
+			glog.Warningf(errorMessage)
 			return "", fmt.Errorf(errorMessage)
 		}
 		for end := len(seg); end > 0; end -= 2 {

--- a/pkg/discovery/stitching/node_uuid_test.go
+++ b/pkg/discovery/stitching/node_uuid_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	api "k8s.io/api/core/v1"
 )
 
@@ -181,4 +182,31 @@ func TestGKENodeUUIDGetter_GetUUID(t *testing.T) {
 			t.Errorf("Wrong node UUID %v Vs. %v", result, pair[1])
 		}
 	}
+}
+
+func TestReverseUUID(t *testing.T) {
+	uuids := []string{
+		"F4843642-7461-5AF2-5EF5-DA59C298CF44",
+		"BCB03642-6AE4-374E-8E17-457945ADA813",
+		"12AF3642-C5A9-6353-7EAE-AD5FD1E919C0",
+		"2AEB3642-28D6-946B-7B6F-55978F0F6628",
+		"51C03642-B323-C843-0CF9-FB0E46E4E29C",
+		"D1873642-A003-0963-D1C4-21A9AD6E5C79",
+		"EE3A3642-4D1F-23F3-A63A-D8991BC38002",
+	}
+
+	for _, uuid := range uuids {
+		// Our code converts these to lower case prior to entering this method
+		lowerUuid := strings.ToLower(uuid)
+		reversedUuid, err := reverseUuid(strings.ToLower(lowerUuid))
+		assert.Nil(t, err)
+		assert.NotNil(t, reversedUuid)
+		assert.NotEqual(t, lowerUuid, reversedUuid)
+	}
+}
+
+func TestReverseUUIDError(t *testing.T) {
+	// The following UUID was causing kubeturbo to crash. See OM-94666.
+	_, err := reverseUuid("a6e3642-0c9f-d66b-b19b-592157a699ed")
+	assert.NotNil(t, err, "reverse should fail due to invalid segment of odd length")
 }


### PR DESCRIPTION
## Intent

Fix a crash occurring at a customer due to a `slice bounds out of range` exception when attempting to reverse a UUID. 

## Background

A customer's Kubeturbo instance was continually crashing during the discovery phase with the following exception: 
```
panic: runtime error: slice bounds out of range [-1:]

goroutine 452 [running]:
github.com/turbonomic/kubeturbo/pkg/discovery/stitching.reverseUuid({0xc000349e0a?, 0x0?})
	/home/jenkins/workspace/xl-8.7.2-kubeturbo-build/src/github.com/turbonomic/kubeturbo/pkg/discovery/stitching/node_uuid.go:278 +0x1bd
github.com/turbonomic/kubeturbo/pkg/discovery/stitching.(*vsphereNodeUUIDGetter).GetUUID(0x7fd3043b8108?, 0xc000c85cd0)
	/home/jenkins/workspace/xl-8.7.2-kubeturbo-build/src/github.com/turbonomic/kubeturbo/pkg/discovery/stitching/node_uuid.go:241 +0xc5
github.com/turbonomic/kubeturbo/pkg/discovery/stitching.(*StitchingManager).storeNodeUUID(0xc00078c540, 0xc000c85cd0)
	/home/jenkins/workspace/xl-8.7.2-kubeturbo-build/src/github.com/turbonomic/kubeturbo/pkg/discovery/stitching/stitching_manager.go:117 +0x39
github.com/turbonomic/kubeturbo/pkg/discovery/stitching.(*StitchingManager).StoreStitchingValue(0xc00078c540?, 0xc000349e00?)
	/home/jenkins/workspace/xl-8.7.2-kubeturbo-build/src/github.com/turbonomic/kubeturbo/pkg/discovery/stitching/stitching_manager.go:97 +0x35
github.com/turbonomic/kubeturbo/pkg/discovery/worker.(*k8sDiscoveryWorker).buildNodeDTOs(0xc0009531d0, {0xc001f51a90?, 0x1, 0x1})
	/home/jenkins/workspace/xl-8.7.2-kubeturbo-build/src/github.com/turbonomic/kubeturbo/pkg/discovery/worker/k8s_discovery_worker.go:402 +0x114
github.com/turbonomic/kubeturbo/pkg/discovery/worker.(*k8sDiscoveryWorker).buildEntityDTOs(0xc0009531d0, 0xc018163a20)
	/home/jenkins/workspace/xl-8.7.2-kubeturbo-build/src/github.com/turbonomic/kubeturbo/pkg/discovery/worker/k8s_discovery_worker.go:364 +0x66
github.com/turbonomic/kubeturbo/pkg/discovery/worker.(*k8sDiscoveryWorker).executeTask(0xc0009531d0, 0xc018163a20)
	/home/jenkins/workspace/xl-8.7.2-kubeturbo-build/src/github.com/turbonomic/kubeturbo/pkg/discovery/worker/k8s_discovery_worker.go:298 +0x719
github.com/turbonomic/kubeturbo/pkg/discovery/worker.(*k8sDiscoveryWorker).RegisterAndRun(0xc0009531d0, 0xc00090ef30, 0xc000552348)
	/home/jenkins/workspace/xl-8.7.2-kubeturbo-build/src/github.com/turbonomic/kubeturbo/pkg/discovery/worker/k8s_discovery_worker.go:169 +0x166
created by github.com/turbonomic/kubeturbo/pkg/discovery/worker.(*Dispatcher).Init
	/home/jenkins/workspace/xl-8.7.2-kubeturbo-build/src/github.com/turbonomic/kubeturbo/pkg/discovery/worker/dispatcher.go:100 +0x3f
```

Was able to track this down to a "bad" provider ID (`vsphere://a6e3642-0c9f-d66b-b19b-592157a699ed`), in which the initial segment was of odd length (they must be even in order to reverse successfully). We believe it's likely that the customer has some external program that has modified the provider ID, as none of the other IDs exhibit this behavior. 

To remedy, introduced a check on the segment length to avoid the `slice bounds out of range` exception, and prevent Kubeturbo from crashing when this occurs. 

## Testing

Unit testing with the invalid UUID as well as valid ones.
