### PR TITLE
[OM-97758] The deploy/kubeturbo folder gets ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,8 @@ _output/
 .vscode/
 .DS_Store
 kubeturbo.iml
-kubeturbo
-kubeturbo.linux
-kubeturbo.debug
+build/kubeturbo*
+build/linux
 integration.test
 dlv
 bin

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ debug-product: clean
 	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -gcflags "-N -l" -o $(OUTPUT_DIR)/$(BINARY).debug ./cmd/kubeturbo
 
 build: clean
-	go build -ldflags $(LDFLAGS) ./cmd/kubeturbo
+	go build -ldflags $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY) ./cmd/kubeturbo
 
 integration: clean
 	go test -c -o $(OUTPUT_DIR)/integration.test ./test/integration


### PR DESCRIPTION
gitignore was ignoring folder `deploy/kubeturbo` which is not correct.

Not in jira