### PR TITLE
[OM-94895]:Replace busybox image with cpufreqgetter and remove the useless code

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -179,6 +179,11 @@ type VMTServer struct {
 
 	// Git configuration for gitops based action execution
 	gitConfig gitops.GitConfig
+
+	// Cpu frequency getter, used to replace busybox
+	CpuFrequencyGetterImage string
+	// Name of the secret that stores the image pull credentials of cpu freq getter job image
+	CpuFrequencyGetterPullSecret string
 }
 
 // NewVMTServer creates a new VMTServer with default parameters
@@ -242,6 +247,9 @@ func (s *VMTServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.gitConfig.GitEmail, "git-email", "", "The email to be used to push changes to git.")
 	fs.StringVar(&s.gitConfig.CommitMode, "git-commit-mode", "direct", "The commit mode that should be used for git action executions. One of request|direct. Defaults to direct.")
 	fs.Float64Var(&s.vcpuThrottlingUtilThreshold, "vcpu-throttling-threshold", DefaultVcpuThrottlingUtilThreshold, "The VCPU Throttling util threshold.")
+	// CpuFreqGetter image and secret
+	fs.StringVar(&s.CpuFrequencyGetterImage, "cpufreqgetter-image", "icr.io/cpopen/turbonomic/cpufreqgetter", "The complete cpufreqgetter image uri used for fallback node cpu frequency getter job.")
+	fs.StringVar(&s.CpuFrequencyGetterPullSecret, "cpufreqgetter-image-pull-secret", "", "The name of the secret that stores the image pull credentials for cpufreqgetter image.")
 }
 
 // create an eventRecorder to send events to Kubernetes APIserver
@@ -280,13 +288,13 @@ func (s *VMTServer) createKubeClientOrDie(kubeConfig *restclient.Config) *kubern
 }
 
 func (s *VMTServer) CreateKubeletClientOrDie(kubeConfig *restclient.Config, fallbackClient *kubernetes.Clientset,
-	busyboxImage, imagePullSecret string, cpufreqJobExcludeNodeLabels map[string]set.Set, useProxyEndpoint bool) *kubeclient.KubeletClient {
+	cpuFreqGetterImage, imagePullSecret string, cpufreqJobExcludeNodeLabels map[string]set.Set, useProxyEndpoint bool) *kubeclient.KubeletClient {
 	kubeletClient, err := kubeclient.NewKubeletConfig(kubeConfig).
 		WithPort(s.KubeletPort).
 		EnableHttps(s.EnableKubeletHttps).
 		ForceSelfSignedCerts(s.ForceSelfSignedCerts).
 		// Timeout(to).
-		Create(fallbackClient, busyboxImage, imagePullSecret, cpufreqJobExcludeNodeLabels, useProxyEndpoint)
+		Create(fallbackClient, cpuFreqGetterImage, imagePullSecret, cpufreqJobExcludeNodeLabels, useProxyEndpoint)
 	if err != nil {
 		glog.Errorf("Fatal error: failed to create kubeletClient: %v", err)
 		os.Exit(1)
@@ -413,8 +421,8 @@ func (s *VMTServer) Run() {
 		glog.Fatalf("Invalid cpu frequency exclude node label selectors: %v. The selectors "+
 			"should be a comma saperated list of key=value node label pairs", err)
 	}
-	kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, s.BusyboxImage,
-		s.BusyboxImagePullSecret, excludeLabelsMap, s.UseNodeProxyEndpoint)
+	kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, s.CpuFrequencyGetterImage,
+		s.CpuFrequencyGetterPullSecret, excludeLabelsMap, s.UseNodeProxyEndpoint)
 	caClient, err := clusterclient.NewForConfig(kubeConfig)
 	if err != nil {
 		glog.Errorf("Failed to generate correct TAP config: %v", err.Error())

--- a/pkg/kubeclient/cpufrequency_test.go
+++ b/pkg/kubeclient/cpufrequency_test.go
@@ -8,26 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLinuxAmd64NodeCpuFrequencyGetter_ParseCpuFrequency(t *testing.T) {
-	jobLog := "cpu MHz\t\t: 2199.999"
-	getter := &LinuxAmd64NodeCpuFrequencyGetter{
-		NodeCpuFrequencyGetter: *NewNodeCpuFrequencyGetter(nil, "", ""),
-	}
-	cpuFreq, err := getter.ParseCpuFrequency(jobLog)
-	assert.Nil(t, err)
-	assert.Equal(t, 2199.999, cpuFreq)
-}
-
-func TestLinuxPpc64leNodeCpuFrequencyGetter_ParseCpuFrequency(t *testing.T) {
-	jobLog := "clock\t\t: 2500.000000MHz"
-	getter := &LinuxPpc64leNodeCpuFrequencyGetter{
-		NodeCpuFrequencyGetter: *NewNodeCpuFrequencyGetter(nil, "", ""),
-	}
-	cpuFreq, err := getter.ParseCpuFrequency(jobLog)
-	assert.Nil(t, err)
-	assert.Equal(t, 2500.0, cpuFreq)
-}
-
 func TestBackoffFailures(t *testing.T) {
 	type failedTimes int
 	type testCase struct {

--- a/pkg/kubeclient/kubelet_client_test.go
+++ b/pkg/kubeclient/kubelet_client_test.go
@@ -1,8 +1,9 @@
 package kubeclient
 
 import (
-	set "github.com/deckarep/golang-set"
 	"testing"
+
+	set "github.com/deckarep/golang-set"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -69,7 +70,7 @@ func TestKubeletClientCacheNil(t *testing.T) {
 	kubeConf := &rest.Config{}
 	conf := NewKubeletConfig(kubeConf)
 
-	kc, _ := conf.Create(nil, "busybox", "", map[string]set.Set{}, false)
+	kc, _ := conf.Create(nil, "icr.io/cpopen/turbonomic/cpufreqgetter", "", map[string]set.Set{}, false)
 	entry := &CacheEntry{}
 	kc.cache["host_1"] = entry
 	assert.False(t, kc.HasCacheBeenUsed("host_1"))

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -3,10 +3,11 @@ package integration
 import (
 	"context"
 	"fmt"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
 	"math"
 	"os/exec"
 	"strings"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
 
 	set "github.com/deckarep/golang-set"
 	"github.com/golang/glog"
@@ -91,7 +92,7 @@ var _ = Describe("Discover Cluster", func() {
 			}
 
 			s := app.NewVMTServer()
-			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "", "busybox", map[string]set.Set{}, true)
+			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "", "icr.io/cpopen/turbonomic/cpufreqgetter", map[string]set.Set{}, true)
 
 			apiExtClient, err := apiextclient.NewForConfig(kubeConfig)
 			if err != nil {

--- a/test/integration/orm_action_execution.go
+++ b/test/integration/orm_action_execution.go
@@ -2,8 +2,9 @@ package integration
 
 import (
 	"context"
-	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
 	"strings"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory"
 
 	set "github.com/deckarep/golang-set"
 	"github.com/golang/glog"
@@ -84,7 +85,7 @@ var _ = Describe("Action Executor ", func() {
 			}
 
 			s := app.NewVMTServer()
-			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "", "busybox", map[string]set.Set{}, true)
+			kubeletClient := s.CreateKubeletClientOrDie(kubeConfig, kubeClient, "", "icr.io/cpopen/turbonomic/cpufreqgetter", map[string]set.Set{}, true)
 			apiExtClient, err := apiextclient.NewForConfig(kubeConfig)
 			if err != nil {
 				glog.Fatalf("Failed to generate apiExtensions client for kubernetes target: %v", err)
@@ -99,7 +100,7 @@ var _ = Describe("Action Executor ", func() {
 			discoveryClientConfig := discovery.NewDiscoveryConfig(probeConfig, nil, app.DefaultValidationWorkers,
 				app.DefaultValidationTimeout, aggregation.DefaultContainerUtilizationDataAggStrategy,
 				aggregation.DefaultContainerUsageDataAggStrategy, ormClient, app.DefaultDiscoveryWorkers, app.DefaultDiscoveryTimeoutSec,
-				app.DefaultDiscoverySamples, app.DefaultDiscoverySampleIntervalSec, 0,  dtofactory.DefaultCommodityConfig())
+				app.DefaultDiscoverySamples, app.DefaultDiscoverySampleIntervalSec, 0, dtofactory.DefaultCommodityConfig())
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
 				cluster.NewClusterScraper(kubeClient, dynamicClient, nil, false, nil, ""),
 				[]string{"*"}, ormClient, false, true, 60, gitops.GitConfig{}, "test-cluster-id")


### PR DESCRIPTION
# Intent
As we're moving all of the images to icr.io, the third-party image `busybox` which is used by `kubeturbo` to get CPU frequency from the nodes of one k8s cluster will be replaced by `cpufreqgetter` that is written in Go(only use the standard library) and will be maintained by ourselves. 

# Background
`kubeturbo` relies on `busybox` image to get CPU frequency 

# Implementation
The new `cpufreqgetter` will deal with different platforms(x86/Power/Z), and it will provide multi-arch images also.  The pod of `cpufreqgetter` will print out the final value of CPU frequency in the log. `kubeturbo` will not need to distinguish between different platforms and parse the value according to CPU arch, it will read the value from the pod log directly.

# Test Done

## X86:Rediscovery and check the kubeturbo log
```
[root@api.ocp410kev.cp.fyre.ibm.com git]# k logs kubeturbo-kw-114-59bc97479c-729wc |grep -i "CPU frequency"
W0113 17:21:58.906634       1 kubelet_client.go:339] Failed to get CPU frequency for node master0.ocp410kev.cp.fyre.ibm.com from kubelet: "https://10.22.119.197:10250/spec" was not found. Will try job based getter.
W0113 17:21:58.906641       1 kubelet_client.go:339] Failed to get CPU frequency for node master1.ocp410kev.cp.fyre.ibm.com from kubelet: "https://10.22.121.188:10250/spec" was not found. Will try job based getter.
W0113 17:21:58.907355       1 kubelet_client.go:339] Failed to get CPU frequency for node worker2.ocp410kev.cp.fyre.ibm.com from kubelet: "https://10.22.127.187:10250/spec" was not found. Will try job based getter.
W0113 17:21:58.907387       1 kubelet_client.go:339] Failed to get CPU frequency for node master2.ocp410kev.cp.fyre.ibm.com from kubelet: "https://10.22.122.188:10250/spec" was not found. Will try job based getter.
W0113 17:21:58.907446       1 kubelet_client.go:339] Failed to get CPU frequency for node worker0.ocp410kev.cp.fyre.ibm.com from kubelet: "https://10.22.123.185:10250/spec" was not found. Will try job based getter.
W0113 17:21:58.909338       1 kubelet_client.go:339] Failed to get CPU frequency for node worker1.ocp410kev.cp.fyre.ibm.com from kubelet: "https://10.22.126.129:10250/spec" was not found. Will try job based getter.
I0113 17:22:04.999483       1 kubelet_client.go:397] CPU frequency of node master0.ocp410kev.cp.fyre.ibm.com: 1999.999 MHz. <-------------Get the CPU frequency from the job which is using cpufreqgetter image
I0113 17:22:05.947948       1 kubelet_client.go:397] CPU frequency of node worker2.ocp410kev.cp.fyre.ibm.com: 2000 MHz.
I0113 17:22:05.949917       1 kubelet_client.go:397] CPU frequency of node master1.ocp410kev.cp.fyre.ibm.com: 1999.999 MHz.
I0113 17:22:05.950151       1 kubelet_client.go:397] CPU frequency of node worker1.ocp410kev.cp.fyre.ibm.com: 2000 MHz.
I0113 17:22:05.950224       1 kubelet_client.go:397] CPU frequency of node worker0.ocp410kev.cp.fyre.ibm.com: 2000 MHz.
I0113 17:22:06.949542       1 kubelet_client.go:397] CPU frequency of node master2.ocp410kev.cp.fyre.ibm.com: 2000 MHz.
I0113 17:22:07.518931       1 namespace_discovery_worker.go:67] Average cluster node cpu frequency in MHz: 1999.999667
I0113 17:31:59.525352       1 namespace_discovery_worker.go:67] Average cluster node cpu frequency in MHz: 1999.999667
I0113 17:41:59.619787       1 namespace_discovery_worker.go:67] Average cluster node cpu frequency in MHz: 1999.999667
I0113 17:51:59.574871       1 namespace_discovery_worker.go:67] Average cluster node cpu frequency in MHz: 1999.999667
I0113 18:01:59.721230       1 namespace_discovery_worker.go:67] Average cluster node cpu frequency in MHz: 1999.999667
I0113 18:11:59.467104       1 namespace_discovery_worker.go:67] Average cluster node cpu frequency in MHz: 1999.999667
I0113 18:21:59.528821       1 namespace_discovery_worker.go:67] Average cluster node cpu frequency in MHz: 1999.999667
I0113 18:31:59.535987       1 namespace_discovery_worker.go:67] Average cluster node cpu frequency in MHz: 1999.999667
```
