### PR TITLE
OM-95960: Round up by incrementing recommended Limit by 1 MB

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -395,7 +395,7 @@ func (s *VMTServer) Run() {
 		_ = os.Setenv("AUTOMEMLIMIT_DEBUG", "true")
 		if s.ItemsPerListQuery != 0 {
 			// Perform sanity check on user specified value of itemsPerListQuery
-			if s.ItemsPerListQuery < processor.DefaultItemsPerGBMemory {
+			if s.ItemsPerListQuery < processor.DefaultItemsPerGiMemory {
 				var errMsg string
 				if s.ItemsPerListQuery < 0 {
 					errMsg = "negative"
@@ -403,8 +403,8 @@ func (s *VMTServer) Run() {
 					errMsg = "set too low"
 				}
 				glog.Warningf("Argument --items-per-list-query is %s (%v). Setting it to the default value of %d.",
-					errMsg, s.ItemsPerListQuery, processor.DefaultItemsPerGBMemory)
-				s.ItemsPerListQuery = processor.DefaultItemsPerGBMemory
+					errMsg, s.ItemsPerListQuery, processor.DefaultItemsPerGiMemory)
+				s.ItemsPerListQuery = processor.DefaultItemsPerGiMemory
 			} else {
 				glog.V(2).Infof("Set items per list API call to the user specified value: %v.", s.ItemsPerListQuery)
 			}

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -277,6 +277,8 @@ func (p *ClusterProcessor) calculateItemsPerListQuery(podCount int) (int, float6
 		return 0, 0, fmt.Errorf("limit found set to zero (0)")
 	}
 	podsInThousands := float64(podCount) / 1000
+	//round up recommended limit by 1 MB increment value
+	incrementRecommendInGB := 0.001
 	currentLimitInGB := util.Base2BytesToGigabytes(float64(limit))
 	availMemInGB := currentLimitInGB*DefaultAutoMemLimitPct -
 		DefaultGenericMetricSizePerThousandPodsInGB*podsInThousands -
@@ -286,10 +288,10 @@ func (p *ClusterProcessor) calculateItemsPerListQuery(podCount int) (int, float6
 		recommendedLimitInGB := (1.0 + DefaultExtraClusterWideUsageInGB +
 			(DefaultCadvisorMetricSizePerPodInGB*DefaultMaxPodsPerNode + DefaultExtraPerNodeUsageInGB) +
 			DefaultGenericMetricSizePerThousandPodsInGB*podsInThousands) / DefaultAutoMemLimitPct
-		return 0, 0, fmt.Errorf("the memory limit of kubeturbo %.2f GB is too low to calculate "+
+		return 0, 0, fmt.Errorf("the memory limit of kubeturbo %.3f Gi is too low to calculate "+
 			"a reasonable number of items per list API call. Kubeturbo may run into OOM. "+
-			"Consider increasing the memory limit of kubeturbo to at least %.2f GB",
-			currentLimitInGB, recommendedLimitInGB)
+			"Consider increasing the memory limit of kubeturbo to at least %.3f Gi",
+			currentLimitInGB, recommendedLimitInGB+incrementRecommendInGB)
 	}
 	return int(DefaultItemsPerGBMemory * availMemInGB), currentLimitInGB, nil
 }

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -201,7 +201,7 @@ func (p *ClusterProcessor) DiscoverCluster() (*repository.ClusterSummary, error)
 			glog.V(2).Infof("Set items per list API call to the default value of %v.", itemsPerListQuery)
 		} else {
 			itemsPerListQuery = items
-			glog.V(2).Infof("Set items per list API call to %v based on memory limit of %.2f GB "+
+			glog.V(2).Infof("Set items per list API call to %v based on memory limit of %.3f Gi "+
 				"and pod count of %v.", items, limit, podCount)
 		}
 	}

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -17,14 +17,14 @@ import (
 )
 
 const (
-	// DefaultItemsPerGBMemory defines number of items to retrieve for each GB of memory
-	DefaultItemsPerGBMemory                     = 5000
+	// DefaultItemsPerGiMemory defines number of items to retrieve for each GB of memory
+	DefaultItemsPerGiMemory                     = 5000
 	DefaultAutoMemLimitPct                      = 0.9
-	DefaultGenericMetricSizePerThousandPodsInGB = 0.24
-	DefaultCadvisorMetricSizePerPodInGB         = 0.004
+	DefaultGenericMetricSizePerThousandPodsInGi = 0.24
+	DefaultCadvisorMetricSizePerPodInGi         = 0.004
 	DefaultMaxPodsPerNode                       = 250
-	DefaultExtraPerNodeUsageInGB                = 0.2
-	DefaultExtraClusterWideUsageInGB            = 0.2
+	DefaultExtraPerNodeUsageInGi                = 0.2
+	DefaultExtraClusterWideUsageInGi            = 0.2
 )
 
 var (
@@ -196,7 +196,7 @@ func (p *ClusterProcessor) DiscoverCluster() (*repository.ClusterSummary, error)
 		// Determine items per list API call
 		items, limit, err := p.calculateItemsPerListQuery(podCount)
 		if err != nil {
-			itemsPerListQuery = DefaultItemsPerGBMemory
+			itemsPerListQuery = DefaultItemsPerGiMemory
 			glog.Warningf("Cannot calculate items per list API call: %v.", err)
 			glog.V(2).Infof("Set items per list API call to the default value of %v.", itemsPerListQuery)
 		} else {
@@ -244,6 +244,7 @@ func (p *ClusterProcessor) DiscoverCluster() (*repository.ClusterSummary, error)
 // This value must be calculated dynamically because:
 //   - the number of pods changes over time
 //   - the kubeturbo memory limit can change over time (when in-place pod resize is enabled)
+//   - gb here refers to Gi(1Gi = 1024*1024*1024)
 //
 // The following formula is used:
 //
@@ -278,20 +279,20 @@ func (p *ClusterProcessor) calculateItemsPerListQuery(podCount int) (int, float6
 	}
 	podsInThousands := float64(podCount) / 1000
 	//round up recommended limit by 1 MB increment value
-	incrementRecommendInGB := 0.001
-	currentLimitInGB := util.Base2BytesToGigabytes(float64(limit))
-	availMemInGB := currentLimitInGB*DefaultAutoMemLimitPct -
-		DefaultGenericMetricSizePerThousandPodsInGB*podsInThousands -
-		(DefaultCadvisorMetricSizePerPodInGB*DefaultMaxPodsPerNode + DefaultExtraPerNodeUsageInGB) -
-		DefaultExtraClusterWideUsageInGB
-	if availMemInGB < 1.0 {
-		recommendedLimitInGB := (1.0 + DefaultExtraClusterWideUsageInGB +
-			(DefaultCadvisorMetricSizePerPodInGB*DefaultMaxPodsPerNode + DefaultExtraPerNodeUsageInGB) +
-			DefaultGenericMetricSizePerThousandPodsInGB*podsInThousands) / DefaultAutoMemLimitPct
+	incrementRecommendInGi := 0.001
+	currentLimitInGi := util.Base2BytesToGigabytes(float64(limit))
+	availMemInGi := currentLimitInGi*DefaultAutoMemLimitPct -
+		DefaultGenericMetricSizePerThousandPodsInGi*podsInThousands -
+		(DefaultCadvisorMetricSizePerPodInGi*DefaultMaxPodsPerNode + DefaultExtraPerNodeUsageInGi) -
+		DefaultExtraClusterWideUsageInGi
+	if availMemInGi < 1.0 {
+		recommendedLimitInGi := (1.0 + DefaultExtraClusterWideUsageInGi +
+			(DefaultCadvisorMetricSizePerPodInGi*DefaultMaxPodsPerNode + DefaultExtraPerNodeUsageInGi) +
+			DefaultGenericMetricSizePerThousandPodsInGi*podsInThousands) / DefaultAutoMemLimitPct
 		return 0, 0, fmt.Errorf("the memory limit of kubeturbo %.3f Gi is too low to calculate "+
 			"a reasonable number of items per list API call. Kubeturbo may run into OOM. "+
 			"Consider increasing the memory limit of kubeturbo to at least %.3f Gi",
-			currentLimitInGB, recommendedLimitInGB+incrementRecommendInGB)
+			currentLimitInGi, recommendedLimitInGi+incrementRecommendInGi)
 	}
-	return int(DefaultItemsPerGBMemory * availMemInGB), currentLimitInGB, nil
+	return int(DefaultItemsPerGiMemory * availMemInGi), currentLimitInGi, nil
 }


### PR DESCRIPTION
**Background**
This code change intends to resolve [OM-95960](https://vmturbo.atlassian.net/browse/OM-95960). Kubeturbo recommends memory limit to set if user set limit in the deployment is lower than required based on the calculation 
`(kubeturbo_mem_limit_gb * 0.9 - number_of_pods_in_thousands_in_cluster * 0.24 - 1.4) *  5000`

A recommended limit is calculated and displayed in the kubeturbo logs as a warning to set at least recommended memory limit in the kubeturbo deployment. In the warning message, kubeturbo displayed only 2 decimal digits leading to sometimes setting lower value than required. User might see some error message like below which is confusing
`Cannot calculate items per list API call: the memory limit of kubeturbo 3.00 GB is too low to calculate a reasonable number of items per list API call. Kubeturbo may run into OOM. Consider increasing the memory limit of kubeturbo to at least 3.00 GB.`

**Code change**
This change increments any value by 0.001 Gi (1Mi) and displays the warning with 3 decimal points
<img width="1787" alt="Screen Shot 2023-02-06 at 10 46 27 PM" src="https://user-images.githubusercontent.com/22046780/217159267-8909ab4c-f8a9-4f2e-bb58-61c3dc45b696.png">

<img width="1595" alt="Screen Shot 2023-02-06 at 10 46 13 PM" src="https://user-images.githubusercontent.com/22046780/217159372-ecf5f202-98a0-449c-bc21-848602eba237.png">
