### PR TITLE
[OM-98205]: Upgraded golang.org/x/crypto to fix CVE-2022-27191

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/turbonomic/turbo-go-sdk v0.0.0-20221212155126-6e7e16cf1e1f
 	github.com/turbonomic/turbo-policy v0.0.0-20230227150618-cce94c7d2742
 	github.com/xanzy/go-gitlab v0.74.0
+	k8s.io/klog/v2 v2.30.0
 )
 
 require (
@@ -58,7 +59,7 @@ require (
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa // indirect
-	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b // indirect
 	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
@@ -70,7 +71,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/kubernetes v1.23.1 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -274,7 +274,7 @@ github.com/turbonomic/turbo-policy/api/v1alpha1
 # github.com/xanzy/go-gitlab v0.74.0
 ## explicit; go 1.18
 github.com/xanzy/go-gitlab
-# golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 => golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f
+# golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b => golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f
 ## explicit; go 1.17
 golang.org/x/crypto/cast5
 golang.org/x/crypto/openpgp


### PR DESCRIPTION
## Intent

Fix [CVE-2022-27191](https://nvd.nist.gov/vuln/detail/CVE-2022-27191).

## Testing

Tested basic functionality in Kubeturbo.

Built an image with upgraded dependency and scanned with [Twistlock](https://pages.github.ibm.com/SOSTeam/SOS-Docs/container-security/quickstart/). See attached scan results.

[twistlock-scan-results-20230309-171743-N-UTC-D02AB1AF.results.csv](https://github.com/turbonomic/kubeturbo/files/10935357/twistlock-scan-results-20230309-171743-N-UTC-D02AB1AF.results.csv)

