### PR TITLE
build for target architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ debug-product: clean
 
 build: clean
 	@ if [ -z '${TARGETPLATFORM}' ]; then \
-	    echo "target is current platform"; \
+		echo "target is current platform"; \
 		go build -ldflags $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY) ./cmd/kubeturbo; \
 	else \
-	    echo "target is ${TARGETPLATFORM}"; \
+		echo "target is ${TARGETPLATFORM}"; \
 		env GOOS=$(firstword $(subst /, ,$(TARGETPLATFORM))) GOARCH=$(word 2, $(subst /, ,$(TARGETPLATFORM))) go build -ldflags $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY) ./cmd/kubeturbo; \
 	fi
 	

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,14 @@ debug-product: clean
 	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -gcflags "-N -l" -o $(OUTPUT_DIR)/$(BINARY).debug ./cmd/kubeturbo
 
 build: clean
-	go build -ldflags $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY) ./cmd/kubeturbo
-
+	@ if [ -z '${TARGETPLATFORM}' ]; then \
+	    echo "target is current platform"; \
+		go build -ldflags $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY) ./cmd/kubeturbo; \
+	else \
+	    echo "target is ${TARGETPLATFORM}"; \
+		env GOOS=$(firstword $(subst /, ,$(TARGETPLATFORM))) GOARCH=$(word 2, $(subst /, ,$(TARGETPLATFORM))) go build -ldflags $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY) ./cmd/kubeturbo; \
+	fi
+	
 integration: clean
 	go test -c -o $(OUTPUT_DIR)/integration.test ./test/integration
 

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,10 +1,11 @@
 # Building base image
 FROM --platform=$BUILDPLATFORM golang:1.20.3 AS builder
 ARG version
+ARG TARGETPLATFORM
 ENV KUBETURBO_VERSION $version
 WORKDIR /workspace
 ADD . ./
-RUN make build
+RUN make TARGETPLATFORM=$TARGETPLATFORM build
 
 
 FROM registry.access.redhat.com/ubi8


### PR DESCRIPTION
The builder is using the architecture of the build CPU which is not correct and results in a binary that cannot run on the target CPU.
This PR adds the compiler flags to fix it.