### PR TITLE
Add TTLSecondsAfterFinished paramenter in cpufreq jobs to ensure they are cleaned up if left behind

### DIFF
--- a/pkg/kubeclient/cpufrequency.go
+++ b/pkg/kubeclient/cpufrequency.go
@@ -267,11 +267,14 @@ func (n *NodeCpuFrequencyGetter) createJob(namespace, nodeName string) (*batchv1
 func (n *NodeCpuFrequencyGetter) getCpuFreqJobDefinition(nodeName string) *batchv1.Job {
 	// There are no retries if the job fails it fails
 	backoffLimit := int32(0)
+	// Finished jobs will be automatically cleaned up in case they are leaked behind
+	ttlSecondsAfterFinished := int32(120)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kubeturbo-cpufreq-" + strconv.FormatInt(time.Now().UnixNano(), 32),
 		},
 		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{


### PR DESCRIPTION
**Intent**
_TTLSecondsAfterFinished_ has been available for jobs and stable since 1.23 k8s release. We have been missing to leverage the same. This PR simply adds the parameter for better cleanup

**Background**
Although we have the cleanup mechanism after the jobs complete or fail, we have had reports from user environments sometimes that they see plenty of jobs left behind. The only scenario which can be attributed to such behaviour is that kubeturbo is restarting multiple times for some reason and unable to cleanup the jobs it created (We do not have GC for jobs). This change should handle such envs.

