### PR TITLE
Fix the issue for supporting multi-platform build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,12 @@ vet:
 
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 REPO_NAME ?= icr.io/cpopen/turbonomic
+.PHONY: multi-archs
+multi-archs:
+	env GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY) ./cmd/kubeturbo
 .PHONY: docker-buildx
 docker-buildx:
 	docker buildx create --name kubeturbo-builder
 	- docker buildx use kubeturbo-builder
-	- docker buildx build --platform=$(PLATFORMS) --push --tag $(REPO_NAME)/kubeturbo:$(VERSION) -f build/Dockerfile.multi-archs --build-arg version=$(VERSION) .
+	- docker buildx build --platform=$(PLATFORMS) --label "git-commit=$(GIT_COMMIT)" --push --tag $(REPO_NAME)/kubeturbo:$(VERSION) -f build/Dockerfile.multi-archs --build-arg VERSION=$(VERSION) .
 	docker buildx rm kubeturbo-builder

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,10 +1,10 @@
 # Building base image
 FROM --platform=$BUILDPLATFORM golang:1.20.3 AS builder
-ARG version
-ENV KUBETURBO_VERSION $version
+ARG VERSION TARGETOS TARGETARCH
+ENV KUBETURBO_VERSION $VERSION
 WORKDIR /workspace
 ADD . ./
-RUN make build
+RUN make multi-archs
 
 
 FROM registry.access.redhat.com/ubi8


### PR DESCRIPTION
# Intent
To fix the problem that the `kubeturbo` binary in the ppc64le/arm64/s390x image is wrongly built

# Background
https://vmturbo.atlassian.net/browse/OM-100670

# Implementation
Pass the `GOOS` and GOARCH` arguments to the build command


# Test
```
root@dawning1:~# docker pull kevin0204/kubeturbo:8.8.6-LAST
8.8.6-LAST: Pulling from kevin0204/kubeturbo
05749dd975fe: Already exists 
4f4fb700ef54: Pull complete 
7f8d7b141389: Pull complete 
9eae8b582f24: Pull complete 
55d4a56a8808: Pull complete 
474fad9eff7a: Pull complete 
4c7144a99411: Pull complete 
b1fbd5319d9e: Pull complete 
a400436312b9: Pull complete 
Digest: sha256:be451e978801dead425fd69d52d4c0bf0282c244a1f41fbbb96177f3982f349e
Status: Downloaded newer image for kevin0204/kubeturbo:8.8.6-LAST
docker.io/kevin0204/kubeturbo:8.8.6-LAST
root@dawning1:~# docker exec -it --entrypoint sh  kevin0204/kubeturbo:8.8.6-LAST
unknown flag: --entrypoint
See 'docker exec --help'.
root@dawning1:~# docker run -it --entrypoint sh  kevin0204/kubeturbo:8.8.6-LAST
sh-4.4$ exec  /opt/turbonomic/bin/kubeturbo 
I0416 11:55:34.934961       1 kubeturbo.go:116] Running kubeturbo VERSION: 8.8.6-LAST, GIT_COMMIT: 052b4fa773ed0e9a1ed231b570f987e81d1de194, BUILD_TIME: Sun, 16 Apr 2023 11:47:43 +0000, GO_VERSION: go1.20.3
W0416 11:55:34.938137       1 kubeturbo_builder.go:331] Neither --kubeconfig nor --master was specified.  Using default API client.  This might not work.
W0416 11:55:34.938479       1 client_config.go:617] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
W0416 11:55:34.938507       1 client_config.go:622] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
E0416 11:55:34.938852       1 kubeturbo_builder.go:272] Fatal error: failed to get kubeconfig:  invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
root@dawning1:~# uname -a    <-------------- Power CPU Machine
Linux dawning1.fyre.ibm.com 5.4.0-144-generic #161-Ubuntu SMP Fri Feb 3 14:49:07 UTC 2023 ppc64le ppc64le ppc64le GNU/Linux
root@dawning1:~# docker inspect kevin0204/kubeturbo:8.8.6-LAST
[
    {
        "Id": "sha256:fed169c19edab4ad4676bb9eb9c44ccb4b0c2209faa78b1c0e17a67f6dbe3a5a",
        "RepoTags": [
            "kevin0204/kubeturbo:8.8.6-LAST"
        ],
        "RepoDigests": [
            "kevin0204/kubeturbo@sha256:be451e978801dead425fd69d52d4c0bf0282c244a1f41fbbb96177f3982f349e"
        ],
        "Parent": "",
        "Comment": "buildkit.dockerfile.v0",
        "Created": "2023-04-16T11:51:25.148007914Z",
        "Container": "",
        "ContainerConfig": {
            "Hostname": "",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": null,
            "Cmd": null,
            "Image": "",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": null,
            "OnBuild": null,
            "Labels": null
        },
        "DockerVersion": "",
        "Author": "Turbonomic <turbodeploy@turbonomic.com>",
        "Config": {
            "Hostname": "",
            "Domainname": "",
            "User": "10001",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/turbonomic/bin",
                "container=oci",
                "APP_ROOT=/opt/turbonomic",
                "USER_NAME=default",
                "USER_UID=10001"
            ],
            "Cmd": null,
            "Image": "",
            "Volumes": null,
            "WorkingDir": "/opt/turbonomic",
            "Entrypoint": [
                "/opt/turbonomic/bin/kubeturbo"
            ],
            "OnBuild": null,
            "Labels": {
                "architecture": "ppc64le",
                "build-date": "2023-03-28T04:02:10",
                "com.redhat.component": "ubi8-container",
                "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
                "description": "Hybrid Cloud Container leverages Turbonomic control platform, to assure the performance of micro-services running in OpenShift, as well as the efficiency of underlying infrastructure.",
                "distribution-scope": "public",
                "git-commit": "052b4fa773ed0e9a1ed231b570f987e81d1de194",
                "io.buildah.version": "1.27.3",
                "io.k8s.description": "Hybrid Cloud Container will monitor and control the entire stack, from OpenShift down to your underlying infrastructure. ",
                "io.k8s.display-name": "Hybrid Cloud Container",
                "io.openshift.expose-services": "",
                "io.openshift.tags": "turbonomic,Hybrid Cloud Container",
                "maintainer": "Red Hat, Inc.",
                "name": "Hybrid Cloud Container",
                "release": "1",
                "summary": "Performance assurance for the applications in Openshift",
                "url": "https://www.turbonomic.com",
                "vcs-ref": "a995512a05037e3b60bbb1bf9fa6e394063131c3",
                "vcs-type": "git",
                "vendor": "Turbonomic",
                "version": "v8.0.0"
            }
        },
        "Architecture": "ppc64le",
        "Os": "linux",
        "Size": 431767754,
        "VirtualSize": 431767754,
        "GraphDriver": {
            "Data": {
                "LowerDir": "/var/lib/docker/overlay2/32ff59099d5f3d40e4daa55e4501d6886d5bf86abcc8494274cdecff22fdfaec/diff:/var/lib/docker/overlay2/1f4f5a478a64dba82771d0563d599c90f320013b8e0c8e2548e52d14e4cd02a4/diff:/var/lib/docker/overlay2/da0e331a5a1c6e916d44400b275d5c3e5490a789ba577151cbcdf7e1c8a854f0/diff:/var/lib/docker/overlay2/ff38bdf7a4c83621ca615e8a051b7097fcff07262196c4ed0b0b99eec58af5c7/diff:/var/lib/docker/overlay2/8442c06f0e9f4b1e952b1e9883a3aa40c10efc45b066c91403009144f805f52b/diff:/var/lib/docker/overlay2/d84ef0ba967dc548a1366d2de5db6653238897852c2dd67aab7543bb6a081127/diff:/var/lib/docker/overlay2/c87d1c97dbbafcfcb8b85ec4e21bed31a8d2baebb26d4da674c9e2e6bd11a79b/diff:/var/lib/docker/overlay2/43ad7dc5c67a68f2bdbca029c51732fea8770feaa487a51354186f0d5984531e/diff:/var/lib/docker/overlay2/ed3ffc0d4c3a482206e24087e50463e6639c3c99cc332d9a3df93c4595c40e88/diff",
                "MergedDir": "/var/lib/docker/overlay2/ef80ecb3ae171076d3529cc1a5d7890d738ed21676ddcc0b45dc8868b4c1b5c8/merged",
                "UpperDir": "/var/lib/docker/overlay2/ef80ecb3ae171076d3529cc1a5d7890d738ed21676ddcc0b45dc8868b4c1b5c8/diff",
                "WorkDir": "/var/lib/docker/overlay2/ef80ecb3ae171076d3529cc1a5d7890d738ed21676ddcc0b45dc8868b4c1b5c8/work"
            },
            "Name": "overlay2"
        },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:4594abbd85658e6de3d88a79424f5148b8f1d9677554e4dce5087c99902a9da0",
                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
                "sha256:1b4e021396360d4014ede768e87544771669a3ff45ef2c9734b606537b8c18f6",
                "sha256:8060759ad6f12d08fbe15254f6f621b2807b42c7bd16ebbfcb74b1eec223616b",
                "sha256:d443835a870931954e6d173a18890fb796a9ffa09e5df41b94064d69df38ffef",
                "sha256:5d9bfb61177a0ac855c00196457991d10275680114730bfc41485635070b1630",
                "sha256:4deee71fc8e1222c6a5c71bc395ff04da77a236f4bbbcb0b5318c00933c5e215",
                "sha256:39d4fea43353823c00eb7aa8f82c0ae74d38ab04d7db42fa576393a424b7192a",
                "sha256:12285271e201d42ef7e64f573cbe023f55bbd6d3d24b9aa4c2b69b14ce2f6d04",
                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
            ]
        },
        "Metadata": {
            "LastTagTime": "0001-01-01T00:00:00Z"
        }
    }
]
```