### PR TITLE
[OM-96836]:Update go-restful dependency to solve CVE issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/docker/distribution v2.8.0+incompatible // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,9 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.16.0+incompatible h1:rgqiKNjTnFQA6kkhFe16D8epTksy9HQ1MyrbDXSdYhM=
+github.com/emicklei/go-restful v2.16.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/vendor/github.com/emicklei/go-restful/.gitignore
+++ b/vendor/github.com/emicklei/go-restful/.gitignore
@@ -68,3 +68,4 @@ examples/restful-html-template
 
 s.html
 restful-path-tail
+.idea

--- a/vendor/github.com/emicklei/go-restful/.travis.yml
+++ b/vendor/github.com/emicklei/go-restful/.travis.yml
@@ -3,4 +3,11 @@ language: go
 go:
   - 1.x
 
-script: go test -v
+before_install:
+  - go test -v
+
+script:
+  - go test -race -coverprofile=coverage.txt -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/vendor/github.com/emicklei/go-restful/CHANGES.md
+++ b/vendor/github.com/emicklei/go-restful/CHANGES.md
@@ -1,59 +1,104 @@
-## Change history of go-restful
+# Change history of go-restful (v2 only)
+
+## v2.16.0 - 2022-07-11
+
+- Backported CORS filter. #489 (#493) #503
+
+## v2.15.0 - 2020-11-10
+
+- Add OPTIONS in Webservice
+
+## v2.14.3 - 2020-08-31
+- Fixed duplicate compression in dispatch. #449
 
 
-v2.9.5
+## v2.14.2 - 2020-08-31
+
+- Added check on writer to prevent compression of response twice. #447
+
+## v2.14.0 - 2020-08-19
+
+- Enable content encoding on Handle and ServeHTTP (#446)
+- List available representations in 406 body (#437)
+- Convert to string using rune() (#443)
+
+## v2.13.0 - 2020-06-21
+
+- 405 Method Not Allowed must have Allow header (#436)
+- add field allowedMethodsWithoutContentType (#424)
+
+## v2.12.0
+
+- support describing response headers (#426)
+- fix openapi examples (#425)
+- merge v3 fix (#422)
+
+## v2.11.1
+
+- fix WriteError return value (#415)
+
+## v2.11.0 
+
+- allow prefix and suffix in path variable expression (#414)
+
+## v2.9.6
+
+- support google custome verb (#413)
+
+## v2.9.5
+
 - fix panic in Response.WriteError if err == nil
 
-v2.9.4
+## v2.9.4
 
 - fix issue #400 , parsing mime type quality
 - Route Builder added option for contentEncodingEnabled (#398)
 
-v2.9.3
+## v2.9.3
 
 - Avoid return of 415 Unsupported Media Type when request body is empty (#396)
 
-v2.9.2
+## v2.9.2
 
 - Reduce allocations in per-request methods to improve performance (#395)
 
-v2.9.1
+## v2.9.1
 
 - Fix issue with default responses and invalid status code 0. (#393)
 
-v2.9.0
+## v2.9.0
 
 - add per Route content encoding setting (overrides container setting)
 
-v2.8.0
+## v2.8.0
 
 - add Request.QueryParameters()
 - add json-iterator (via build tag)
 - disable vgo module (until log is moved)
 
-v2.7.1
+## v2.7.1
 
 - add vgo module
 
-v2.6.1
+## v2.6.1
 
 - add JSONNewDecoderFunc to allow custom JSON Decoder usage (go 1.10+)
 
-v2.6.0
+## v2.6.0
 
 - Make JSR 311 routing and path param processing consistent
 - Adding description to RouteBuilder.Reads()
 - Update example for Swagger12 and OpenAPI
 
-2017-09-13
+## 2017-09-13
 
 - added route condition functions using `.If(func)` in route building.
 
-2017-02-16
+## 2017-02-16
 
 - solved issue #304, make operation names unique
 
-2017-01-30
+## 2017-01-30
  
 	[IMPORTANT] For swagger users, change your import statement to:	
 	swagger "github.com/emicklei/go-restful-swagger12"
@@ -61,60 +106,60 @@ v2.6.0
 - moved swagger 1.2 code to go-restful-swagger12
 - created TAG 2.0.0
 
-2017-01-27
+## 2017-01-27
 
 - remove defer request body close
 - expose Dispatch for testing filters and Routefunctions
 - swagger response model cannot be array 
 - created TAG 1.0.0
 
-2016-12-22
+## 2016-12-22
 
 - (API change) Remove code related to caching request content. Removes SetCacheReadEntity(doCache bool)
 
-2016-11-26
+## 2016-11-26
 
 - Default change! now use CurlyRouter (was RouterJSR311)
 - Default change! no more caching of request content
 - Default change! do not recover from panics
 
-2016-09-22
+## 2016-09-22
 
 - fix the DefaultRequestContentType feature
 
-2016-02-14
+## 2016-02-14
 
 - take the qualify factor of the Accept header mediatype into account when deciding the contentype of the response
 - add constructors for custom entity accessors for xml and json 
 
-2015-09-27
+## 2015-09-27
 
 - rename new WriteStatusAnd... to WriteHeaderAnd... for consistency
 
-2015-09-25
+## 2015-09-25
 
 - fixed problem with changing Header after WriteHeader (issue 235)
 
-2015-09-14
+## 2015-09-14
 
 - changed behavior of WriteHeader (immediate write) and WriteEntity (no status write)
 - added support for custom EntityReaderWriters.
 
-2015-08-06
+## 2015-08-06
 
 - add support for reading entities from compressed request content
 - use sync.Pool for compressors of http response and request body
 - add Description to Parameter for documentation in Swagger UI
 
-2015-03-20
+## 2015-03-20
 
 - add configurable logging
 
-2015-03-18
+## 2015-03-18
 
 - if not specified, the Operation is derived from the Route function
 
-2015-03-17
+## 2015-03-17
 
 - expose Parameter creation functions
 - make trace logger an interface
@@ -123,26 +168,26 @@ v2.6.0
 - JSR311 router now handles wildcards
 - add Notes to Route
 
-2014-11-27
+## 2014-11-27
 
 - (api add) PrettyPrint per response. (as proposed in #167)
 
-2014-11-12
+## 2014-11-12
 
 - (api add) ApiVersion(.) for documentation in Swagger UI
 
-2014-11-10
+## 2014-11-10
 
 - (api change) struct fields tagged with "description" show up in Swagger UI
 
-2014-10-31
+## 2014-10-31
 
 - (api change) ReturnsError -> Returns
 - (api add)    RouteBuilder.Do(aBuilder) for DRY use of RouteBuilder
 - fix swagger nested structs
 - sort Swagger response messages by code
 
-2014-10-23
+## 2014-10-23
 
 - (api add) ReturnsError allows you to document Http codes in swagger
 - fixed problem with greedy CurlyRouter
@@ -156,73 +201,73 @@ v2.6.0
 - (api add) added AllowedDomains in CORS
 - (api add) ParameterNamed for detailed documentation
 
-2014-04-16
+## 2014-04-16
 
 - (api add) expose constructor of Request for testing.
 
-2014-06-27
+## 2014-06-27
 
 - (api add) ParameterNamed gives access to a Parameter definition and its data (for further specification).
 - (api add) SetCacheReadEntity allow scontrol over whether or not the request body is being cached (default true for compatibility reasons).
 
-2014-07-03
+## 2014-07-03
 
 - (api add) CORS can be configured with a list of allowed domains
 
-2014-03-12
+## 2014-03-12
 
 - (api add) Route path parameters can use wildcard or regular expressions. (requires CurlyRouter)
 
-2014-02-26
+## 2014-02-26
 
 - (api add) Request now provides information about the matched Route, see method SelectedRoutePath 
 
-2014-02-17
+## 2014-02-17
 
 - (api change) renamed parameter constants (go-lint checks)
 
-2014-01-10
+## 2014-01-10
 
 - (api add) support for CloseNotify, see http://golang.org/pkg/net/http/#CloseNotifier
 
-2014-01-07
+## 2014-01-07
 
 - (api change) Write* methods in Response now return the error or nil.
 - added example of serving HTML from a Go template.
 - fixed comparing Allowed headers in CORS (is now case-insensitive)
 
-2013-11-13
+## 2013-11-13
 
 - (api add) Response knows how many bytes are written to the response body.
 
-2013-10-29
+## 2013-10-29
 
 - (api add) RecoverHandler(handler RecoverHandleFunction) to change how panic recovery is handled. Default behavior is to log and return a stacktrace. This may be a security issue as it exposes sourcecode information.
 
-2013-10-04
+## 2013-10-04
 
 - (api add) Response knows what HTTP status has been written
 - (api add) Request can have attributes (map of string->interface, also called request-scoped variables
 
-2013-09-12
+## 2013-09-12
 
 - (api change) Router interface simplified
 - Implemented CurlyRouter, a Router that does not use|allow regular expressions in paths
 
-2013-08-05
+## 2013-08-05
  - add OPTIONS support
  - add CORS support
 
-2013-08-27
+## 2013-08-27
 
 - fixed some reported issues (see github)
 - (api change) deprecated use of WriteError; use WriteErrorString instead
 
-2014-04-15
+## 2014-04-15
 
 - (fix) v1.0.1 tag: fix Issue 111: WriteErrorString
 
-2013-08-08
+## 2013-08-08
 
 - (api add) Added implementation Container: a WebServices collection with its own http.ServeMux allowing multiple endpoints per program. Existing uses of go-restful will register their services to the DefaultContainer.
 - (api add) the swagger package has be extended to have a UI per container.
@@ -235,38 +280,38 @@ Important API changes:
 - (api remove) package variable EnableContentEncoding no longer works ; use restful.DefaultContainer.EnableContentEncoding(true) instead.
  
  
-2013-07-06
+## 2013-07-06
 
 - (api add) Added support for response encoding (gzip and deflate(zlib)). This feature is disabled on default (for backwards compatibility). Use restful.EnableContentEncoding = true in your initialization to enable this feature.
 
-2013-06-19
+## 2013-06-19
 
 - (improve) DoNotRecover option, moved request body closer, improved ReadEntity
 
-2013-06-03
+## 2013-06-03
 
 - (api change) removed Dispatcher interface, hide PathExpression
 - changed receiver names of type functions to be more idiomatic Go
 
-2013-06-02
+## 2013-06-02
 
 - (optimize) Cache the RegExp compilation of Paths.
 
-2013-05-22
+## 2013-05-22
 	
 - (api add) Added support for request/response filter functions
 
-2013-05-18
+## 2013-05-18
 
 
 - (api add) Added feature to change the default Http Request Dispatch function (travis cline)
 - (api change) Moved Swagger Webservice to swagger package (see example restful-user)
 
-[2012-11-14 .. 2013-05-18>
+## [2012-11-14 .. 2013-05-18>
  
 - See https://github.com/emicklei/go-restful/commits
 
-2012-11-14
+## 2012-11-14
 
 - Initial commit
 

--- a/vendor/github.com/emicklei/go-restful/Makefile
+++ b/vendor/github.com/emicklei/go-restful/Makefile
@@ -1,7 +1,5 @@
 all: test
 
 test:
-	go test -v .
-
-ex:
-	cd examples && ls *.go | xargs go build -o /tmp/ignore
+	go vet .
+	go test -cover -v .

--- a/vendor/github.com/emicklei/go-restful/README.md
+++ b/vendor/github.com/emicklei/go-restful/README.md
@@ -4,9 +4,10 @@ package for building REST-style Web Services using Google Go
 
 [![Build Status](https://travis-ci.org/emicklei/go-restful.png)](https://travis-ci.org/emicklei/go-restful)
 [![Go Report Card](https://goreportcard.com/badge/github.com/emicklei/go-restful)](https://goreportcard.com/report/github.com/emicklei/go-restful)
-[![GoDoc](https://godoc.org/github.com/emicklei/go-restful?status.svg)](https://godoc.org/github.com/emicklei/go-restful)
+[![GoDoc](https://godoc.org/github.com/emicklei/go-restful?status.svg)](https://pkg.go.dev/github.com/emicklei/go-restful)
+[![codecov](https://codecov.io/gh/emicklei/go-restful/branch/master/graph/badge.svg)](https://codecov.io/gh/emicklei/go-restful)
 
-- [Code examples](https://github.com/emicklei/go-restful/tree/master/examples)
+- [Code examples using v3](https://github.com/emicklei/go-restful/tree/master/examples)
 
 REST asks developers to use HTTP methods explicitly and in a way that's consistent with the protocol definition. This basic REST design principle establishes a one-to-one mapping between create, read, update, and delete (CRUD) operations and HTTP methods. According to this mapping:
 
@@ -18,6 +19,28 @@ REST asks developers to use HTTP methods explicitly and in a way that's consiste
 - PATCH = Update partial content of a resource
 - OPTIONS = Get information about the communication options for the request URI
     
+### Usage
+
+#### Using Go Modules
+
+As of version `v3.0.0` (on the v3 branch), this package supports Go modules.
+
+```
+import (
+	restful "github.com/emicklei/go-restful/v3"
+)
+```
+
+#### Without Go Modules
+
+All versions up to `v2.*.*` (on the master) are not supporting Go modules.
+
+```
+import (
+	restful "github.com/emicklei/go-restful"
+)
+```
+
 ### Example
 
 ```Go
@@ -38,14 +61,14 @@ func (u UserResource) findUser(request *restful.Request, response *restful.Respo
 	...
 }
 ```
-	
-[Full API of a UserResource](https://github.com/emicklei/go-restful/tree/master/examples/restful-user-resource.go) 
-		
+
+[Full API of a UserResource](https://github.com/emicklei/go-restful/tree/master/examples/user-resource/restful-user-resource.go)
+
 ### Features
 
-- Routes for request &#8594; function mapping with path parameter (e.g. {id}) support
+- Routes for request &#8594; function mapping with path parameter (e.g. {id} but also prefix_{var} and {var}_suffix) support
 - Configurable router:
-	- (default) Fast routing algorithm that allows static elements, regular expressions and dynamic parameters in the URL path (e.g. /meetings/{id} or /static/{subpath:*}
+	- (default) Fast routing algorithm that allows static elements, [google custom method](https://cloud.google.com/apis/design/custom_methods), regular expressions and dynamic parameters in the URL path (e.g. /resource/name:customVerb, /meetings/{id} or /static/{subpath:*})
 	- Routing algorithm after [JSR311](http://jsr311.java.net/nonav/releases/1.1/spec/spec.html) that is implemented using (but does **not** accept) regular expressions
 - Request API for reading structs from JSON/XML and accesing parameters (path,query,header)
 - Response API for writing structs to JSON/XML and setting headers
@@ -85,4 +108,4 @@ TODO: write examples of these.
 
 Type ```git shortlog -s``` for a full list of contributors.
 
-© 2012 - 2018, http://ernestmicklei.com. MIT License. Contributions are welcome.
+© 2012 - 2020, http://ernestmicklei.com. MIT License. Contributions are welcome.

--- a/vendor/github.com/emicklei/go-restful/cors_filter.go
+++ b/vendor/github.com/emicklei/go-restful/cors_filter.go
@@ -18,9 +18,22 @@ import (
 // http://enable-cors.org/server.html
 // http://www.html5rocks.com/en/tutorials/cors/#toc-handling-a-not-so-simple-request
 type CrossOriginResourceSharing struct {
-	ExposeHeaders  []string // list of Header names
-	AllowedHeaders []string // list of Header names
-	AllowedDomains []string // list of allowed values for Http Origin. An allowed value can be a regular expression to support subdomain matching. If empty all are allowed.
+	ExposeHeaders []string // list of Header names
+
+	// AllowedHeaders is alist of Header names. Checking is case-insensitive.
+	// The list may contain the special wildcard string ".*" ; all is allowed
+	AllowedHeaders []string
+
+	// AllowedDomains is a list of allowed values for Http Origin.
+	// The list may contain the special wildcard string ".*" ; all is allowed
+	// If empty all are allowed.
+	AllowedDomains []string
+
+	// AllowedDomainFunc is optional and is a function that will do the check
+	// when the origin is not part of the AllowedDomains and it does not contain the wildcard ".*".
+	AllowedDomainFunc func(origin string) bool
+
+	// AllowedMethods is either empty or has a list of http methods names. Checking is case-insensitive.
 	AllowedMethods []string
 	MaxAge         int // number of seconds before requiring new Options request
 	CookiesAllowed bool
@@ -119,36 +132,24 @@ func (c CrossOriginResourceSharing) isOriginAllowed(origin string) bool {
 	if len(origin) == 0 {
 		return false
 	}
+	lowerOrigin := strings.ToLower(origin)
 	if len(c.AllowedDomains) == 0 {
+		if c.AllowedDomainFunc != nil {
+			return c.AllowedDomainFunc(lowerOrigin)
+		}
 		return true
 	}
 
-	allowed := false
+	// exact match on each allowed domain
 	for _, domain := range c.AllowedDomains {
-		if domain == origin {
-			allowed = true
-			break
+		if domain == ".*" || strings.ToLower(domain) == lowerOrigin {
+			return true
 		}
 	}
-
-	if !allowed {
-		if len(c.allowedOriginPatterns) == 0 {
-			// compile allowed domains to allowed origin patterns
-			allowedOriginRegexps, err := compileRegexps(c.AllowedDomains)
-			if err != nil {
-				return false
-			}
-			c.allowedOriginPatterns = allowedOriginRegexps
-		}
-
-		for _, pattern := range c.allowedOriginPatterns {
-			if allowed = pattern.MatchString(origin); allowed {
-				break
-			}
-		}
+	if c.AllowedDomainFunc != nil {
+		return c.AllowedDomainFunc(origin)
 	}
-
-	return allowed
+	return false
 }
 
 func (c CrossOriginResourceSharing) setAllowOriginHeader(req *Request, resp *Response) {
@@ -184,19 +185,9 @@ func (c CrossOriginResourceSharing) isValidAccessControlRequestHeader(header str
 		if strings.ToLower(each) == strings.ToLower(header) {
 			return true
 		}
+		if each == "*" {
+			return true
+		}
 	}
 	return false
-}
-
-// Take a list of strings and compile them into a list of regular expressions.
-func compileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
-	regexps := []*regexp.Regexp{}
-	for _, regexpStr := range regexpStrings {
-		r, err := regexp.Compile(regexpStr)
-		if err != nil {
-			return regexps, err
-		}
-		regexps = append(regexps, r)
-	}
-	return regexps, nil
 }

--- a/vendor/github.com/emicklei/go-restful/curly.go
+++ b/vendor/github.com/emicklei/go-restful/curly.go
@@ -47,7 +47,7 @@ func (c CurlyRouter) SelectRoute(
 func (c CurlyRouter) selectRoutes(ws *WebService, requestTokens []string) sortableCurlyRoutes {
 	candidates := make(sortableCurlyRoutes, 0, 8)
 	for _, each := range ws.routes {
-		matches, paramCount, staticCount := c.matchesRouteByPathTokens(each.pathParts, requestTokens)
+		matches, paramCount, staticCount := c.matchesRouteByPathTokens(each.pathParts, requestTokens, each.hasCustomVerb)
 		if matches {
 			candidates.add(curlyRoute{each, paramCount, staticCount}) // TODO make sure Routes() return pointers?
 		}
@@ -57,7 +57,7 @@ func (c CurlyRouter) selectRoutes(ws *WebService, requestTokens []string) sortab
 }
 
 // matchesRouteByPathTokens computes whether it matches, howmany parameters do match and what the number of static path elements are.
-func (c CurlyRouter) matchesRouteByPathTokens(routeTokens, requestTokens []string) (matches bool, paramCount int, staticCount int) {
+func (c CurlyRouter) matchesRouteByPathTokens(routeTokens, requestTokens []string, routeHasCustomVerb bool) (matches bool, paramCount int, staticCount int) {
 	if len(routeTokens) < len(requestTokens) {
 		// proceed in matching only if last routeToken is wildcard
 		count := len(routeTokens)
@@ -72,6 +72,15 @@ func (c CurlyRouter) matchesRouteByPathTokens(routeTokens, requestTokens []strin
 			return false, 0, 0
 		}
 		requestToken := requestTokens[i]
+		if routeHasCustomVerb && hasCustomVerb(routeToken){
+			if !isMatchCustomVerb(routeToken, requestToken) {
+				return false, 0, 0
+			}
+			staticCount++
+			requestToken = removeCustomVerb(requestToken)
+			routeToken = removeCustomVerb(routeToken)
+		}
+
 		if strings.HasPrefix(routeToken, "{") {
 			paramCount++
 			if colon := strings.Index(routeToken, ":"); colon != -1 {

--- a/vendor/github.com/emicklei/go-restful/custom_verb.go
+++ b/vendor/github.com/emicklei/go-restful/custom_verb.go
@@ -1,0 +1,29 @@
+package restful
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	customVerbReg = regexp.MustCompile(":([A-Za-z]+)$")
+)
+
+func hasCustomVerb(routeToken string) bool {
+	return customVerbReg.MatchString(routeToken)
+}
+
+func isMatchCustomVerb(routeToken string, pathToken string) bool {
+	rs := customVerbReg.FindStringSubmatch(routeToken)
+	if len(rs) < 2 {
+		return false
+	}
+
+	customVerb := rs[1]
+	specificVerbReg := regexp.MustCompile(fmt.Sprintf(":%s$", customVerb))
+	return specificVerbReg.MatchString(pathToken)
+}
+
+func removeCustomVerb(str string) string {
+	return customVerbReg.ReplaceAllString(str, "")
+}

--- a/vendor/github.com/emicklei/go-restful/parameter.go
+++ b/vendor/github.com/emicklei/go-restful/parameter.go
@@ -20,6 +20,9 @@ const (
 	// FormParameterKind = indicator of Request parameter type "form"
 	FormParameterKind
 
+	// MultiPartFormParameterKind = indicator of Request parameter type "multipart/form-data"
+	MultiPartFormParameterKind
+
 	// CollectionFormatCSV comma separated values `foo,bar`
 	CollectionFormatCSV = CollectionFormat("csv")
 
@@ -91,6 +94,11 @@ func (p *Parameter) beHeader() *Parameter {
 
 func (p *Parameter) beForm() *Parameter {
 	p.data.Kind = FormParameterKind
+	return p
+}
+
+func (p *Parameter) beMultiPartForm() *Parameter {
+	p.data.Kind = MultiPartFormParameterKind
 	return p
 }
 

--- a/vendor/github.com/emicklei/go-restful/path_processor.go
+++ b/vendor/github.com/emicklei/go-restful/path_processor.go
@@ -29,7 +29,12 @@ func (d defaultPathProcessor) ExtractParameters(r *Route, _ *WebService, urlPath
 		} else {
 			value = urlParts[i]
 		}
-		if strings.HasPrefix(key, "{") { // path-parameter
+		if r.hasCustomVerb && hasCustomVerb(key) {
+			key = removeCustomVerb(key)
+			value = removeCustomVerb(value)
+		}
+
+		if strings.Index(key, "{") > -1 { // path-parameter
 			if colon := strings.Index(key, ":"); colon != -1 {
 				// extract by regex
 				regPart := key[colon+1 : len(key)-1]
@@ -42,7 +47,13 @@ func (d defaultPathProcessor) ExtractParameters(r *Route, _ *WebService, urlPath
 				}
 			} else {
 				// without enclosing {}
-				pathParameters[key[1:len(key)-1]] = value
+				startIndex := strings.Index(key, "{")
+				endKeyIndex := strings.Index(key, "}")
+
+				suffixLength := len(key) - endKeyIndex - 1
+				endValueIndex := len(value) - suffixLength
+
+				pathParameters[key[startIndex+1:endKeyIndex]] = value[startIndex:endValueIndex]
 			}
 		}
 	}

--- a/vendor/github.com/emicklei/go-restful/request.go
+++ b/vendor/github.com/emicklei/go-restful/request.go
@@ -17,6 +17,7 @@ type Request struct {
 	pathParameters    map[string]string
 	attributes        map[string]interface{} // for storing request-scoped values
 	selectedRoutePath string                 // root path + route path that matched the request, e.g. /meetings/{id}/attendees
+	selectedRoute     *Route
 }
 
 func NewRequest(httpRequest *http.Request) *Request {
@@ -114,5 +115,10 @@ func (r Request) Attribute(name string) interface{} {
 
 // SelectedRoutePath root path + route path that matched the request, e.g. /meetings/{id}/attendees
 func (r Request) SelectedRoutePath() string {
-	return r.selectedRoutePath
+	return r.selectedRoute.Path
+}
+
+// SelectedRoute return the Route that selected by the container
+func (r Request) SelectedRoute() RouteReader {
+	return routeAccessor{route: r.selectedRoute}
 }

--- a/vendor/github.com/emicklei/go-restful/response.go
+++ b/vendor/github.com/emicklei/go-restful/response.go
@@ -174,15 +174,16 @@ func (r *Response) WriteHeaderAndJson(status int, value interface{}, contentType
 	return writeJSON(r, status, contentType, value)
 }
 
-// WriteError write the http status and the error string on the response. err can be nil.
-func (r *Response) WriteError(httpStatus int, err error) error {
+// WriteError writes the http status and the error string on the response. err can be nil.
+// Return an error if writing was not successful.
+func (r *Response) WriteError(httpStatus int, err error) (writeErr error) {
 	r.err = err
 	if err == nil {
-		r.WriteErrorString(httpStatus, "")
+		writeErr = r.WriteErrorString(httpStatus, "")
 	} else {
-		r.WriteErrorString(httpStatus, err.Error())
+		writeErr = r.WriteErrorString(httpStatus, err.Error())
 	}
-	return err
+	return writeErr
 }
 
 // WriteServiceError is a convenience method for a responding with a status and a ServiceError

--- a/vendor/github.com/emicklei/go-restful/route.go
+++ b/vendor/github.com/emicklei/go-restful/route.go
@@ -49,33 +49,31 @@ type Route struct {
 
 	//Overrides the container.contentEncodingEnabled
 	contentEncodingEnabled *bool
+
+	// indicate route path has custom verb
+	hasCustomVerb bool
+
+	// if a request does not include a content-type header then
+	// depending on the method, it may return a 415 Unsupported Media
+	// Must have uppercase HTTP Method names such as GET,HEAD,OPTIONS,...
+	allowedMethodsWithoutContentType []string
 }
 
 // Initialize for Route
 func (r *Route) postBuild() {
 	r.pathParts = tokenizePath(r.Path)
+	r.hasCustomVerb = hasCustomVerb(r.Path)
 }
 
 // Create Request and Response from their http versions
 func (r *Route) wrapRequestResponse(httpWriter http.ResponseWriter, httpRequest *http.Request, pathParams map[string]string) (*Request, *Response) {
 	wrappedRequest := NewRequest(httpRequest)
 	wrappedRequest.pathParameters = pathParams
-	wrappedRequest.selectedRoutePath = r.Path
+	wrappedRequest.selectedRoute = r
 	wrappedResponse := NewResponse(httpWriter)
 	wrappedResponse.requestAccept = httpRequest.Header.Get(HEADER_Accept)
 	wrappedResponse.routeProduces = r.Produces
 	return wrappedRequest, wrappedResponse
-}
-
-// dispatchWithFilters call the function after passing through its own filters
-func (r *Route) dispatchWithFilters(wrappedRequest *Request, wrappedResponse *Response) {
-	if len(r.Filters) > 0 {
-		chain := FilterChain{Filters: r.Filters, Target: r.Function}
-		chain.ProcessFilter(wrappedRequest, wrappedResponse)
-	} else {
-		// unfiltered
-		r.Function(wrappedRequest, wrappedResponse)
-	}
 }
 
 func stringTrimSpaceCutset(r rune) bool {
@@ -121,8 +119,17 @@ func (r Route) matchesContentType(mimeTypes string) bool {
 	if len(mimeTypes) == 0 {
 		// idempotent methods with (most-likely or guaranteed) empty content match missing Content-Type
 		m := r.Method
-		if m == "GET" || m == "HEAD" || m == "OPTIONS" || m == "DELETE" || m == "TRACE" {
-			return true
+		// if route specifies less or non-idempotent methods then use that
+		if len(r.allowedMethodsWithoutContentType) > 0 {
+			for _, each := range r.allowedMethodsWithoutContentType {
+				if m == each {
+					return true
+				}
+			}
+		} else {
+			if m == "GET" || m == "HEAD" || m == "OPTIONS" || m == "DELETE" || m == "TRACE" {
+				return true
+			}
 		}
 		// proceed with default
 		mimeTypes = MIME_OCTET

--- a/vendor/github.com/emicklei/go-restful/route_reader.go
+++ b/vendor/github.com/emicklei/go-restful/route_reader.go
@@ -1,0 +1,66 @@
+package restful
+
+// Copyright 2021 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+type RouteReader interface {
+	Method() string
+	Consumes() []string
+	Path() string
+	Doc() string
+	Notes() string
+	Operation() string
+	ParameterDocs() []*Parameter
+	// Returns a copy
+	Metadata() map[string]interface{}
+	Deprecated() bool
+}
+
+type routeAccessor struct {
+	route *Route
+}
+
+func (r routeAccessor) Method() string {
+	return r.route.Method
+}
+func (r routeAccessor) Consumes() []string {
+	return r.route.Consumes[:]
+}
+func (r routeAccessor) Path() string {
+	return r.route.Path
+}
+func (r routeAccessor) Doc() string {
+	return r.route.Doc
+}
+func (r routeAccessor) Notes() string {
+	return r.route.Notes
+}
+func (r routeAccessor) Operation() string {
+	return r.route.Operation
+}
+func (r routeAccessor) ParameterDocs() []*Parameter {
+	return r.route.ParameterDocs[:]
+}
+
+// Returns a copy
+func (r routeAccessor) Metadata() map[string]interface{} {
+	return copyMap(r.route.Metadata)
+}
+func (r routeAccessor) Deprecated() bool {
+	return r.route.Deprecated
+}
+
+// https://stackoverflow.com/questions/23057785/how-to-copy-a-map
+func copyMap(m map[string]interface{}) map[string]interface{} {
+	cp := make(map[string]interface{})
+	for k, v := range m {
+		vm, ok := v.(map[string]interface{})
+		if ok {
+			cp[k] = copyMap(vm)
+		} else {
+			cp[k] = v
+		}
+	}
+	return cp
+}

--- a/vendor/github.com/emicklei/go-restful/service_error.go
+++ b/vendor/github.com/emicklei/go-restful/service_error.go
@@ -4,17 +4,26 @@ package restful
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 // ServiceError is a transport object to pass information about a non-Http error occurred in a WebService while processing a request.
 type ServiceError struct {
 	Code    int
 	Message string
+	Header  http.Header
 }
 
 // NewError returns a ServiceError using the code and reason
 func NewError(code int, message string) ServiceError {
 	return ServiceError{Code: code, Message: message}
+}
+
+// NewErrorWithHeader returns a ServiceError using the code, reason and header
+func NewErrorWithHeader(code int, message string, header http.Header) ServiceError {
+	return ServiceError{Code: code, Message: message, Header: header}
 }
 
 // Error returns a text representation of the service error

--- a/vendor/github.com/emicklei/go-restful/web_service.go
+++ b/vendor/github.com/emicklei/go-restful/web_service.go
@@ -165,6 +165,18 @@ func FormParameter(name, description string) *Parameter {
 	return p
 }
 
+// MultiPartFormParameter creates a new Parameter of kind Form (using multipart/form-data) for documentation purposes.
+// It is initialized as required with string as its DataType.
+func (w *WebService) MultiPartFormParameter(name, description string) *Parameter {
+	return MultiPartFormParameter(name, description)
+}
+
+func MultiPartFormParameter(name, description string) *Parameter {
+	p := &Parameter{&ParameterData{Name: name, Description: description, Required: false, DataType: "string"}}
+	p.beMultiPartForm()
+	return p
+}
+
 // Route creates a new Route using the RouteBuilder and add to the ordered list of Routes.
 func (w *WebService) Route(builder *RouteBuilder) *WebService {
 	w.routesLock.Lock()
@@ -188,7 +200,7 @@ func (w *WebService) RemoveRoute(path, method string) error {
 			continue
 		}
 		newRoutes[current] = w.routes[ix]
-		current = current + 1
+		current++
 	}
 	w.routes = newRoutes
 	return nil
@@ -287,4 +299,9 @@ func (w *WebService) PATCH(subPath string) *RouteBuilder {
 // DELETE is a shortcut for .Method("DELETE").Path(subPath)
 func (w *WebService) DELETE(subPath string) *RouteBuilder {
 	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("DELETE").Path(subPath)
+}
+
+// OPTIONS is a shortcut for .Method("OPTIONS").Path(subPath)
+func (w *WebService) OPTIONS(subPath string) *RouteBuilder {
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("OPTIONS").Path(subPath)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -50,7 +50,7 @@ github.com/docker/distribution/reference
 # github.com/docker/go-units v0.4.0
 ## explicit
 github.com/docker/go-units
-# github.com/emicklei/go-restful v2.9.5+incompatible
+# github.com/emicklei/go-restful v2.16.0+incompatible
 ## explicit
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log


### PR DESCRIPTION
## Background 
The `go-restful` library(version 2.9.5) is causing a security vulnerability issue. the fix will update it to version 2.16.0 which could solve the issue
https://vmturbo.atlassian.net/browse/OM-96836


## Build the custom image and scan it with  `twistlock`, no `critical` issue anymore
```
./tt images pull-and-scan --user xxx --url "https://w3twistlock.sos.ibm.com" --control-group public docker.io/kevin0204/kubeturbo:security0214
```
![image](https://user-images.githubusercontent.com/61252360/218799516-8755686a-da14-4822-8f02-10cbcac1fb1c.png)
