### PR TITLE
[OM-81610]: Fix missing tolerationSeconds

### DIFF
--- a/pkg/discovery/dtofactory/property/pod_properties.go
+++ b/pkg/discovery/dtofactory/property/pod_properties.go
@@ -2,6 +2,7 @@ package property
 
 import (
 	"fmt"
+	"strconv"
 
 	api "k8s.io/api/core/v1"
 
@@ -65,6 +66,11 @@ func BuildPodProperties(pod *api.Pod) []*proto.EntityDTO_EntityProperty {
 				tagNamePropertyValue += " " + toleration.Value
 			}
 		}
+
+		if toleration.TolerationSeconds != nil {
+			tagNamePropertyValue += " for " + strconv.FormatInt(*toleration.TolerationSeconds, 10) + "s"
+		}
+
 		tagProperty := &proto.EntityDTO_EntityProperty{
 			Namespace: &tagsPropertyNamespace,
 			Name:      &tagNamePropertyName,

--- a/pkg/discovery/dtofactory/property/property_test.go
+++ b/pkg/discovery/dtofactory/property/property_test.go
@@ -177,6 +177,33 @@ func TestBuildPodProperties(t *testing.T) {
 	assert.Equal(t, 5, matches, "there should be 5 matches in the test pod properties")
 }
 
+func TestBuildPodPropertiesWithSeconds(t *testing.T) {
+	tolerationSeconds := int64(300)
+	pod := &api.Pod{
+		Spec: api.PodSpec{
+			Tolerations: []api.Toleration{
+				{
+					Key:               "key",
+					Operator:          "op",
+					Effect:            "effect",
+					TolerationSeconds: &tolerationSeconds,
+				},
+			},
+		},
+	}
+
+	ps := BuildPodProperties(pod)
+
+	for _, p := range ps {
+		if p.GetName() == "[k8s toleration] effect" {
+			assert.EqualValues(t, "key op for 300s", p.GetValue())
+			return
+		}
+	}
+
+	assert.Fail(t, "tolerationSeconds is not found.")
+}
+
 func TestAddHostingPodProperties(t *testing.T) {
 	namespace := "xyz"
 	name := "poda"


### PR DESCRIPTION
**Problem:**

Add `tolerationSeconds` to toleration tags.

**Testing:**

Added a unit test. Ran `make tests`.

Tolerations tags have the seconds now:
![image](https://user-images.githubusercontent.com/12169353/228198006-9002f8bc-d23e-44da-84bc-8b3c3466be05.png)

