### PR TITLE
[OM-97031]:Change scc-support flag default value from restricted to wildcard

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -73,7 +73,7 @@ const (
 )
 
 var (
-	defaultSccSupport = []string{"restricted"}
+	defaultSccSupport = []string{"*"}
 
 	// these variables will be deprecated. Keep it here for backward compatibility only
 	k8sVersion        = "1.8"


### PR DESCRIPTION
## Intent
Change the default value of `scc-support` flag from `restricted` to `*`

## Test
1. Create a custom SCC/Serviceaccount/Role/Rolebinding with the following yaml
```
---
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: use-scc-tutorial-scc
rules:
  - apiGroups: ["security.openshift.io"]
    resources: ["securitycontextconstraints"]
    resourceNames: ["scc-tutorial-scc"]
    verbs: ["use"]
---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: use-scc-tutorial-scc
subjects:
  - kind: ServiceAccount
    name: scc-tutorial-sa
roleRef:
  kind: Role
  name: use-scc-tutorial-scc
  apiGroup: rbac.authorization.k8s.io
---
allowHostDirVolumePlugin: false
allowHostIPC: false
allowHostNetwork: false
allowHostPID: false
allowHostPorts: false
allowPrivilegeEscalation: true
allowPrivilegedContainer: false
allowedCapabilities: null
kind: SecurityContextConstraints
readOnlyRootFilesystem: false
apiVersion: security.openshift.io/v1
metadata:
  name: scc-tutorial-scc
allowPrivilegedContainer: false
runAsUser:
  type: MustRunAsRange 
  uidRangeMin: 1000
  uidRangeMax: 2000
seLinuxContext:
  type: RunAsAny
fsGroup:
  type: MustRunAs 
  ranges:
  - min: 5000
    max: 6000
supplementalGroups:
  type: MustRunAs 
  ranges:
  - min: 5000
    max: 6000
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: scc-move
spec:
  selector:
    matchLabels:
      app: scc-move
  template:
    metadata:
      labels:
        app: scc-move
    spec:
      nodeSelector:
        scctest: "yes"
      containers:
      - image: ubi8/ubi-minimal
        name: ubi-minimal
        command: ['sh', '-c', 'echo "Hello from user $(id -u)" && sleep infinity']
        securityContext:
          runAsUser: 1234
          runAsGroup: 5678
      serviceAccountName: scc-tutorial-sa
      securityContext:
        fsGroup: 5555
        supplementalGroups: [5777, 5888]
```

2. Check the pod's scc 
```
[root@api.ocp410kev.cp.fyre.ibm.com scctest]# k get pods scc-move-7b7c978c9f-8xfxp  -o yaml|grep "openshift.io/scc"
    openshift.io/scc: scc-tutorial-scc
```


3. Make sure the kubeturbo deployment doesn't specify the `scc-support` flag

```
k get -n default pod kubeturbo-kw-114-6dfb8cf99d-v2xkq -o yaml|grep scc
~~no output~~
```

4. Generate a move action on that pod and execute the action

5. The action is supposed to be executed well and the new pod is expected to run on the target node
```
[root@api.ocp410kev.cp.fyre.ibm.com scctest]# k get pods
NAME                                      READY   STATUS    RESTARTS   AGE
scc-move-7b7c978c9f-8xfxp-1eh5od08bl12u   1/1     Running   0          15m
```
![image](https://user-images.githubusercontent.com/61252360/219795680-4c583005-2166-4675-aea8-340f57feafb8.png)
