### PR TITLE
[OM-100430]: Update turbo-go-sdk vendor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/turbonomic/orm v0.0.0-20230411145227-4dccb88ccbac
 	github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20230307040640-43e100c457e6
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20230426193838-3d42e481fec9
 	github.com/turbonomic/turbo-policy v0.0.0-20230328195608-0556e3cbe9b3
 	github.com/xanzy/go-gitlab v0.74.0
 	k8s.io/klog/v2 v2.80.1

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa h1:x7AkF/BAbv
 github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3 h1:R/3tmGlz0R2NakwJqoigcMNYN0jTYYXz1ngTFs0nD9M=
 github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3/go.mod h1:HAD6GcQFpgDGHOwhuCCjxQQWDjK2wv6gUvd5J3ZNU2g=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20230307040640-43e100c457e6 h1:5e9XGi6c5gfJhFhVCnAZL64oF3UcdsemtSW9XcRlC+o=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20230307040640-43e100c457e6/go.mod h1:RWvXz62oL7Yhkw+WRdDRdOEZSsm8f0vR3xvsgSU9ohM=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20230426193838-3d42e481fec9 h1:drCOeXNVkAEm/FNngouf6mS3237eKZPc1EXn10KSqi8=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20230426193838-3d42e481fec9/go.mod h1:RWvXz62oL7Yhkw+WRdDRdOEZSsm8f0vR3xvsgSU9ohM=
 github.com/turbonomic/turbo-policy v0.0.0-20230328195608-0556e3cbe9b3 h1:KQkPBU3uKH87s4FjMrtxT4sYQCFab1kC7tTv46FZerE=
 github.com/turbonomic/turbo-policy v0.0.0-20230328195608-0556e3cbe9b3/go.mod h1:FlrjRrIlIT5MbFh9HmWiW8ZJ6qHCcuXNOJ6wCe6bFJ0=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
@@ -227,7 +227,7 @@ func (wsTransport *ClientWebSocketTransport) ListenForMessages() {
 				//notify upper module that this connection is closed
 				wsTransport.connClosedNotificationCh <- true // Note: this will block till the message is received
 
-				glog.V(1).Infof("[ListenForMessages] websocket error notified, stop lisening for messages.")
+				glog.V(1).Infof("[ListenForMessages] websocket error notified, stop listening for messages.")
 				return
 			}
 			// write the message on the channel

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go
@@ -70,7 +70,9 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 
 	// Sdk Protocol handler
 	sdkProtocolHandler := CreateSdkClientProtocolHandler(remoteMediationClient.allProbes,
-		remoteMediationClient.containerConfig.Version, remoteMediationClient.containerConfig.CommunicationBindingChannel)
+		remoteMediationClient.containerConfig.Version,
+		remoteMediationClient.containerConfig.CommunicationBindingChannel,
+		&remoteMediationClient.containerConfig.SdkProtocolConfig)
 	// ------ Websocket transport
 
 	transport := CreateClientWebSocketTransport(connConfig) //, transportClosedNotificationCh)

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/sdk_client_protocol.go
@@ -4,6 +4,7 @@ import (
 	protobuf "github.com/golang/protobuf/proto"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"github.com/turbonomic/turbo-go-sdk/pkg/version"
+	"os"
 
 	"fmt"
 	"time"
@@ -11,23 +12,37 @@ import (
 	"github.com/golang/glog"
 )
 
-const (
-	waitResponseTimeOut = time.Second * 30
-)
-
 type SdkClientProtocol struct {
-	allProbes                   map[string]*ProbeProperties
-	version                     string
-	communicationBindingChannel string
-	//TransportReady chan bool
+	allProbes                    map[string]*ProbeProperties
+	version                      string
+	communicationBindingChannel  string
+	registrationResponseTimeout  time.Duration
+	restartOnRegistrationTimeout bool
 }
 
-func CreateSdkClientProtocolHandler(allProbes map[string]*ProbeProperties, version, communicationBindingChannel string) *SdkClientProtocol {
+func CreateSdkClientProtocolHandler(allProbes map[string]*ProbeProperties, version, communicationBindingChannel string,
+	sdkProtocolConfig *SdkProtocolConfig) *SdkClientProtocol {
+
+	registrationResponseTimeout := time.Second * DefaultRegistrationTimeOut
+	restartOnRegistrationTimeout := false
+
+	if sdkProtocolConfig != nil {
+		if sdkProtocolConfig.RegistrationTimeoutSec >= DefaultRegistrationTimeoutThreshold {
+			var timeout time.Duration
+			timeout = time.Duration(sdkProtocolConfig.RegistrationTimeoutSec)
+			registrationResponseTimeout = time.Second * timeout
+		}
+
+		restartOnRegistrationTimeout = sdkProtocolConfig.RestartOnRegistrationTimeout
+	}
+	glog.Infof("SDK Protocol timeout related config [%+v]", sdkProtocolConfig)
+
 	return &SdkClientProtocol{
-		allProbes:                   allProbes,
-		version:                     version,
-		communicationBindingChannel: communicationBindingChannel,
-		//TransportReady: done,
+		allProbes:                    allProbes,
+		version:                      version,
+		communicationBindingChannel:  communicationBindingChannel,
+		registrationResponseTimeout:  registrationResponseTimeout,
+		restartOnRegistrationTimeout: restartOnRegistrationTimeout,
 	}
 }
 
@@ -45,6 +60,11 @@ func (clientProtocol *SdkClientProtocol) handleClientProtocol(transport ITranspo
 	status = clientProtocol.HandleRegistration(transport)
 	if !status {
 		glog.Errorf("Failure during Registration, cannot receive server messages")
+		// exit here ... so Kubernetes can restart the probe container
+		if clientProtocol.restartOnRegistrationTimeout {
+			panic("********* Failure during Registration **********")
+			os.Exit(1)
+		}
 		transportReady <- false
 		// clientProtocol.TransportReady <- false
 		return
@@ -71,6 +91,7 @@ func timeOutRead(name string, du time.Duration, ch chan *ParsedMessage) (*Parsed
 		}
 		return msg, nil
 	case <-timer.C:
+		glog.Infof("[%s]: timeout during version negotiation/registration after %v seconds", name, du.Seconds())
 		err := fmt.Errorf("[%s]: wait for message from channel timeout(%v seconds)", name, du.Seconds())
 		glog.Error(err.Error())
 		return nil, err
@@ -95,11 +116,19 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) 
 	endpoint.Send(endMsg)
 
 	// Wait for the response to be received by the transport and then parsed and put on the endpoint's message channel
-	serverMsg, err := timeOutRead(endpoint.GetName(), waitResponseTimeOut, endpoint.MessageReceiver())
+	negotiationStartTime := time.Now()
+	serverMsg, err := timeOutRead(endpoint.GetName(), clientProtocol.registrationResponseTimeout, endpoint.MessageReceiver())
 	if err != nil {
+		glog.V(2).Infof("[%s] : Error during version negotiation: %+v, disconnecting from server", endpoint.GetName(), err)
 		glog.Errorf("[%s] : read VersionNegotiation response from channel failed: %v", endpoint.GetName(), err)
 		return false
 	}
+	negotiationEndTime := time.Now()
+	negotiationTime := negotiationEndTime.Sub(negotiationStartTime)
+
+	glog.V(2).Infof("[%s] : Received VersionNegotiation response after %v ",
+		endpoint.GetName(), negotiationTime)
+
 	glog.V(4).Infof("[%s] : Received: %+v", endpoint.GetName(), serverMsg)
 
 	// Handler response
@@ -142,12 +171,21 @@ func (clientProtocol *SdkClientProtocol) HandleRegistration(transport ITransport
 	endpoint.Send(endMsg)
 
 	// Wait for the response to be received by the transport and then parsed and put on the endpoint's message channel
-	serverMsg, err := timeOutRead(endpoint.GetName(), waitResponseTimeOut, endpoint.MessageReceiver())
+
+	registrationStartTime := time.Now()
+	serverMsg, err := timeOutRead(endpoint.GetName(), clientProtocol.registrationResponseTimeout, endpoint.MessageReceiver())
 	if err != nil {
+		glog.V(2).Infof("[%s] : Error during registration: %+v, disconnecting from server", endpoint.GetName(), err)
 		glog.Errorf("[%s] : read Registration response from channel failed: %v", endpoint.GetName(), err)
 		return false
 	}
-	glog.V(4).Infof("[%s] : Received: %+v", endpoint.GetName(), serverMsg.RegistrationMsg)
+	registrationEndTime := time.Now()
+	registrationTime := registrationEndTime.Sub(registrationStartTime)
+
+	glog.V(2).Infof("[%s] : Received registration response after %v",
+		endpoint.GetName(), registrationTime)
+
+	glog.V(4).Infof("[%s] : Received registration response: %+v", endpoint.GetName(), serverMsg)
 
 	// Handler response
 	registrationResponse := protoMsg.RegistrationMsg

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/service/tap_service.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/service/tap_service.go
@@ -198,6 +198,7 @@ func (builder *TAPServiceBuilder) WithTurboCommunicator(commConfig *TurboCommuni
 		ServerMeta:                  commConfig.ServerMeta,
 		WebSocketConfig:             commConfig.WebSocketConfig,
 		CommunicationBindingChannel: builder.tapService.communicationBindingChannel,
+		SdkProtocolConfig:           commConfig.SdkProtocolConfig,
 	}
 	mediationcontainer.CreateMediationContainer(containerConfig)
 

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/service/turbo_communication_config.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/service/turbo_communication_config.go
@@ -29,9 +29,10 @@ func (rc *RestAPIConfig) ValidRestAPIConfig() error {
 
 // Configuration parameters for communicating with the Turbo server
 type TurboCommunicationConfig struct {
-	mediationcontainer.ServerMeta      `json:"serverMeta,omitempty"`
-	mediationcontainer.WebSocketConfig `json:"websocketConfig,omitempty"`
-	RestAPIConfig                      `json:"restAPIConfig,omitempty"`
+	mediationcontainer.ServerMeta        `json:"serverMeta,omitempty"`
+	mediationcontainer.WebSocketConfig   `json:"websocketConfig,omitempty"`
+	RestAPIConfig                        `json:"restAPIConfig,omitempty"`
+	mediationcontainer.SdkProtocolConfig `json:"sdkProtocolConfig,omitempty"`
 }
 
 func (turboCommConfig *TurboCommunicationConfig) ValidateTurboCommunicationConfig() error {
@@ -43,6 +44,9 @@ func (turboCommConfig *TurboCommunicationConfig) ValidateTurboCommunicationConfi
 		return err
 	}
 	if err := turboCommConfig.ValidRestAPIConfig(); err != nil {
+		return err
+	}
+	if err := turboCommConfig.ValidateSdkProtocolConfig(); err != nil {
 		return err
 	}
 	return nil
@@ -69,7 +73,7 @@ func ParseTurboCommunicationConfig(configFile string) (*TurboCommunicationConfig
 		return nil, err
 	}
 	glog.V(3).Infof("TurboCommunicationConfig Config: %v", turboCommConfig)
-
+	glog.Infof("TurboCommunicationConfig Config: %v", turboCommConfig)
 	if err := turboCommConfig.ValidateTurboCommunicationConfig(); err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -264,7 +264,7 @@ github.com/turbonomic/turbo-api/pkg/client
 # github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3
 ## explicit; go 1.19
 github.com/turbonomic/turbo-gitops/api/v1alpha1
-# github.com/turbonomic/turbo-go-sdk v0.0.0-20230307040640-43e100c457e6
+# github.com/turbonomic/turbo-go-sdk v0.0.0-20230426193838-3d42e481fec9
 ## explicit; go 1.13
 github.com/turbonomic/turbo-go-sdk/pkg
 github.com/turbonomic/turbo-go-sdk/pkg/builder


### PR DESCRIPTION
Update kubeturbo vendor directory with new changes to the tubo-go-sdk vendor based on [this PR](https://github.com/turbonomic/turbo-go-sdk/pull/147).

This sdk change includes new configuration options to increase the probe registration timeout interval and an option to restart the probe in case of registration failures.