### PR TITLE
[OM-94867] Unit tests for new podaffinity processing algorithm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/turbonomic/turbo-policy v0.0.0-20230227150618-cce94c7d2742
 	github.com/xanzy/go-gitlab v0.74.0
 	k8s.io/klog/v2 v2.30.0
+	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 )
 
 require (
@@ -73,7 +74,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/kubernetes v1.23.1 // indirect
-	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
 	sigs.k8s.io/cluster-api-provider-aws v0.0.0-00010101000000-000000000000 // indirect
 	sigs.k8s.io/cluster-api-provider-azure v0.0.0-00010101000000-000000000000 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -882,8 +882,6 @@ github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa h1:x7AkF/BAbv
 github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3 h1:R/3tmGlz0R2NakwJqoigcMNYN0jTYYXz1ngTFs0nD9M=
 github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3/go.mod h1:HAD6GcQFpgDGHOwhuCCjxQQWDjK2wv6gUvd5J3ZNU2g=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20221212155126-6e7e16cf1e1f h1:Q5S97C+xi2ykIVjz5vXhZIrDG7BMAfbpAC/0INTvL4I=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20221212155126-6e7e16cf1e1f/go.mod h1:RWvXz62oL7Yhkw+WRdDRdOEZSsm8f0vR3xvsgSU9ohM=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20230307040640-43e100c457e6 h1:5e9XGi6c5gfJhFhVCnAZL64oF3UcdsemtSW9XcRlC+o=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20230307040640-43e100c457e6/go.mod h1:RWvXz62oL7Yhkw+WRdDRdOEZSsm8f0vR3xvsgSU9ohM=
 github.com/turbonomic/turbo-policy v0.0.0-20230227150618-cce94c7d2742 h1:xj2BKHTjTGtCe7w0AFQ4lACtcCuzUO/zJbUyQhebtdc=

--- a/pkg/discovery/worker/compliance/podaffinity/filtering_test.go
+++ b/pkg/discovery/worker/compliance/podaffinity/filtering_test.go
@@ -1,0 +1,863 @@
+package podaffinity
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
+	at "github.com/turbonomic/kubeturbo/pkg/discovery/worker/compliance/podaffinity/testing"
+)
+
+var (
+	defaultNamespace = ""
+	ns1              = "ns1"
+)
+
+var nsLabelT1 = map[string]string{"team": "team1"}
+var nsLabelT2 = map[string]string{"team": "team2"}
+var namespaces = []*v1.Namespace{
+	{ObjectMeta: metav1.ObjectMeta{Name: "subteam1.team1", Labels: nsLabelT1}},
+	{ObjectMeta: metav1.ObjectMeta{Name: "subteam2.team1", Labels: nsLabelT1}},
+	{ObjectMeta: metav1.ObjectMeta{Name: "subteam1.team2", Labels: nsLabelT2}},
+	{ObjectMeta: metav1.ObjectMeta{Name: "subteam2.team2", Labels: nsLabelT2}},
+}
+
+type fakeNSLister struct {
+	namespaces []*v1.Namespace
+}
+
+func NewFakeNSLister(namespaces []*v1.Namespace) listersv1.NamespaceLister {
+	return &fakeNSLister{
+		namespaces: namespaces,
+	}
+}
+
+func (f *fakeNSLister) List(selector labels.Selector) (ret []*v1.Namespace, err error) {
+	for _, ns := range f.namespaces {
+		if selector.Matches(labels.Set(ns.GetLabels())) {
+			ret = append(ret, ns)
+		}
+	}
+	return ret, nil
+}
+
+func (f *fakeNSLister) Get(name string) (*v1.Namespace, error) {
+	for _, ns := range f.namespaces {
+		if ns.Name == name {
+			return ns, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Namespace does not exist")
+}
+
+func TestRequiredAffinitySingleNode(t *testing.T) {
+	podLabel := map[string]string{"service": "securityscan"}
+	pod := at.MakePod().Name("pod1").Namespace(ns1).Labels(podLabel).Node("node1").Obj()
+
+	labels1 := map[string]string{
+		"region": "r1",
+		"zone":   "z11",
+	}
+	podLabel2 := map[string]string{"security": "S1"}
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: labels1}}
+
+	tests := []struct {
+		name                string
+		podToPlace          *v1.Pod
+		pods                []*v1.Pod
+		expectPlaced        bool
+		expectPrefilterFail bool
+	}{
+		{
+			name:         "A pod that has no required pod affinity scheduling rules can schedule onto a node with no existing pods",
+			podToPlace:   new(v1.Pod),
+			expectPlaced: true,
+		},
+		{
+			name:         "satisfies the pod with requiredDuringSchedulingIgnoredDuringExecution in PodAffinity using In operator that matches the existing pod",
+			podToPlace:   at.MakePod().Name("podToPlace").Namespace(ns1).Labels(podLabel2).PodAffinityIn("service", "region", []string{"securityscan", "value2"}, at.PodAffinityWithRequiredReq).Obj(),
+			pods:         []*v1.Pod{pod},
+			expectPlaced: true,
+		},
+		{
+			name:         "satisfies the pod with requiredDuringSchedulingIgnoredDuringExecution in PodAffinity using not in operator in labelSelector that matches the existing pod",
+			podToPlace:   at.MakePod().Name("podToPlace").Namespace(ns1).Labels(podLabel2).PodAffinityNotIn("service", "region", []string{"securityscan3", "value3"}, at.PodAffinityWithRequiredReq).Obj(),
+			pods:         []*v1.Pod{pod},
+			expectPlaced: true,
+		},
+		{
+			name: "Does not satisfy the PodAffinity with labelSelector because of diff Namespace",
+			podToPlace: createPodWithAffinityTerms(defaultNamespace, "", "podToPlace", podLabel2,
+				[]v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"securityscan", "value2"},
+								},
+							},
+						},
+						Namespaces: []string{"DiffNameSpace"},
+					},
+				}, nil),
+			pods:         []*v1.Pod{at.MakePod().Namespace("ns").Label("service", "securityscan").Node("node1").Obj()},
+			expectPlaced: false,
+		},
+		{
+			name:         "Doesn't satisfy the PodAffinity because of unmatching labelSelector with the existing pod",
+			podToPlace:   at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(podLabel).PodAffinityIn("service", "", []string{"antivirusscan", "value2"}, at.PodAffinityWithRequiredReq).Obj(),
+			pods:         []*v1.Pod{pod},
+			expectPlaced: false,
+		},
+		{
+			name: "satisfies the PodAffinity with different label Operators in multiple RequiredDuringSchedulingIgnoredDuringExecution ",
+			podToPlace: createPodWithAffinityTerms(ns1, "", "podToPlace", podLabel2,
+				[]v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpExists,
+								}, {
+									Key:      "wrongkey",
+									Operator: metav1.LabelSelectorOpDoesNotExist,
+								},
+							},
+						},
+						TopologyKey: "region",
+					}, {
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"securityscan"},
+								}, {
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpNotIn,
+									Values:   []string{"WrongValue"},
+								},
+							},
+						},
+						TopologyKey: "region",
+					},
+				}, nil),
+			pods:         []*v1.Pod{pod},
+			expectPlaced: true,
+		},
+		{
+			name: "The labelSelector requirements(items of matchExpressions) are ANDed, the pod cannot schedule onto the node because one of the matchExpression item don't match.",
+			podToPlace: createPodWithAffinityTerms(defaultNamespace, "", "podToPlace", podLabel2,
+				[]v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpExists,
+								}, {
+									Key:      "wrongkey",
+									Operator: metav1.LabelSelectorOpDoesNotExist,
+								},
+							},
+						},
+						TopologyKey: "region",
+					}, {
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"securityscan2"},
+								}, {
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpNotIn,
+									Values:   []string{"WrongValue"},
+								},
+							},
+						},
+						TopologyKey: "region",
+					},
+				}, nil),
+			pods:         []*v1.Pod{pod},
+			expectPlaced: false,
+		},
+		{
+			name: "satisfies the PodAffinity and PodAntiAffinity with the existing pod",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(ns1).Labels(podLabel2).
+				PodAffinityIn("service", "region", []string{"securityscan", "value2"}, at.PodAffinityWithRequiredReq).
+				PodAntiAffinityIn("service", "node", []string{"antivirusscan", "value2"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods:         []*v1.Pod{pod},
+			expectPlaced: true,
+		},
+		{
+			name: "satisfies the PodAffinity and PodAntiAffinity and PodAntiAffinity symmetry with the existing pod",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(podLabel2).
+				PodAffinityIn("service", "region", []string{"securityscan", "value2"}, at.PodAffinityWithRequiredReq).
+				PodAntiAffinityIn("service", "node", []string{"antivirusscan", "value2"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("pod1").Namespace(defaultNamespace).Node("node1").Labels(podLabel).
+					PodAntiAffinityIn("service", "node", []string{"antivirusscan", "value2"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectPlaced: true,
+		},
+		{
+			name: "satisfies the PodAffinity but doesn't satisfy the PodAntiAffinity with the existing pod",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(podLabel2).
+				PodAffinityIn("service", "region", []string{"securityscan", "value2"}, at.PodAffinityWithRequiredReq).
+				PodAntiAffinityIn("service", "zone", []string{"securityscan", "value2"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods:         []*v1.Pod{pod},
+			expectPlaced: false,
+		},
+		{
+			name: "satisfies the PodAffinity and PodAntiAffinity but doesn't satisfy PodAntiAffinity symmetry with the existing pod",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(podLabel).
+				PodAffinityIn("service", "region", []string{"securityscan", "value2"}, at.PodAffinityWithRequiredReq).
+				PodAntiAffinityIn("service", "node", []string{"antivirusscan", "value2"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("pod1").Namespace(defaultNamespace).Labels(podLabel).Node("node1").PodAntiAffinityIn("service", "zone", []string{"securityscan", "value2"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectPlaced: false,
+		},
+		{
+			name: "pod matches its own Label in PodAffinity and that matches the existing pod Labels",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(podLabel).
+				PodAffinityNotIn("service", "region", []string{"securityscan", "value2"}, at.PodAffinityWithRequiredReq).Obj(),
+			pods:         []*v1.Pod{at.MakePod().Name("pod1").Label("service", "securityscan").Node("node2").Obj()},
+			expectPlaced: false,
+		},
+		{
+			name:       "verify that PodAntiAffinity from existing pod is respected when pod has no AntiAffinity constraints. doesn't satisfy PodAntiAffinity symmetry with the existing pod",
+			podToPlace: at.MakePod().Name("podToPlace").Labels(podLabel).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("pod1").Namespace(defaultNamespace).Node("node1").Labels(podLabel).
+					PodAntiAffinityIn("service", "zone", []string{"securityscan", "value2"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectPlaced: false,
+		},
+		{
+			name:       "verify that PodAntiAffinity from existing pod is respected when pod has no AntiAffinity constraints. satisfy PodAntiAffinity symmetry with the existing pod",
+			podToPlace: at.MakePod().Name("podToPlace").Labels(podLabel).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("pod1").Namespace(defaultNamespace).Node("node1").Labels(podLabel).
+					PodAntiAffinityNotIn("service", "zone", []string{"securityscan", "value2"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectPlaced: true,
+		},
+		{
+			name: "satisfies the PodAntiAffinity with existing pod but doesn't satisfy PodAntiAffinity symmetry with incoming pod",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(podLabel).
+				PodAntiAffinityExists("service", "region", at.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityExists("security", "region", at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("pod1").Namespace(defaultNamespace).Node("node1").Labels(podLabel2).
+					PodAntiAffinityExists("security", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectPlaced: false,
+		},
+		{
+			name: "PodAntiAffinity symmetry check a1: incoming pod and existing pod partially match each other on AffinityTerms",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(podLabel).
+				PodAntiAffinityExists("service", "zone", at.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityExists("security", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("pod1").Namespace(defaultNamespace).Node("node1").Labels(podLabel2).
+					PodAntiAffinityExists("security", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectPlaced: false,
+		},
+		{
+			name: "PodAntiAffinity symmetry check a2: incoming pod and existing pod partially match each other on AffinityTerms",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(podLabel2).
+				PodAntiAffinityExists("security", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("pod1").Namespace(defaultNamespace).Node("node1").Labels(podLabel).
+					PodAntiAffinityExists("service", "zone", at.PodAntiAffinityWithRequiredReq).
+					PodAntiAffinityExists("security", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectPlaced: false,
+		},
+		{
+			name: "PodAntiAffinity symmetry check b1: incoming pod and existing pod partially match each other on AffinityTerms",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(map[string]string{"abc": "", "xyz": ""}).
+				PodAntiAffinityExists("abc", "zone", at.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityExists("def", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("pod1").Namespace(defaultNamespace).Node("node1").Labels(map[string]string{"def": "", "xyz": ""}).
+					PodAntiAffinityExists("abc", "zone", at.PodAntiAffinityWithRequiredReq).
+					PodAntiAffinityExists("def", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectPlaced: false,
+		},
+		{
+			name: "PodAntiAffinity symmetry check b2: incoming pod and existing pod partially match each other on AffinityTerms",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(map[string]string{"def": "", "xyz": ""}).
+				PodAntiAffinityExists("abc", "zone", at.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityExists("def", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("pod1").Namespace(defaultNamespace).Node("node1").Labels(map[string]string{"abc": "", "xyz": ""}).
+					PodAntiAffinityExists("abc", "zone", at.PodAntiAffinityWithRequiredReq).
+					PodAntiAffinityExists("def", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectPlaced: false,
+		},
+		{
+			name: "PodAffinity fails PreFilter with an invalid affinity label syntax",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(podLabel).
+				PodAffinityIn("service", "region", []string{"{{.bad-value.}}"}, at.PodAffinityWithRequiredReq).
+				PodAffinityIn("service", "node", []string{"antivirusscan", "value2"}, at.PodAffinityWithRequiredReq).Obj(),
+			expectPlaced:        false,
+			expectPrefilterFail: true,
+		},
+		{
+			name: "PodAntiAffinity fails PreFilter with an invalid antiaffinity label syntax",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(podLabel).
+				PodAffinityIn("service", "region", []string{"foo"}, at.PodAffinityWithRequiredReq).
+				PodAffinityIn("service", "node", []string{"{{.bad-value.}}"}, at.PodAffinityWithRequiredReq).Obj(),
+			expectPlaced:        false,
+			expectPrefilterFail: true,
+		},
+		{
+			name: "affinity with NamespaceSelector",
+			podToPlace: createPodWithAffinityTerms(defaultNamespace, "", "podToPlace", podLabel2,
+				[]v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"securityscan", "value2"},
+								},
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "team",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"team1"},
+								},
+							},
+						},
+						TopologyKey: "region",
+					},
+				}, nil),
+			pods:         []*v1.Pod{{Spec: v1.PodSpec{NodeName: "node1"}, ObjectMeta: metav1.ObjectMeta{Namespace: "subteam1.team1", Labels: podLabel}}},
+			expectPlaced: true,
+		},
+		{
+			name: "affinity with non-matching NamespaceSelector",
+			podToPlace: createPodWithAffinityTerms(ns1, "", "podToPlace", podLabel2,
+				[]v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"securityscan", "value2"},
+								},
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "team",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"team1"},
+								},
+							},
+						},
+						TopologyKey: "region",
+					},
+				}, nil),
+			pods:         []*v1.Pod{{Spec: v1.PodSpec{NodeName: "node1"}, ObjectMeta: metav1.ObjectMeta{Namespace: "subteam1.team2", Labels: podLabel}}},
+			expectPlaced: false,
+		},
+		{
+			name: "anti-affinity with matching NamespaceSelector",
+			podToPlace: createPodWithAffinityTerms("subteam1.team1", "", "podToPlace", podLabel2, nil,
+				[]v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"securityscan", "value2"},
+								},
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "team",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"team1"},
+								},
+							},
+						},
+						TopologyKey: "zone",
+					},
+				}),
+			pods:         []*v1.Pod{{Spec: v1.PodSpec{NodeName: "node1"}, ObjectMeta: metav1.ObjectMeta{Namespace: "subteam2.team1", Name: "pod1", Labels: podLabel}}},
+			expectPlaced: false,
+		},
+		{
+			name: "anti-affinity with matching all NamespaceSelector",
+			podToPlace: createPodWithAffinityTerms("subteam1.team1", "", "podToPlace", podLabel2, nil,
+				[]v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"securityscan", "value2"},
+								},
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{},
+						TopologyKey:       "zone",
+					},
+				}),
+			pods:         []*v1.Pod{{Spec: v1.PodSpec{NodeName: "node1"}, ObjectMeta: metav1.ObjectMeta{Namespace: "subteam2.team1", Labels: podLabel}}},
+			expectPlaced: false,
+		},
+		{
+			name: "anti-affinity with non-matching NamespaceSelector",
+			podToPlace: createPodWithAffinityTerms("subteam1.team1", "", "podToPlace", podLabel2, nil,
+				[]v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "service",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"securityscan", "value2"},
+								},
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "team",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"team1"},
+								},
+							},
+						},
+						TopologyKey: "zone",
+					},
+				}),
+			pods:         []*v1.Pod{{Spec: v1.PodSpec{NodeName: "node1"}, ObjectMeta: metav1.ObjectMeta{Namespace: "subteam1.team2", Labels: podLabel}}},
+			expectPlaced: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			pods := []*v1.Pod{}
+			pods = append(pods, test.pods...)
+			clusterSummary := createTestClusterSummary(pods, []*v1.Node{node})
+			pr, err := New(clusterSummary,
+				NewNodeInfoLister(clusterSummary), NewFakeNSLister(namespaces))
+			if err != nil {
+				t.Errorf("Error creating new processor: %v", err)
+				return
+			}
+			nodeInfos, err := pr.nodeInfoLister.List()
+			if err != nil {
+				t.Errorf("Error retreiving nodeinfos while processing affinities, %V.", err)
+				return
+			}
+
+			podToPlace := test.podToPlace
+			qualifiedPodName := podToPlace.Namespace + "/" + podToPlace.Name
+			state, err := pr.PreFilter(ctx, podToPlace)
+			if err != nil {
+				if test.expectPrefilterFail {
+					return
+				}
+				t.Errorf("Error computing prefilter state for pod, %s.", qualifiedPodName)
+			}
+
+			err = pr.Filter(ctx, state, podToPlace, nodeInfos[0])
+			// Err means a placement was not found on this node
+			if err != nil && test.expectPlaced {
+				t.Errorf("Pod %s was expected to be placed on %s", podToPlace.Name, nodeInfos[0].node.Name)
+			} else if err == nil && !test.expectPlaced {
+				t.Errorf("Pod %s was NOT expected to be placed on %s", podToPlace.Name, nodeInfos[0].node.Name)
+			}
+		})
+	}
+}
+
+func TestRequiredAffinityMultipleNodes(t *testing.T) {
+	podLabelA := map[string]string{
+		"foo": "bar",
+	}
+	labelRgChina := map[string]string{
+		"region": "China",
+	}
+	labelRgChinaAzAz1 := map[string]string{
+		"region": "China",
+		"az":     "az1",
+	}
+	labelRgIndia := map[string]string{
+		"region": "India",
+	}
+
+	tests := []struct {
+		name              string
+		podToPlace        *v1.Pod
+		pods              []*v1.Pod
+		nodes             []*v1.Node
+		expectPlacedOn    sets.String
+		expectNotPlacedOn sets.String
+	}{
+		{
+			name:       "A pod can be scheduled onto all the nodes that have the same topology key & label value with one of them has an existing pod that matches the affinity rules",
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).PodAffinityIn("foo", "region", []string{"bar"}, at.PodAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("p1").Node("node1").Labels(podLabelA).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: labelRgChina}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: labelRgChinaAzAz1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: labelRgIndia}},
+			},
+			expectPlacedOn:    sets.NewString("node1", "node2"),
+			expectNotPlacedOn: sets.NewString("node3"),
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(map[string]string{"foo": "bar", "service": "securityscan"}).
+				PodAffinityIn("foo", "zone", []string{"bar"}, at.PodAffinityWithRequiredReq).
+				PodAffinityIn("service", "zone", []string{"securityscan"}, at.PodAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("p1").Node("nodeA").Labels(map[string]string{"foo": "bar"}).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"zone": "az1", "hostname": "h1"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"zone": "az2", "hostname": "h2"}}},
+			},
+			expectPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name: "The affinity rule is to schedule all of the pods of this collection to the same zone. The first pod of the collection " +
+				"should not be blocked from being scheduled onto any node, even there's no existing pod that matches the rule anywhere.",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).Labels(map[string]string{"foo": "bar", "service": "securityscan"}).
+				PodAffinityIn("foo", "zone", []string{"bar"}, at.PodAffinityWithRequiredReq).
+				PodAffinityIn("service", "zone", []string{"securityscan"}, at.PodAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("p1").Node("nodeA").Labels(map[string]string{"foo": "bar"}).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"zoneLabel": "az1", "hostname": "h1"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"zoneLabel": "az2", "hostname": "h2"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name:              "The first pod of the collection can only be scheduled on nodes labelled with the requested topology keys",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).PodAntiAffinityIn("foo", "region", []string{"abc"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Labels(map[string]string{"foo": "abc"}).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "hostname": "nodeB"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name:              "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that matches the inter pod affinity rule. The pod can not be scheduled onto nodeA and nodeB.",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).PodAntiAffinityIn("foo", "region", []string{"abc"}, at.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityIn("service", "zone", []string{"securityscan"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Labels(map[string]string{"foo": "abc", "service": "securityscan"}).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name:              "This test ensures that anti-affinity matches a pod when any term of the anti-affinity rule matches a pod.",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).PodAntiAffinityIn("foo", "region", []string{"abc"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Labels(map[string]string{"foo": "abc"}).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: labelRgChina}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: labelRgChinaAzAz1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeC", Labels: labelRgIndia}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA", "nodeB"),
+			expectPlacedOn:    sets.NewString("nodeC"),
+			name:              "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that matches the inter pod affinity rule. The pod can not be scheduled onto nodeA and nodeB but can be scheduled onto nodeC",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace("NS1").Labels(map[string]string{"foo": "123"}).PodAntiAffinityIn("foo", "region", []string{"bar"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Namespace("NS1").Labels(map[string]string{"foo": "bar"}).Obj(),
+				at.MakePod().Node("nodeC").Namespace("NS2").PodAntiAffinityIn("foo", "region", []string{"123"}, at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: labelRgChina}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: labelRgChinaAzAz1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeC", Labels: labelRgIndia}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA", "nodeB"),
+			expectPlacedOn:    sets.NewString("nodeC"),
+			name:              "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that matches the inter pod affinity rule. The pod can not be scheduled onto nodeA, nodeB, but can be scheduled onto nodeC (NodeC has an existing pod that match the inter pod affinity rule but in different namespace)",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Label("foo", "").Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Namespace(defaultNamespace).PodAntiAffinityExists("foo", "invalid-node-label", at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeB"}}},
+			},
+			expectPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name:           "Test existing pod's anti-affinity: if an existing pod has a term with invalid topologyKey, labelSelector of the term is firstly checked, and then topologyKey of the term is also checked",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Node("nodeA").Namespace(defaultNamespace).PodAntiAffinityExists("foo", "invalid-node-label", at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Labels(map[string]string{"foo": ""}).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeB"}}},
+			},
+			expectPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name:           "Test incoming pod's anti-affinity: even if labelSelector matches, we still check if topologyKey matches",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Label("foo", "").Label("bar", "").Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Namespace(defaultNamespace).PodAntiAffinityExists("foo", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+				at.MakePod().Node("nodeA").Namespace(defaultNamespace).PodAntiAffinityExists("bar", "region", at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name:              "Test existing pod's anti-affinity: incoming pod wouldn't considered as a fit as it violates each existingPod's terms on all nodes",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).PodAntiAffinityExists("foo", "zone", at.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityExists("bar", "region", at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Labels(map[string]string{"foo": ""}).Obj(),
+				at.MakePod().Node("nodeB").Labels(map[string]string{"bar": ""}).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name:              "Test incoming pod's anti-affinity: incoming pod wouldn't considered as a fit as it at least violates one anti-affinity rule of existingPod",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Label("foo", "").Label("bar", "").Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Namespace(defaultNamespace).PodAntiAffinityExists("foo", "invalid-node-label", at.PodAntiAffinityWithRequiredReq).
+					PodAntiAffinityExists("bar", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA"),
+			expectPlacedOn:    sets.NewString("nodeB"),
+			name:              "Test existing pod's anti-affinity: only when labelSelector and topologyKey both match, it's counted as a single term match - case when one term has invalid topologyKey",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).PodAntiAffinityExists("foo", "invalid-node-label", at.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityExists("bar", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("podA").Node("nodeA").Labels(map[string]string{"foo": "", "bar": ""}).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA"),
+			expectPlacedOn:    sets.NewString("nodeB"),
+			name:              "Test incoming pod's anti-affinity: only when labelSelector and topologyKey both match, it's counted as a single term match - case when one term has invalid topologyKey",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Label("foo", "").Label("bar", "").Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Namespace(defaultNamespace).Node("nodeA").PodAntiAffinityExists("foo", "region", at.PodAntiAffinityWithRequiredReq).
+					PodAntiAffinityExists("bar", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name:              "Test existing pod's anti-affinity: only when labelSelector and topologyKey both match, it's counted as a single term match - case when all terms have valid topologyKey",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).PodAntiAffinityExists("foo", "region", at.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityExists("bar", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Labels(map[string]string{"foo": "", "bar": ""}).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name:              "Test incoming pod's anti-affinity: only when labelSelector and topologyKey both match, it's counted as a single term match - case when all terms have valid topologyKey",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Label("foo", "").Label("bar", "").Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Namespace(defaultNamespace).PodAntiAffinityExists("foo", "zone", at.PodAntiAffinityWithRequiredReq).
+					PodAntiAffinityExists("labelA", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+				at.MakePod().Node("nodeB").Namespace(defaultNamespace).PodAntiAffinityExists("bar", "zone", at.PodAntiAffinityWithRequiredReq).
+					PodAntiAffinityExists("labelB", "zone", at.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeC", Labels: map[string]string{"region": "r1", "zone": "z3", "hostname": "nodeC"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeA", "nodeB"),
+			expectPlacedOn:    sets.NewString("nodeC"),
+			name:              "Test existing pod's anti-affinity: existingPod on nodeA and nodeB has at least one anti-affinity term matches incoming pod, so incoming pod can only be scheduled to nodeC",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).PodAffinityExists("foo", "region", at.PodAffinityWithRequiredReq).
+				PodAffinityExists("bar", "zone", at.PodAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Name("pod1").Labels(map[string]string{"foo": "", "bar": ""}).Node("nodeA").Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeB"}}},
+			},
+			expectPlacedOn: sets.NewString("nodeA", "nodeB"),
+			name:           "Test incoming pod's affinity: firstly check if all affinityTerms match, and then check if all topologyKeys match",
+		},
+		{
+			podToPlace: at.MakePod().Name("podToPlace").Namespace(defaultNamespace).PodAffinityExists("foo", "region", at.PodAffinityWithRequiredReq).
+				PodAffinityExists("bar", "zone", at.PodAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				at.MakePod().Node("nodeA").Name("pod1").Namespace(defaultNamespace).Labels(map[string]string{"foo": ""}).Obj(),
+				at.MakePod().Node("nodeB").Name("pod2").Namespace(defaultNamespace).Labels(map[string]string{"bar": ""}).Obj(),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
+			},
+			expectNotPlacedOn: sets.NewString("nodeC"),
+			name:              "Test incoming pod's affinity: firstly check if all affinityTerms match, and then check if all topologyKeys match, and the match logic should be satisfied on the same pod",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			pods := []*v1.Pod{}
+			pods = append(pods, test.pods...)
+			nodes := test.nodes
+			clusterSummary := createTestClusterSummary(pods, nodes)
+			pr, err := New(clusterSummary,
+				NewNodeInfoLister(clusterSummary), NewFakeNSLister([]*v1.Namespace{
+					{ObjectMeta: metav1.ObjectMeta{Name: "NS1"}},
+				}))
+			if err != nil {
+				t.Errorf("Error creating new processor: %v", err)
+				return
+			}
+			nodeInfos, err := pr.nodeInfoLister.List()
+			if err != nil {
+				t.Errorf("Error retreiving nodeinfos while processing affinities, %V.", err)
+				return
+			}
+
+			podToPlace := test.podToPlace
+			qualifiedPodName := podToPlace.Namespace + "/" + podToPlace.Name
+			state, err := pr.PreFilter(ctx, podToPlace)
+			if err != nil {
+				t.Errorf("Error computing prefilter state for pod, %s.", qualifiedPodName)
+				return
+			}
+
+			for _, nodeInfo := range nodeInfos {
+				err := pr.Filter(ctx, state, podToPlace, nodeInfo)
+				// Err means a placement was not found on this node
+				if err != nil && test.expectPlacedOn.Has(nodeInfo.node.Name) {
+					t.Errorf("Pod %s was supposed to be placed on %s", podToPlace.Name, nodeInfo.node.Name)
+				} else if err == nil && test.expectNotPlacedOn.Has(nodeInfo.node.Name) {
+					t.Errorf("Pod %s was NOT supposed to be placed on %s", podToPlace.Name, nodeInfo.node.Name)
+				}
+			}
+		})
+	}
+}
+
+func createPodWithAffinityTerms(namespace, nodeName, name string, labels map[string]string, affinity, antiAffinity []v1.PodAffinityTerm) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    labels,
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1.PodSpec{
+			NodeName: nodeName,
+			Affinity: &v1.Affinity{
+				PodAffinity: &v1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: affinity,
+				},
+				PodAntiAffinity: &v1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: antiAffinity,
+				},
+			},
+		},
+	}
+}
+
+func createTestClusterSummary(pods []*v1.Pod, nodes []*v1.Node) *repository.ClusterSummary {
+	kubecluster := &repository.KubeCluster{
+		Pods:  pods,
+		Nodes: nodes,
+	}
+	cs := &repository.ClusterSummary{
+		KubeCluster: kubecluster,
+	}
+
+	nodeToRunningPods := map[string][]*v1.Pod{}
+	for _, pod := range pods {
+		nodeToRunningPods[pod.Spec.NodeName] = append(nodeToRunningPods[pod.Spec.NodeName], pod)
+	}
+	cs.NodeToRunningPods = nodeToRunningPods
+
+	return cs
+}

--- a/pkg/discovery/worker/compliance/podaffinity/listers.go
+++ b/pkg/discovery/worker/compliance/podaffinity/listers.go
@@ -97,7 +97,7 @@ func NewNamespaceLister(client *client.Clientset, clusterSummary *repository.Clu
 
 		//	return
 		// TODO
-		return nil, fmt.Errorf("failed to sync")
+		return nil, fmt.Errorf("failed to sync lister cache while processing podaffinities")
 	}
 
 	return nsInformer.Lister(), nil

--- a/pkg/discovery/worker/compliance/podaffinity/processor.go
+++ b/pkg/discovery/worker/compliance/podaffinity/processor.go
@@ -24,13 +24,11 @@ package podaffinity
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
-	client "k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 
@@ -49,19 +47,16 @@ type PodAffinityProcessor struct {
 }
 
 // New initializes a new plugin and returns it.
-func New(client *client.Clientset, clusterSummary *repository.ClusterSummary) (*PodAffinityProcessor, error) {
+func New(clusterSummary *repository.ClusterSummary, nodeInfoLister NodeInfoLister,
+	namespaceLister listersv1.NamespaceLister) (*PodAffinityProcessor, error) {
 	pr := &PodAffinityProcessor{
-		nodeInfoLister:  NewNodeInfoLister(clusterSummary),
+		nodeInfoLister:  nodeInfoLister,
 		podToVolumesMap: clusterSummary.PodToVolumesMap,
 		// TODO: make the parallelizm configurable
 		parallelizer: parallelizer.NewParallelizer(parallelizer.DefaultParallelism),
-	}
-	nsLister, err := NewNamespaceLister(client, clusterSummary)
-	if err != nil {
-		return nil, fmt.Errorf("error creating affinity processor: %v", err)
+		nsLister:     namespaceLister,
 	}
 
-	pr.nsLister = nsLister
 	return pr, nil
 }
 

--- a/pkg/discovery/worker/compliance/podaffinity/testing/wrappers.go
+++ b/pkg/discovery/worker/compliance/podaffinity/testing/wrappers.go
@@ -1,0 +1,825 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This code is partially or fully copied from upstream k8s.
+This is copied over because it contains code which cannot be used externally
+and/or to avoid depending on k8s core.
+The k8s authors header is retained here to ensure due credit remains to original
+k8s code authors.
+*/
+
+/*
+This code retains some non used helpers for use in future test implementations.
+*/
+
+package testing
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+)
+
+var zero int64
+
+// NodeSelectorWrapper wraps a NodeSelector inside.
+type NodeSelectorWrapper struct{ v1.NodeSelector }
+
+// MakeNodeSelector creates a NodeSelector wrapper.
+func MakeNodeSelector() *NodeSelectorWrapper {
+	return &NodeSelectorWrapper{v1.NodeSelector{}}
+}
+
+// In injects a matchExpression (with an operator IN) as a selectorTerm
+// to the inner nodeSelector.
+// NOTE: appended selecterTerms are ORed.
+func (s *NodeSelectorWrapper) In(key string, vals []string) *NodeSelectorWrapper {
+	expression := v1.NodeSelectorRequirement{
+		Key:      key,
+		Operator: v1.NodeSelectorOpIn,
+		Values:   vals,
+	}
+	selectorTerm := v1.NodeSelectorTerm{}
+	selectorTerm.MatchExpressions = append(selectorTerm.MatchExpressions, expression)
+	s.NodeSelectorTerms = append(s.NodeSelectorTerms, selectorTerm)
+	return s
+}
+
+// NotIn injects a matchExpression (with an operator NotIn) as a selectorTerm
+// to the inner nodeSelector.
+func (s *NodeSelectorWrapper) NotIn(key string, vals []string) *NodeSelectorWrapper {
+	expression := v1.NodeSelectorRequirement{
+		Key:      key,
+		Operator: v1.NodeSelectorOpNotIn,
+		Values:   vals,
+	}
+	selectorTerm := v1.NodeSelectorTerm{}
+	selectorTerm.MatchExpressions = append(selectorTerm.MatchExpressions, expression)
+	s.NodeSelectorTerms = append(s.NodeSelectorTerms, selectorTerm)
+	return s
+}
+
+// Obj returns the inner NodeSelector.
+func (s *NodeSelectorWrapper) Obj() *v1.NodeSelector {
+	return &s.NodeSelector
+}
+
+// LabelSelectorWrapper wraps a LabelSelector inside.
+type LabelSelectorWrapper struct{ metav1.LabelSelector }
+
+// MakeLabelSelector creates a LabelSelector wrapper.
+func MakeLabelSelector() *LabelSelectorWrapper {
+	return &LabelSelectorWrapper{metav1.LabelSelector{}}
+}
+
+// Label applies a {k,v} pair to the inner LabelSelector.
+func (s *LabelSelectorWrapper) Label(k, v string) *LabelSelectorWrapper {
+	if s.MatchLabels == nil {
+		s.MatchLabels = make(map[string]string)
+	}
+	s.MatchLabels[k] = v
+	return s
+}
+
+// In injects a matchExpression (with an operator In) to the inner labelSelector.
+func (s *LabelSelectorWrapper) In(key string, vals []string) *LabelSelectorWrapper {
+	expression := metav1.LabelSelectorRequirement{
+		Key:      key,
+		Operator: metav1.LabelSelectorOpIn,
+		Values:   vals,
+	}
+	s.MatchExpressions = append(s.MatchExpressions, expression)
+	return s
+}
+
+// NotIn injects a matchExpression (with an operator NotIn) to the inner labelSelector.
+func (s *LabelSelectorWrapper) NotIn(key string, vals []string) *LabelSelectorWrapper {
+	expression := metav1.LabelSelectorRequirement{
+		Key:      key,
+		Operator: metav1.LabelSelectorOpNotIn,
+		Values:   vals,
+	}
+	s.MatchExpressions = append(s.MatchExpressions, expression)
+	return s
+}
+
+// Exists injects a matchExpression (with an operator Exists) to the inner labelSelector.
+func (s *LabelSelectorWrapper) Exists(k string) *LabelSelectorWrapper {
+	expression := metav1.LabelSelectorRequirement{
+		Key:      k,
+		Operator: metav1.LabelSelectorOpExists,
+	}
+	s.MatchExpressions = append(s.MatchExpressions, expression)
+	return s
+}
+
+// NotExist injects a matchExpression (with an operator NotExist) to the inner labelSelector.
+func (s *LabelSelectorWrapper) NotExist(k string) *LabelSelectorWrapper {
+	expression := metav1.LabelSelectorRequirement{
+		Key:      k,
+		Operator: metav1.LabelSelectorOpDoesNotExist,
+	}
+	s.MatchExpressions = append(s.MatchExpressions, expression)
+	return s
+}
+
+// Obj returns the inner LabelSelector.
+func (s *LabelSelectorWrapper) Obj() *metav1.LabelSelector {
+	return &s.LabelSelector
+}
+
+// ContainerWrapper wraps a Container inside.
+type ContainerWrapper struct{ v1.Container }
+
+// MakeContainer creates a Container wrapper.
+func MakeContainer() *ContainerWrapper {
+	return &ContainerWrapper{v1.Container{}}
+}
+
+// Obj returns the inner Container.
+func (c *ContainerWrapper) Obj() v1.Container {
+	return c.Container
+}
+
+// Name sets `n` as the name of the inner Container.
+func (c *ContainerWrapper) Name(n string) *ContainerWrapper {
+	c.Container.Name = n
+	return c
+}
+
+// Image sets `image` as the image of the inner Container.
+func (c *ContainerWrapper) Image(image string) *ContainerWrapper {
+	c.Container.Image = image
+	return c
+}
+
+// HostPort sets `hostPort` as the host port of the inner Container.
+func (c *ContainerWrapper) HostPort(hostPort int32) *ContainerWrapper {
+	c.Container.Ports = []v1.ContainerPort{{HostPort: hostPort}}
+	return c
+}
+
+// ContainerPort sets `ports` as the ports of the inner Container.
+func (c *ContainerWrapper) ContainerPort(ports []v1.ContainerPort) *ContainerWrapper {
+	c.Container.Ports = ports
+	return c
+}
+
+// Resources sets the container resources to the given resource map.
+func (c *ContainerWrapper) Resources(resMap map[v1.ResourceName]string) *ContainerWrapper {
+	res := v1.ResourceList{}
+	for k, v := range resMap {
+		res[k] = resource.MustParse(v)
+	}
+	c.Container.Resources = v1.ResourceRequirements{
+		Requests: res,
+		Limits:   res,
+	}
+	return c
+}
+
+// ResourceRequests sets the container resources requests to the given resource map of requests.
+func (c *ContainerWrapper) ResourceRequests(reqMap map[v1.ResourceName]string) *ContainerWrapper {
+	res := v1.ResourceList{}
+	for k, v := range reqMap {
+		res[k] = resource.MustParse(v)
+	}
+	c.Container.Resources = v1.ResourceRequirements{
+		Requests: res,
+	}
+	return c
+}
+
+// ResourceLimits sets the container resource limits to the given resource map.
+func (c *ContainerWrapper) ResourceLimits(limMap map[v1.ResourceName]string) *ContainerWrapper {
+	res := v1.ResourceList{}
+	for k, v := range limMap {
+		res[k] = resource.MustParse(v)
+	}
+	c.Container.Resources = v1.ResourceRequirements{
+		Limits: res,
+	}
+	return c
+}
+
+// PodWrapper wraps a Pod inside.
+type PodWrapper struct{ v1.Pod }
+
+// MakePod creates a Pod wrapper.
+func MakePod() *PodWrapper {
+	return &PodWrapper{v1.Pod{}}
+}
+
+// Obj returns the inner Pod.
+func (p *PodWrapper) Obj() *v1.Pod {
+	return &p.Pod
+}
+
+// Name sets `s` as the name of the inner pod.
+func (p *PodWrapper) Name(s string) *PodWrapper {
+	p.SetName(s)
+	return p
+}
+
+// UID sets `s` as the UID of the inner pod.
+func (p *PodWrapper) UID(s string) *PodWrapper {
+	p.SetUID(types.UID(s))
+	return p
+}
+
+// SchedulerName sets `s` as the scheduler name of the inner pod.
+func (p *PodWrapper) SchedulerName(s string) *PodWrapper {
+	p.Spec.SchedulerName = s
+	return p
+}
+
+// Namespace sets `s` as the namespace of the inner pod.
+func (p *PodWrapper) Namespace(s string) *PodWrapper {
+	p.SetNamespace(s)
+	return p
+}
+
+// OwnerReference updates the owning controller of the pod.
+func (p *PodWrapper) OwnerReference(name string, gvk schema.GroupVersionKind) *PodWrapper {
+	p.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
+			Name:       name,
+			Controller: pointer.Bool(true),
+		},
+	}
+	return p
+}
+
+// Container appends a container into PodSpec of the inner pod.
+func (p *PodWrapper) Container(s string) *PodWrapper {
+	name := fmt.Sprintf("con%d", len(p.Spec.Containers))
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image(s).Obj())
+	return p
+}
+
+// Containers sets `containers` to the PodSpec of the inner pod.
+func (p *PodWrapper) Containers(containers []v1.Container) *PodWrapper {
+	p.Spec.Containers = containers
+	return p
+}
+
+// Priority sets a priority value into PodSpec of the inner pod.
+func (p *PodWrapper) Priority(val int32) *PodWrapper {
+	p.Spec.Priority = &val
+	return p
+}
+
+// CreationTimestamp sets the inner pod's CreationTimestamp.
+func (p *PodWrapper) CreationTimestamp(t metav1.Time) *PodWrapper {
+	p.ObjectMeta.CreationTimestamp = t
+	return p
+}
+
+// Terminating sets the inner pod's deletionTimestamp to current timestamp.
+func (p *PodWrapper) Terminating() *PodWrapper {
+	now := metav1.Now()
+	p.DeletionTimestamp = &now
+	return p
+}
+
+// ZeroTerminationGracePeriod sets the TerminationGracePeriodSeconds of the inner pod to zero.
+func (p *PodWrapper) ZeroTerminationGracePeriod() *PodWrapper {
+	p.Spec.TerminationGracePeriodSeconds = &zero
+	return p
+}
+
+// Node sets `s` as the nodeName of the inner pod.
+func (p *PodWrapper) Node(s string) *PodWrapper {
+	p.Spec.NodeName = s
+	return p
+}
+
+// NodeSelector sets `m` as the nodeSelector of the inner pod.
+func (p *PodWrapper) NodeSelector(m map[string]string) *PodWrapper {
+	p.Spec.NodeSelector = m
+	return p
+}
+
+// NodeAffinityIn creates a HARD node affinity (with the operator In)
+// and injects into the inner pod.
+func (p *PodWrapper) NodeAffinityIn(key string, vals []string) *PodWrapper {
+	if p.Spec.Affinity == nil {
+		p.Spec.Affinity = &v1.Affinity{}
+	}
+	if p.Spec.Affinity.NodeAffinity == nil {
+		p.Spec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+	}
+	nodeSelector := MakeNodeSelector().In(key, vals).Obj()
+	p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = nodeSelector
+	return p
+}
+
+// NodeAffinityNotIn creates a HARD node affinity (with the operator NotIn)
+// and injects into the inner pod.
+func (p *PodWrapper) NodeAffinityNotIn(key string, vals []string) *PodWrapper {
+	if p.Spec.Affinity == nil {
+		p.Spec.Affinity = &v1.Affinity{}
+	}
+	if p.Spec.Affinity.NodeAffinity == nil {
+		p.Spec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+	}
+	nodeSelector := MakeNodeSelector().NotIn(key, vals).Obj()
+	p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = nodeSelector
+	return p
+}
+
+// StartTime sets `t` as .status.startTime for the inner pod.
+func (p *PodWrapper) StartTime(t metav1.Time) *PodWrapper {
+	p.Status.StartTime = &t
+	return p
+}
+
+// NominatedNodeName sets `n` as the .Status.NominatedNodeName of the inner pod.
+func (p *PodWrapper) NominatedNodeName(n string) *PodWrapper {
+	p.Status.NominatedNodeName = n
+	return p
+}
+
+// Phase sets `phase` as .status.Phase of the inner pod.
+func (p *PodWrapper) Phase(phase v1.PodPhase) *PodWrapper {
+	p.Status.Phase = phase
+	return p
+}
+
+// Condition adds a `condition(Type, Status, Reason)` to .Status.Conditions.
+func (p *PodWrapper) Condition(t v1.PodConditionType, s v1.ConditionStatus, r string) *PodWrapper {
+	p.Status.Conditions = append(p.Status.Conditions, v1.PodCondition{Type: t, Status: s, Reason: r})
+	return p
+}
+
+// Conditions sets `conditions` as .status.Conditions of the inner pod.
+func (p *PodWrapper) Conditions(conditions []v1.PodCondition) *PodWrapper {
+	p.Status.Conditions = append(p.Status.Conditions, conditions...)
+	return p
+}
+
+// Toleration creates a toleration (with the operator Exists)
+// and injects into the inner pod.
+func (p *PodWrapper) Toleration(key string) *PodWrapper {
+	p.Spec.Tolerations = append(p.Spec.Tolerations, v1.Toleration{
+		Key:      key,
+		Operator: v1.TolerationOpExists,
+	})
+	return p
+}
+
+// HostPort creates a container with a hostPort valued `hostPort`,
+// and injects into the inner pod.
+func (p *PodWrapper) HostPort(port int32) *PodWrapper {
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name("container").Image("pause").HostPort(port).Obj())
+	return p
+}
+
+// ContainerPort creates a container with ports valued `ports`,
+// and injects into the inner pod.
+func (p *PodWrapper) ContainerPort(ports []v1.ContainerPort) *PodWrapper {
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name("container").Image("pause").ContainerPort(ports).Obj())
+	return p
+}
+
+// PVC creates a Volume with a PVC and injects into the inner pod.
+func (p *PodWrapper) PVC(name string) *PodWrapper {
+	p.Spec.Volumes = append(p.Spec.Volumes, v1.Volume{
+		Name: name,
+		VolumeSource: v1.VolumeSource{
+			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: name},
+		},
+	})
+	return p
+}
+
+// Volume creates volume and injects into the inner pod.
+func (p *PodWrapper) Volume(volume v1.Volume) *PodWrapper {
+	p.Spec.Volumes = append(p.Spec.Volumes, volume)
+	return p
+}
+
+// PodAffinityKind represents different kinds of PodAffinity.
+type PodAffinityKind int
+
+const (
+	// NilPodAffinity is a no-op which doesn't apply any PodAffinity.
+	NilPodAffinity PodAffinityKind = iota
+	// PodAffinityWithRequiredReq applies a HARD requirement to pod.spec.affinity.PodAffinity.
+	PodAffinityWithRequiredReq
+	// PodAffinityWithPreferredReq applies a SOFT requirement to pod.spec.affinity.PodAffinity.
+	PodAffinityWithPreferredReq
+	// PodAffinityWithRequiredPreferredReq applies HARD and SOFT requirements to pod.spec.affinity.PodAffinity.
+	PodAffinityWithRequiredPreferredReq
+	// PodAntiAffinityWithRequiredReq applies a HARD requirement to pod.spec.affinity.PodAntiAffinity.
+	PodAntiAffinityWithRequiredReq
+	// PodAntiAffinityWithPreferredReq applies a SOFT requirement to pod.spec.affinity.PodAntiAffinity.
+	PodAntiAffinityWithPreferredReq
+	// PodAntiAffinityWithRequiredPreferredReq applies HARD and SOFT requirements to pod.spec.affinity.PodAntiAffinity.
+	PodAntiAffinityWithRequiredPreferredReq
+)
+
+// PodAffinity creates a PodAffinity with topology key and label selector
+// and injects into the inner pod.
+func (p *PodWrapper) PodAffinity(topologyKey string, labelSelector *metav1.LabelSelector, kind PodAffinityKind) *PodWrapper {
+	if kind == NilPodAffinity {
+		return p
+	}
+
+	if p.Spec.Affinity == nil {
+		p.Spec.Affinity = &v1.Affinity{}
+	}
+	if p.Spec.Affinity.PodAffinity == nil {
+		p.Spec.Affinity.PodAffinity = &v1.PodAffinity{}
+	}
+	term := v1.PodAffinityTerm{LabelSelector: labelSelector, TopologyKey: topologyKey}
+	switch kind {
+	case PodAffinityWithRequiredReq:
+		p.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+			p.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+			term,
+		)
+	case PodAffinityWithPreferredReq:
+		p.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			p.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			v1.WeightedPodAffinityTerm{Weight: 1, PodAffinityTerm: term},
+		)
+	case PodAffinityWithRequiredPreferredReq:
+		p.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+			p.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+			term,
+		)
+		p.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			p.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			v1.WeightedPodAffinityTerm{Weight: 1, PodAffinityTerm: term},
+		)
+	}
+	return p
+}
+
+// PodAntiAffinity creates a PodAntiAffinity with topology key and label selector
+// and injects into the inner pod.
+func (p *PodWrapper) PodAntiAffinity(topologyKey string, labelSelector *metav1.LabelSelector, kind PodAffinityKind) *PodWrapper {
+	if kind == NilPodAffinity {
+		return p
+	}
+
+	if p.Spec.Affinity == nil {
+		p.Spec.Affinity = &v1.Affinity{}
+	}
+	if p.Spec.Affinity.PodAntiAffinity == nil {
+		p.Spec.Affinity.PodAntiAffinity = &v1.PodAntiAffinity{}
+	}
+	term := v1.PodAffinityTerm{LabelSelector: labelSelector, TopologyKey: topologyKey}
+	switch kind {
+	case PodAntiAffinityWithRequiredReq:
+		p.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+			p.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+			term,
+		)
+	case PodAntiAffinityWithPreferredReq:
+		p.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			p.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			v1.WeightedPodAffinityTerm{Weight: 1, PodAffinityTerm: term},
+		)
+	case PodAntiAffinityWithRequiredPreferredReq:
+		p.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+			p.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+			term,
+		)
+		p.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			p.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			v1.WeightedPodAffinityTerm{Weight: 1, PodAffinityTerm: term},
+		)
+	}
+	return p
+}
+
+// PodAffinityExists creates a PodAffinity with the operator "Exists"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAffinityExists(labelKey, topologyKey string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().Exists(labelKey).Obj()
+	p.PodAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAntiAffinityExists creates a PodAntiAffinity with the operator "Exists"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAntiAffinityExists(labelKey, topologyKey string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().Exists(labelKey).Obj()
+	p.PodAntiAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAffinityNotExists creates a PodAffinity with the operator "NotExists"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAffinityNotExists(labelKey, topologyKey string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().NotExist(labelKey).Obj()
+	p.PodAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAntiAffinityNotExists creates a PodAntiAffinity with the operator "NotExists"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAntiAffinityNotExists(labelKey, topologyKey string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().NotExist(labelKey).Obj()
+	p.PodAntiAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAffinityIn creates a PodAffinity with the operator "In"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAffinityIn(labelKey, topologyKey string, vals []string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().In(labelKey, vals).Obj()
+	p.PodAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAntiAffinityIn creates a PodAntiAffinity with the operator "In"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAntiAffinityIn(labelKey, topologyKey string, vals []string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().In(labelKey, vals).Obj()
+	p.PodAntiAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAffinityNotIn creates a PodAffinity with the operator "NotIn"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAffinityNotIn(labelKey, topologyKey string, vals []string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().NotIn(labelKey, vals).Obj()
+	p.PodAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAntiAffinityNotIn creates a PodAntiAffinity with the operator "NotIn"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAntiAffinityNotIn(labelKey, topologyKey string, vals []string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().NotIn(labelKey, vals).Obj()
+	p.PodAntiAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// Label sets a {k,v} pair to the inner pod label.
+func (p *PodWrapper) Label(k, v string) *PodWrapper {
+	if p.ObjectMeta.Labels == nil {
+		p.ObjectMeta.Labels = make(map[string]string)
+	}
+	p.ObjectMeta.Labels[k] = v
+	return p
+}
+
+// Labels sets all {k,v} pair provided by `labels` to the inner pod labels.
+func (p *PodWrapper) Labels(labels map[string]string) *PodWrapper {
+	for k, v := range labels {
+		p.Label(k, v)
+	}
+	return p
+}
+
+// Annotation sets a {k,v} pair to the inner pod annotation.
+func (p *PodWrapper) Annotation(key, value string) *PodWrapper {
+	metav1.SetMetaDataAnnotation(&p.ObjectMeta, key, value)
+	return p
+}
+
+// Annotations sets all {k,v} pair provided by `annotations` to the inner pod annotations.
+func (p *PodWrapper) Annotations(annotations map[string]string) *PodWrapper {
+	for k, v := range annotations {
+		p.Annotation(k, v)
+	}
+	return p
+}
+
+// Res adds a new container to the inner pod with given resource map.
+func (p *PodWrapper) Res(resMap map[v1.ResourceName]string) *PodWrapper {
+	if len(resMap) == 0 {
+		return p
+	}
+
+	name := fmt.Sprintf("con%d", len(p.Spec.Containers))
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image("busybox").Resources(resMap).Obj())
+	return p
+}
+
+// Req adds a new container to the inner pod with given resource map of requests.
+func (p *PodWrapper) Req(reqMap map[v1.ResourceName]string) *PodWrapper {
+	if len(reqMap) == 0 {
+		return p
+	}
+
+	name := fmt.Sprintf("con%d", len(p.Spec.Containers))
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image("busybox").ResourceRequests(reqMap).Obj())
+	return p
+}
+
+// Lim adds a new container to the inner pod with given resource map of limits.
+func (p *PodWrapper) Lim(limMap map[v1.ResourceName]string) *PodWrapper {
+	if len(limMap) == 0 {
+		return p
+	}
+
+	name := fmt.Sprintf("con%d", len(p.Spec.Containers))
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image("busybox").ResourceLimits(limMap).Obj())
+	return p
+}
+
+// InitReq adds a new init container to the inner pod with given resource map.
+func (p *PodWrapper) InitReq(resMap map[v1.ResourceName]string) *PodWrapper {
+	if len(resMap) == 0 {
+		return p
+	}
+
+	name := fmt.Sprintf("init-con%d", len(p.Spec.InitContainers))
+	p.Spec.InitContainers = append(p.Spec.InitContainers, MakeContainer().Name(name).Image("busybox").Resources(resMap).Obj())
+	return p
+}
+
+// PreemptionPolicy sets the give preemption policy to the inner pod.
+func (p *PodWrapper) PreemptionPolicy(policy v1.PreemptionPolicy) *PodWrapper {
+	p.Spec.PreemptionPolicy = &policy
+	return p
+}
+
+// Overhead sets the give ResourceList to the inner pod
+func (p *PodWrapper) Overhead(rl v1.ResourceList) *PodWrapper {
+	p.Spec.Overhead = rl
+	return p
+}
+
+// NodeWrapper wraps a Node inside.
+type NodeWrapper struct{ v1.Node }
+
+// MakeNode creates a Node wrapper.
+func MakeNode() *NodeWrapper {
+	w := &NodeWrapper{v1.Node{}}
+	return w.Capacity(nil)
+}
+
+// Obj returns the inner Node.
+func (n *NodeWrapper) Obj() *v1.Node {
+	return &n.Node
+}
+
+// Name sets `s` as the name of the inner pod.
+func (n *NodeWrapper) Name(s string) *NodeWrapper {
+	n.SetName(s)
+	return n
+}
+
+// UID sets `s` as the UID of the inner pod.
+func (n *NodeWrapper) UID(s string) *NodeWrapper {
+	n.SetUID(types.UID(s))
+	return n
+}
+
+// Label applies a {k,v} label pair to the inner node.
+func (n *NodeWrapper) Label(k, v string) *NodeWrapper {
+	if n.Labels == nil {
+		n.Labels = make(map[string]string)
+	}
+	n.Labels[k] = v
+	return n
+}
+
+// Capacity sets the capacity and the allocatable resources of the inner node.
+// Each entry in `resources` corresponds to a resource name and its quantity.
+// By default, the capacity and allocatable number of pods are set to 32.
+func (n *NodeWrapper) Capacity(resources map[v1.ResourceName]string) *NodeWrapper {
+	res := v1.ResourceList{
+		v1.ResourcePods: resource.MustParse("32"),
+	}
+	for name, value := range resources {
+		res[name] = resource.MustParse(value)
+	}
+	n.Status.Capacity, n.Status.Allocatable = res, res
+	return n
+}
+
+// Images sets the images of the inner node. Each entry in `images` corresponds
+// to an image name and its size in bytes.
+func (n *NodeWrapper) Images(images map[string]int64) *NodeWrapper {
+	var containerImages []v1.ContainerImage
+	for name, size := range images {
+		containerImages = append(containerImages, v1.ContainerImage{Names: []string{name}, SizeBytes: size})
+	}
+	n.Status.Images = containerImages
+	return n
+}
+
+// Taints applies taints to the inner node.
+func (n *NodeWrapper) Taints(taints []v1.Taint) *NodeWrapper {
+	n.Spec.Taints = taints
+	return n
+}
+
+// PersistentVolumeClaimWrapper wraps a PersistentVolumeClaim inside.
+type PersistentVolumeClaimWrapper struct{ v1.PersistentVolumeClaim }
+
+// MakePersistentVolumeClaim creates a PersistentVolumeClaim wrapper.
+func MakePersistentVolumeClaim() *PersistentVolumeClaimWrapper {
+	return &PersistentVolumeClaimWrapper{}
+}
+
+// Obj returns the inner PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Obj() *v1.PersistentVolumeClaim {
+	return &p.PersistentVolumeClaim
+}
+
+// Name sets `s` as the name of the inner PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Name(s string) *PersistentVolumeClaimWrapper {
+	p.SetName(s)
+	return p
+}
+
+// Namespace sets `s` as the namespace of the inner PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Namespace(s string) *PersistentVolumeClaimWrapper {
+	p.SetNamespace(s)
+	return p
+}
+
+// Annotation sets a {k,v} pair to the inner PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Annotation(key, value string) *PersistentVolumeClaimWrapper {
+	metav1.SetMetaDataAnnotation(&p.ObjectMeta, key, value)
+	return p
+}
+
+// VolumeName sets `name` as the volume name of the inner
+// PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) VolumeName(name string) *PersistentVolumeClaimWrapper {
+	p.PersistentVolumeClaim.Spec.VolumeName = name
+	return p
+}
+
+// AccessModes sets `accessModes` as the access modes of the inner
+// PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) AccessModes(accessModes []v1.PersistentVolumeAccessMode) *PersistentVolumeClaimWrapper {
+	p.PersistentVolumeClaim.Spec.AccessModes = accessModes
+	return p
+}
+
+// Resources sets `resources` as the resource requirements of the inner
+// PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Resources(resources v1.ResourceRequirements) *PersistentVolumeClaimWrapper {
+	p.PersistentVolumeClaim.Spec.Resources = resources
+	return p
+}
+
+// PersistentVolumeWrapper wraps a PersistentVolume inside.
+type PersistentVolumeWrapper struct{ v1.PersistentVolume }
+
+// MakePersistentVolume creates a PersistentVolume wrapper.
+func MakePersistentVolume() *PersistentVolumeWrapper {
+	return &PersistentVolumeWrapper{}
+}
+
+// Obj returns the inner PersistentVolume.
+func (p *PersistentVolumeWrapper) Obj() *v1.PersistentVolume {
+	return &p.PersistentVolume
+}
+
+// Name sets `s` as the name of the inner PersistentVolume.
+func (p *PersistentVolumeWrapper) Name(s string) *PersistentVolumeWrapper {
+	p.SetName(s)
+	return p
+}
+
+// AccessModes sets `accessModes` as the access modes of the inner
+// PersistentVolume.
+func (p *PersistentVolumeWrapper) AccessModes(accessModes []v1.PersistentVolumeAccessMode) *PersistentVolumeWrapper {
+	p.PersistentVolume.Spec.AccessModes = accessModes
+	return p
+}
+
+// Capacity sets `capacity` as the resource list of the inner PersistentVolume.
+func (p *PersistentVolumeWrapper) Capacity(capacity v1.ResourceList) *PersistentVolumeWrapper {
+	p.PersistentVolume.Spec.Capacity = capacity
+	return p
+}
+
+// HostPathVolumeSource sets `src` as the host path volume source of the inner
+// PersistentVolume.
+func (p *PersistentVolumeWrapper) HostPathVolumeSource(src *v1.HostPathVolumeSource) *PersistentVolumeWrapper {
+	p.PersistentVolume.Spec.HostPath = src
+	return p
+}


### PR DESCRIPTION
This implements units tests for the new algorithm merged in #791
The test cases are all that exist upstream and the idea is to ensure tht all those test cases do pass, even after all the changes that we have done to adapt and import the algorithm from k8s upstream or will do in future.

This does not include tests for nodeaffiinity and pv affinity and can be taken up as a separate task at some point later.