### PR TITLE
[OM-95986] Allow changing image tag with certified kubeturbo-operator

### DIFF
--- a/deploy/kubeturbo-operator/Dockerfile
+++ b/deploy/kubeturbo-operator/Dockerfile
@@ -1,26 +1,32 @@
 FROM quay.io/operator-framework/helm-operator:v1.25
 MAINTAINER Turbonomic <turbodeploy@turbonomic.com>
+ARG VERSION
+
+RUN echo "Building kubeturbo-operator:$VERSION"
 
 # Required OpenShift Labels
 LABEL name="Kubeturbo Operator" \
-      vendor="Turbonomic" \
-      version="8" \
-      release="6" \
+      vendor="IBM" \
+      version=$VERSION \
+      release=$VERSION \
       summary="This is the kubeturbo operator." \
       description="This operator will deploy an instance of kubeturbo." \
 ### Required labels above - recommended below
-      url="https://www.turbonomic.com" \
+      url="https://www.ibm.com/products/turbonomic" \
       io.k8s.description="Turbonomic Workload Automation Platform simultaneously optimizes performance, compliance, and cost in real-time. Workloads are precisely resourced, automatically, to perform while satisfying business constraints.  " \
       io.k8s.display-name="Kubeturbo Operator" \
       io.openshift.expose-services="" \
       io.openshift.tags="turbonomic, Multicloud Container"
 
 USER root
+# Update security library
 RUN microdnf update -y krb5-libs
-USER ${USER_UID}
-
 # Required Licenses
 COPY licenses /licenses
-
+# Copy helm charts
 COPY watches.yaml ${HOME}/watches.yaml
 COPY helm-charts/ ${HOME}/helm-charts/
+# Set default version number
+RUN sed -i "s/VERSION/$VERSION/g" ${HOME}/helm-charts/kubeturbo/values.yaml
+# Change user
+USER ${USER_UID}

--- a/deploy/kubeturbo-operator/Makefile
+++ b/deploy/kubeturbo-operator/Makefile
@@ -3,7 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 8.7.2
+DEFAULT_VERSION=8.8.0
+VERSION=$(or $(KUBETURBO_VERSION), $(DEFAULT_VERSION))
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -66,7 +67,7 @@ run: helm-operator ## Run against the configured Kubernetes cluster in ~/.kube/c
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --build-arg VERSION=${VERSION} -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
@@ -35,11 +35,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-{{- if and .Values.image.related (eq .Values.image.repository "icr.io/cpopen/turbonomic/kubeturbo") }}
-          image: {{ .Values.image.related }}
-{{- else }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - --turboconfig=/etc/kubeturbo/turbo.config

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 # Replace the image with desired version
 image:
   repository: icr.io/cpopen/turbonomic/kubeturbo
-  tag: 8.7.5
+  tag: VERSION
   pullPolicy: IfNotPresent
 #  busyboxRepository: busybox
 #  imagePullSecret: ""
@@ -29,7 +29,7 @@ serviceAccountName: "turbo-user"
 
 # Turbo server version and address
 serverMeta:
-  version: "8.0"
+  version: VERSION
   turboServer: https://Turbo_server_URL
 #  proxy: http://username:password@proxyserver:proxyport
 

--- a/deploy/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo/templates/deployment.yaml
@@ -35,11 +35,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-{{- if and .Values.image.related (eq .Values.image.repository "icr.io/cpopen/turbonomic/kubeturbo") }}
-          image: {{ .Values.image.related }}
-{{- else }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - --turboconfig=/etc/kubeturbo/turbo.config


### PR DESCRIPTION
## Background

After switching to `kubeturbo` image registry to `icr.io`, user cannot change the `kubeturbo` version using the `icr.io/cpopen/turbonomic` repository. This is a critical issue as user cannot change `kubeturbo` version to match with old server version.

## Solution

* Remove the logic to set hardcoded image digest for `kubeturbo` images
* Allow build script to set default `kubeturbo` version in `values.yaml`

With the above changes, the build script should specify a `VERSION` build argument when building `kubeturbo-operator` container image, for example:

```
docker buildx build --platform "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x" --build-arg VERSION=8.8.0 --push -t icr.io/cpopen/turbonomic/kubeturbo-operator:8.8.0 .
```

The `Dockerfile` will replace the `VERSION` placeholder in the `values.yaml` file with the provided build argument.

## Test
* Create a dev build `kubeturbo-operator` container image with `VERSION=8.8.0-SNAPSHOT` , and use that to create and publish a certified kubeturbo operator bundle into the beta channel:
 
  ![image](https://user-images.githubusercontent.com/10012486/216694363-286da1c2-c82f-40ca-ad6a-fe4fda3b73de.png)

* Deploy the above certified operator bundle in an Openshift v4.11 cluster, and verify that `icr.io/cpopen/turbonomic/kubeturbo:8.8.0-SNAPSHOT` instance is created and working as expected

* Add the following into the operator yaml:
```
  image:
    tag: 8.7.6
```
* Verify that `icr.io/cpopen/turbonomic/kubeturbo:8.7.6` is created and working as expected
  
  ![image](https://user-images.githubusercontent.com/10012486/216695571-e320fa91-0673-4998-8547-28fffa045511.png)
