### PR TITLE
[OM-97759] Kubeturbo helm deployment fails if turbonomicCredentialsSecretName gets commented out by user

### DIFF
--- a/deploy/kubeturbo/templates/deployment.yaml
+++ b/deploy/kubeturbo/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
         secret:
           defaultMode: 420
           optional: true
-          secretName: {{ .Values.restAPIConfig.turbonomicCredentialsSecretName | quote }}
+          secretName: {{ .Values.restAPIConfig.turbonomicCredentialsSecretName | default "turbonomic-credentials" | quote }}
       - name: varlog
         emptyDir: {}
       restartPolicy: Always


### PR DESCRIPTION
This fixes the error

```
Error: INSTALLATION FAILED: Deployment.apps "kubeturbo-..." is invalid: [spec.template.spec.volumes[1].secret.secretName: Required value, spec.template.spec.containers[0].volumeMounts[1].name: Not found: "turbonomic-credentials-volume"]
```

when the value for `turbonomicCredentialsSecretName` is not used