### PR TITLE
[OM-96095]: Fix creation of node groups for machine sets in OCP environments

### DIFF
--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -146,7 +146,7 @@ func (s *ClusterScraper) GetAllNodes() ([]*api.Node, error) {
 	return s.GetNodes(listOption)
 }
 
-func (s *ClusterScraper) GetMachineSetToNodesMap(nodes []*api.Node) map[string][]*api.Node {
+func (s *ClusterScraper) GetMachineSetToNodesMap(allNodes []*api.Node) map[string][]*api.Node {
 	machineSetToNodes := make(map[string][]*api.Node)
 	if s.caClient == nil {
 		return machineSetToNodes
@@ -164,7 +164,7 @@ func (s *ClusterScraper) GetMachineSetToNodesMap(nodes []*api.Node) map[string][
 		nodes := []*api.Node{}
 		for _, machine := range machines {
 			if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name != "" {
-				if node := findNode(machine.Status.NodeRef.Name, nodes); node != nil {
+				if node := findNode(machine.Status.NodeRef.Name, allNodes); node != nil {
 					nodes = append(nodes, node)
 				}
 			}


### PR DESCRIPTION
As of 8.7.0, we are not able to see machine sets (represented as NodePool) in Turbo.

`kubeturbo` discovers machine sets but the the node pool groups are not created since there are no nodes in the machine sets.

Discovery of machine sets and the nodes belonging to each set is a two-step process -
- fetch list of machine sets
- select nodes belonging to each machine set 

This is done in function `GetMachineSetToNodesMap` in `ClusterScraper`.
This method was refactored and it broke the association of nodes selected from the set of all nodes with a machine set due to the variable naming conflict. The selected nodes for each machine set is 0, hence the node pool group DTO is not created.

**Testing:**
Ran Turbo server using 4.8 OCP cluster on dc-11 that contains machine sets.

TODO: update integration test to discover machine sets and the nodes belonging to each machine set
