### PR TITLE
[OM-99845] Upgrade Cronjobs discovery API Version to v1

### DIFF
--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -78,7 +78,7 @@ var (
 	// The API group under which Job are exposed by the k8s cluster
 	K8sAPIJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1"}
 	// The API group under which CronJob are exposed by the k8s cluster
-	K8sAPICronJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1beta1"}
+	K8sAPICronJobGV = schema.GroupVersion{Group: K8sBatchGroupName, Version: "v1"}
 	// The API group under which openshifts scc resource is exposed by the server
 	OpenShiftAPISCCGV = schema.GroupVersion{Group: OpenShiftSecurityGroupName, Version: "v1"}
 


### PR DESCRIPTION
**Intent**
Fixes the issue reported in https://vmturbo.atlassian.net/browse/OM-99845

**Background**
We have use groups `batch` and API Version `v1beta1` since quite some time to discover cronjobs. These are however promoted to `v1` and `v1beta1` [deprecated in k8s version `1.21`](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md). 

We should use version `v1` for cronjobs in our discovery

**Test**
Ran a discovery cycle on a cluster with version `1.25` and the discovery ran fine without any cronjob related errors