### PR TITLE
[OM-100499] Use the entire cluster svc ID as the unique identifier

### DIFF
--- a/pkg/discovery/dtofactory/application_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/application_entity_dto_builder.go
@@ -221,7 +221,7 @@ func getAppStitchingProperty(pod *api.Pod, index int, svcUID string) string {
 		property = fmt.Sprintf("%s-%d", property, index)
 	}
 	if svcUID != "" {
-		property = fmt.Sprintf("%s,%s", property, property+"-"+util.ParseSvcUID(svcUID))
+		property = fmt.Sprintf("%s,%s-%s", property, property, svcUID)
 	}
 	return property
 }

--- a/pkg/discovery/dtofactory/service_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/service_entity_dto_builder.go
@@ -268,11 +268,11 @@ func getUUIDProperty(uuid string) *proto.EntityDTO_EntityProperty {
 func getIPProperty(pods []*api.Pod, svcUID string) *proto.EntityDTO_EntityProperty {
 	ns := stitching.DefaultPropertyNamespace
 	attr := stitching.AppStitchingAttr
-	ips := []string{}
+	var ips []string
 	for _, pod := range pods {
 		ips = append(ips, servicePrefix+"-"+pod.Status.PodIP)
 		if svcUID != "" {
-			ips = append(ips, servicePrefix+"-"+pod.Status.PodIP+"-"+util.ParseSvcUID(svcUID))
+			ips = append(ips, servicePrefix+"-"+pod.Status.PodIP+"-"+svcUID)
 		}
 	}
 	ip := strings.Join(ips, ",")

--- a/pkg/discovery/util/pod_util.go
+++ b/pkg/discovery/util/pod_util.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -499,19 +498,4 @@ func GetContainerNames(parent *unstructured.Unstructured) (sets.String, error) {
 		names = append(names, container.Name)
 	}
 	return sets.NewString(names...), nil
-}
-
-func ParseSvcUID(svcUID string) string {
-	regex, err := regexp.Compile("^[0-9a-fA-F]{8}")
-	if err != nil {
-		glog.Errorf("failed to compile regex pattern while parsing kubernetes service UUID: %v", err)
-		return ""
-	}
-	match := regex.FindStringSubmatch(svcUID)
-	if len(match) != 1 {
-		glog.Errorf("failed to parse UUID %v of the default kubernetes service %s/%s",
-			svcUID, defaultNamespace, defaultServiceName)
-		return ""
-	}
-	return match[0]
 }


### PR DESCRIPTION
This PR appends the entire cluster svc ID to the IP as the matching property to make sure there will be no practical chance for IP collision. 

I have decided not to hash the string because:

* The length of a typical MD5 or SHA256 hash range from 32 - 64 characters, which doesn't really save much space
* It becomes difficult to debug when there is a problem with stitching when the value is hashed

Verified by deploying the updated `prometurbo` and `kubeturbo` and made sure that stitching is working fine:

<img width="1646" alt="image" src="https://user-images.githubusercontent.com/10012486/233735605-232a86f4-7d66-4abc-920d-6aeb9ff95b3c.png">
