### PR TITLE
[OM-97470]: Update operator to support CLI arg to disable SCC impersonation cleanup

### DIFF
--- a/deploy/kubeturbo-operator/config/crd/bases/charts.helm.k8s.io_kubeturboes.yaml
+++ b/deploy/kubeturbo-operator/config/crd/bases/charts.helm.k8s.io_kubeturboes.yaml
@@ -165,6 +165,9 @@ spec:
                   stitchuuid:
                     description: Identify if using uuid or ip for stitching
                     type: boolean
+                  cleanupSccImpersonationResources:
+                    description: Identify if cleanup the resources created for scc impersonation, default is true
+                    type: boolean
               resources:
                 description: Kubeturbo resource configuration
                 type: object

--- a/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
+++ b/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
@@ -141,6 +141,9 @@ spec:
                 stitchuuid:
                   description: Identify if using uuid or ip for stitching, the default is true (use uuid instead of ip)
                   type: boolean
+                cleanupSccImpersonationResources:
+                  description: Identify if cleanup the resources created for scc impersonation, default is true
+                  type: boolean
             resources:
               type: object
               description: Kubeturbo resource configuration

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/deployment.yaml
@@ -68,6 +68,9 @@ spec:
           {{- if .Values.args.pre16k8sVersion }}
           - --k8sVersion=1.5
           {{- end }}
+          {{- if not .Values.args.cleanupSccImpersonationResources }}
+          - --cleanup-scc-impersonation-resources={{ .Values.args.cleanupSccImpersonationResources }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/deploy/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo/templates/deployment.yaml
@@ -68,6 +68,9 @@ spec:
           {{- if .Values.args.pre16k8sVersion }}
           - --k8sVersion=1.5
           {{- end }}
+          {{- if not .Values.args.cleanupSccImpersonationResources }}
+          - --cleanup-scc-impersonation-resources={{ .Values.args.cleanupSccImpersonationResources }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/deploy/kubeturbo_yamls/step5_turbo_kubeturboDeploy.yaml
+++ b/deploy/kubeturbo_yamls/step5_turbo_kubeturboDeploy.yaml
@@ -53,6 +53,8 @@ spec:
           #- --stitch-uuid=false
           # Uncomment to customize readiness retry threshold. Kubeturbo will try readiness-retry-threshold times before giving up. Default is 60. The retry interval is 10s.
           #- --readiness-retry-threshold=60
+          # Uncomment to disable the cleanup of the resources which are created by kubeturbo for the scc impersonation.
+          #- --cleanup-scc-impersonation-resources=false
         volumeMounts:
           # volume will be created, any name will work and must match below
           - name: turbo-volume


### PR DESCRIPTION
# Intent
Have introduced a new command line arg in kubeturbo to make it support enabling the cleanup of the resources created by kubeturbo when doing the SCC impersonation.  By default, the flag is set to `true` which means those resources will be deleted when kubeturbo exit. This change is going to update kubeturbo operator to support that new command line arg.

# Test Done

##  Set the flag to `true`
1. Create a kubeturbo CR specifying `cleanupSccImpersonationResources: true`
```
apiVersion: charts.helm.k8s.io/v1
kind: Kubeturbo
metadata:
  name: kubeturbo-release
  namespace: kevwang
spec:
  args:
    cleanupSccImpersonationResources: true  <-----Set the flag here
    failVolumePodMoves: "false"
    kubelethttps: true
    kubeletport: 10999
    sccsupport: '*'
  image:
    pullPolicy: Always
    repository: icr.io/cpopen/turbonomic/kubeturbo
    tag: 8.8.2-SNAPSHOT
  restAPIConfig:
    opsManagerPassword: vmturbo
    opsManagerUserName: Administrator
  serverMeta:
    turboServer: https://10.10.169.114
    version: 8.8.2
  targetConfig:
    targetName: aecluster2-via-operator
```
2. Check if the kubeturbo pod is created
```
[kevinw@Kevins-MacBook-Pro.local kubeturbo-operator]$ k get pods kubeturbo-release-65857d9b9f-qqqtc 
NAME                                 READY   STATUS    RESTARTS   AGE
kubeturbo-release-65857d9b9f-qqqtc   1/1     Running   0          17m
```
3. Check if the kubeturbo pod has that flag set, found no cleanup flag set because this flag default to `true` which keeps aligning with the value set in the kubeturbo CR. 
```
spec:
  containers:
  - args:
    - --turboconfig=/etc/kubeturbo/turbo.config
    - --v=2
    - --kubelet-https=true
    - --kubelet-port=10999
    - --scc-support=*
    - --fail-volume-pod-moves=false
   ....
```
4. Check the kubeturbo log and filter `cleanup`
```
[kevinw@Kevins-MacBook-Pro.local kubeturbo-operator]$ k logs kubeturbo-release-65857d9b9f-qqqtc |grep cleanup
I0224 21:22:25.628941       1 kubeturbo.go:89] FLAG: --cleanup-scc-impersonation-resources="true"
```

##  Set the flag to `false`
1. Create a kubeturbo CR specifying `cleanupSccImpersonationResources: false`
```
apiVersion: charts.helm.k8s.io/v1
kind: Kubeturbo
metadata:
  name: kubeturbo-release
  namespace: kevwang
spec:
  args:
    cleanupSccImpersonationResources: false  <-----Set the flag here
    failVolumePodMoves: "false"
    kubelethttps: true
    kubeletport: 10999
    sccsupport: '*'
  image:
    pullPolicy: Always
    repository: icr.io/cpopen/turbonomic/kubeturbo
    tag: 8.8.2-SNAPSHOT
  restAPIConfig:
    opsManagerPassword: vmturbo
    opsManagerUserName: Administrator
  serverMeta:
    turboServer: https://10.10.169.114
    version: 8.8.2
  targetConfig:
    targetName: aecluster2-via-operator
```
2. Check if the kubeturbo pod is created
```
[root@api.ocp410kev.cp.fyre.ibm.com kubeturbo-operator]# k get pods
NAME                                  READY   STATUS    RESTARTS   AGE
kubeturbo-operator-7674c996cd-492p2   1/1     Running   0          20m
kubeturbo-release-699c5f864f-xdqdl    1/1     Running   0          13m
```
3. Check if the kubeturbo pod has that flag set, found the flag in the pod's spec has been set to `false`
```
k edit pods kubeturbo-release-689b95c4d-j2rgq
....
spec:
  containers:
  - args:
    - --turboconfig=/etc/kubeturbo/turbo.config
    - --v=2
    - --kubelet-https=true
    - --kubelet-port=10999
    - --scc-support=*
    - --fail-volume-pod-moves=false
    - --cleanup-scc-impersonation-resources=false   <------------has been set to false
   ....
```
4. Check the kubeturbo log and filter `cleanup`
```
[kevinw@Kevins-MacBook-Pro.local kubeturbo-operator]$ k logs kubeturbo-release-689b95c4d-j2rgq |grep cleanup
I0224 21:45:51.267701       1 kubeturbo.go:89] FLAG: --cleanup-scc-impersonation-resources="false"
```

5. Check the create timestamp of the sa/role/rolebinding  created for scc impersonation
```
[root@api.ocp410kev.cp.fyre.ibm.com kubeturbo-operator]# k get sa|grep scc
kubeturbo-scc-anyuid                            2         14m
kubeturbo-scc-hostaccess                        2         14m
kubeturbo-scc-hostmount-anyuid                  2         14m
kubeturbo-scc-hostnetwork                       2         14m
kubeturbo-scc-machine-api-termination-handler   2         14m
kubeturbo-scc-node-exporter                     2         14m
kubeturbo-scc-nonroot                           2         14m
kubeturbo-scc-privileged                        2         14m
kubeturbo-scc-restricted                        2         14m
kubeturbo-scc-scc-tutorial-scc                  2         14m
[root@api.ocp410kev.cp.fyre.ibm.com kubeturbo-operator]# k get role|grep scc
kubeturbo-scc-use-anyuid                            2023-02-28T01:37:55Z
kubeturbo-scc-use-hostaccess                        2023-02-28T01:37:56Z
kubeturbo-scc-use-hostmount-anyuid                  2023-02-28T01:37:56Z
kubeturbo-scc-use-hostnetwork                       2023-02-28T01:37:56Z
kubeturbo-scc-use-machine-api-termination-handler   2023-02-28T01:37:56Z
kubeturbo-scc-use-node-exporter                     2023-02-28T01:37:56Z
kubeturbo-scc-use-nonroot                           2023-02-28T01:37:56Z
kubeturbo-scc-use-privileged                        2023-02-28T01:37:57Z
kubeturbo-scc-use-restricted                        2023-02-28T01:37:57Z
kubeturbo-scc-use-scc-tutorial-scc                  2023-02-28T01:37:57Z
[root@api.ocp410kev.cp.fyre.ibm.com kubeturbo-operator]# k get rolebinding|grep scc
kubeturbo-scc-use-anyuid                            Role/kubeturbo-scc-use-anyuid                            14m
kubeturbo-scc-use-hostaccess                        Role/kubeturbo-scc-use-hostaccess                        14m
kubeturbo-scc-use-hostmount-anyuid                  Role/kubeturbo-scc-use-hostmount-anyuid                  14m
kubeturbo-scc-use-hostnetwork                       Role/kubeturbo-scc-use-hostnetwork                       14m
kubeturbo-scc-use-machine-api-termination-handler   Role/kubeturbo-scc-use-machine-api-termination-handler   14m
kubeturbo-scc-use-node-exporter                     Role/kubeturbo-scc-use-node-exporter                     14m
kubeturbo-scc-use-nonroot                           Role/kubeturbo-scc-use-nonroot                           14m
kubeturbo-scc-use-privileged                        Role/kubeturbo-scc-use-privileged                        14m
kubeturbo-scc-use-restricted                        Role/kubeturbo-scc-use-restricted                        14m
kubeturbo-scc-use-scc-tutorial-scc                  Role/kubeturbo-scc-use-scc-tutorial-scc                  14m
```

6. Delete kubeturbo pod to make it restart and then check the above resources again, make sure those resources are not re-created, this could be told by the creation timestamp of the resources.
```
[root@api.ocp410kev.cp.fyre.ibm.com kubeturbo-operator]# k delete pods kubeturbo-release-699c5f864f-xdqdl 
pod "kubeturbo-release-699c5f864f-xdqdl" deleted
[root@api.ocp410kev.cp.fyre.ibm.com kubeturbo-operator]# k get pod
NAME                                  READY   STATUS    RESTARTS   AGE
kubeturbo-operator-7674c996cd-492p2   1/1     Running   0          25m
kubeturbo-release-699c5f864f-wdcc8    1/1     Running   0          16s   -----> new pod is created 16s ago
[root@api.ocp410kev.cp.fyre.ibm.com kubeturbo-operator]# k get sa|grep scc
kubeturbo-scc-anyuid                            2         18m       -----> The service account is created 18m ago
kubeturbo-scc-hostaccess                        2         18m
kubeturbo-scc-hostmount-anyuid                  2         18m
kubeturbo-scc-hostnetwork                       2         18m
kubeturbo-scc-machine-api-termination-handler   2         18m
kubeturbo-scc-node-exporter                     2         18m
kubeturbo-scc-nonroot                           2         18m
kubeturbo-scc-privileged                        2         18m
kubeturbo-scc-restricted                        2         18m
kubeturbo-scc-scc-tutorial-scc                  2         18m
[root@api.ocp410kev.cp.fyre.ibm.com kubeturbo-operator]# k get rolebinding|grep scc
kubeturbo-scc-use-anyuid                            Role/kubeturbo-scc-use-anyuid                            18m
kubeturbo-scc-use-hostaccess                        Role/kubeturbo-scc-use-hostaccess                        18m
kubeturbo-scc-use-hostmount-anyuid                  Role/kubeturbo-scc-use-hostmount-anyuid                  18m
kubeturbo-scc-use-hostnetwork                       Role/kubeturbo-scc-use-hostnetwork                       18m
kubeturbo-scc-use-machine-api-termination-handler   Role/kubeturbo-scc-use-machine-api-termination-handler   18m
kubeturbo-scc-use-node-exporter                     Role/kubeturbo-scc-use-node-exporter                     18m
kubeturbo-scc-use-nonroot                           Role/kubeturbo-scc-use-nonroot                           18m
kubeturbo-scc-use-privileged                        Role/kubeturbo-scc-use-privileged                        18m
kubeturbo-scc-use-restricted                        Role/kubeturbo-scc-use-restricted                        18m
kubeturbo-scc-use-scc-tutorial-scc                  Role/kubeturbo-scc-use-scc-tutorial-scc                  18m
[root@api.ocp410kev.cp.fyre.ibm.com kubeturbo-operator]# k get role|grep scc
kubeturbo-scc-use-anyuid                            2023-02-28T01:37:55Z
kubeturbo-scc-use-hostaccess                        2023-02-28T01:37:56Z
kubeturbo-scc-use-hostmount-anyuid                  2023-02-28T01:37:56Z
kubeturbo-scc-use-hostnetwork                       2023-02-28T01:37:56Z
kubeturbo-scc-use-machine-api-termination-handler   2023-02-28T01:37:56Z
kubeturbo-scc-use-node-exporter                     2023-02-28T01:37:56Z
kubeturbo-scc-use-nonroot                           2023-02-28T01:37:56Z
kubeturbo-scc-use-privileged                        2023-02-28T01:37:57Z
kubeturbo-scc-use-restricted                        2023-02-28T01:37:57Z
kubeturbo-scc-use-scc-tutorial-scc                  2023-02-28T01:37:57Z
```