### PR TITLE
[OM-98358]:Set the default value for the scc cleanup arg in the operator

### DIFF
--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -93,5 +93,7 @@ args:
   stitchuuid: true
   # if Kubernetes version is older than 1.6, then add another arg for move/resize action
   pre16k8sVersion: false
+  # cleanup the resources for scc impersonation by deault
+  cleanupSccImpersonationResources: true
 
 resources: {}

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -93,5 +93,7 @@ args:
   stitchuuid: true
   # if Kubernetes version is older than 1.6, then add another arg for move/resize action
   pre16k8sVersion: false
+  # cleanup the resources for scc impersonation by deault
+  cleanupSccImpersonationResources: true
 
 resources: {}


### PR DESCRIPTION
# Test Done

##  Don't define the arg in the CR
**1. Delete the cleanup flag from kubeturbo CR**
```
apiVersion: charts.helm.k8s.io/v1
kind: Kubeturbo
metadata:
  annotations:
    operator-sdk/primary-resource: /turbo-all-binding
    operator-sdk/primary-resource-type: ClusterRoleBinding.rbac.authorization.k8s.io
  creationTimestamp: "2023-02-28T01:33:41Z"
  finalizers:
  - helm.sdk.operatorframework.io/uninstall-release
  generation: 10
  name: kubeturbo-release
  namespace: turbo
  resourceVersion: "39832891"
  uid: c28df7a0-3b7c-4577-8cef-c71a96d7e86a
spec:
  args:
    failVolumePodMoves: "false"
    kubelethttps: true
    kubeletport: 10999
```
**2. Save the CR and wait for the operator to recreate the kubeturbo pod**
```
[root@api.ocp410kev.cp.fyre.ibm.com ~]# k get pod kubeturbo-release-5668d587fd-mp9l6 
NAME                                 READY   STATUS    RESTARTS   AGE
kubeturbo-release-5668d587fd-mp9l6   1/1     Running   0          8m39s
```

**3. Check the cleanup arg in the pod log, it should be set to `true` by default**
```
[root@api.ocp410kev.cp.fyre.ibm.com ~]# k logs kubeturbo-release-5668d587fd-mp9l6 |grep cleanup
I0309 16:38:19.731013       1 kubeturbo.go:89] FLAG: --cleanup-scc-impersonation-resources="true"
```

