### PR TITLE
[WIP][OM-100937] Use workload controller unique name as keys in affinity access commodities

### DIFF
--- a/pkg/discovery/dtofactory/node_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder_test.go
@@ -221,7 +221,7 @@ func TestNodeEntityDTO(t *testing.T) {
 	nodeEntityDTOBuilder := NewNodeEntityDTOBuilder(metricsSink, stitchingManager)
 	pods := []string{"pod1", "pod2"}
 	nodePods := map[string][]string{node.Name: pods}
-	nodeEntityDTOs, _ := nodeEntityDTOBuilder.BuildEntityDTOs([]*api.Node{node}, nodePods)
+	nodeEntityDTOs, _ := nodeEntityDTOBuilder.BuildEntityDTOs([]*api.Node{node}, nodePods, nil)
 	vmData := nodeEntityDTOs[0].GetVirtualMachineData()
 	// The capacity metric is set in millicores but numcpus is set in cores
 	assert.EqualValues(t, 10, vmData.GetNumCpus())
@@ -276,7 +276,7 @@ func Test_getAffinityCommoditiesSold(t *testing.T) {
 	mockNodesPods := make(map[string][]string)
 	mockNodesPods[node.Name] = append(mockNodesPods[node.Name], pod)
 
-	commodities := nodeEntityDTOBuilder.getAffinityCommoditiesSold(node, mockNodesPods)
+	commodities := nodeEntityDTOBuilder.getAffinityCommoditiesSold(node, mockNodesPods, nil)
 
 	assert.NotEmpty(t, commodities)
 	assert.Equal(t, 1, len(commodities))

--- a/pkg/discovery/processor/cluster_processor.go
+++ b/pkg/discovery/processor/cluster_processor.go
@@ -231,7 +231,8 @@ func (p *ClusterProcessor) DiscoverCluster() (*repository.ClusterSummary, error)
 
 	// Update the pod to controller cache
 	if clusterScraper, ok := p.clusterInfoScraper.(*cluster.ClusterScraper); ok {
-		clusterScraper.UpdatePodControllerCache(kubeCluster.Pods, kubeCluster.ControllerMap)
+		podToControllerMap := clusterScraper.UpdatePodControllerCache(kubeCluster.Pods, kubeCluster.ControllerMap)
+		kubeCluster.WithPodToControllerMap(podToControllerMap)
 	}
 
 	// Discover and cache GitOps configuration overrides

--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -35,6 +35,8 @@ type KubeCluster struct {
 	// Map of namespace qualified pod name wrt to the volumes they mount.
 	// This map will not feature volumes which are not mounted by any pods.
 	PodToVolumesMap map[string][]MountedVolume
+	// Map of namespace qualified pod name to their cluster unique parent name
+	PodToControllerMap map[string]string
 
 	K8sAppToComponentMap map[K8sApp][]K8sAppComponent
 	ComponentToAppMap    map[K8sAppComponent][]K8sApp
@@ -64,6 +66,11 @@ func (kc *KubeCluster) WithPods(pods []*v1.Pod) *KubeCluster {
 
 func (kc *KubeCluster) WithMachineSetToNodesMap(machineSetToNodesMap map[string][]*v1.Node) *KubeCluster {
 	kc.MachineSetToNodesMap = machineSetToNodesMap
+	return kc
+}
+
+func (kc *KubeCluster) WithPodToControllerMap(podToControllerMap map[string]string) *KubeCluster {
+	kc.PodToControllerMap = podToControllerMap
 	return kc
 }
 

--- a/pkg/discovery/task/task.go
+++ b/pkg/discovery/task/task.go
@@ -29,6 +29,7 @@ type Task struct {
 	cluster            *repository.ClusterSummary
 	nodesPods          map[string][]string
 	podsWithAffinities sets.String
+	podsToControllers  map[string]string
 }
 
 // Worker task is consisted of a list of nodes the worker must discover.
@@ -95,6 +96,12 @@ func (t *Task) WithPodsWithAffinities(podsWithAffinities sets.String) *Task {
 	return t
 }
 
+// Assign the mapping of each pods cluster unique name to its parent controller unique name.
+func (t *Task) WithPodsToControllers(podsToControllers map[string]string) *Task {
+	t.podsToControllers = podsToControllers
+	return t
+}
+
 // Get node from the task.
 func (t *Task) Node() *api.Node {
 	return t.node
@@ -133,6 +140,10 @@ func (t *Task) NodesPods() map[string][]string {
 
 func (t *Task) PodsWithAffinities() sets.String {
 	return t.podsWithAffinities
+}
+
+func (t *Task) PodstoControllers() map[string]string {
+	return t.podsToControllers
 }
 
 func (t *Task) String() string {

--- a/pkg/discovery/worker/dispatcher.go
+++ b/pkg/discovery/worker/dispatcher.go
@@ -147,7 +147,8 @@ func (d *Dispatcher) Dispatch(nodes []*api.Node, nodesPods map[string][]string,
 				WithPendingPods(pendingPods).
 				WithCluster(cluster).
 				WithNodesPods(nodesPods).
-				WithPodsWithAffinities(podsWithAffinities)
+				WithPodsWithAffinities(podsWithAffinities).
+				WithPodsToControllers(cluster.PodToControllerMap)
 			glog.V(2).Infof("Dispatching task %v", currTask)
 			d.assignTask(currTask)
 		}

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -371,7 +371,8 @@ func (worker *k8sDiscoveryWorker) buildEntityDTOs(currTask *task.Task) ([]*proto
 	var entityDTOs []*proto.EntityDTO
 	var notReadyNodes []string
 	// Build entity DTOs for nodes
-	nodeDTOs, notReadyNodes := worker.buildNodeDTOs([]*api.Node{currTask.Node()}, currTask.NodesPods())
+	nodeDTOs, notReadyNodes := worker.buildNodeDTOs([]*api.Node{currTask.Node()},
+		currTask.NodesPods(), currTask.PodstoControllers())
 
 	glog.V(3).Infof("Worker %s built %d node DTOs.", worker.id, len(nodeDTOs))
 	if len(nodeDTOs) == 0 {
@@ -401,7 +402,8 @@ func (worker *k8sDiscoveryWorker) buildEntityDTOs(currTask *task.Task) ([]*proto
 	return entityDTOs, podEntities, sidecarContainerSpecs, podWithVolumes, notReadyNodes, mirrorPodUids
 }
 
-func (worker *k8sDiscoveryWorker) buildNodeDTOs(nodes []*api.Node, nodesPods map[string][]string) ([]*proto.EntityDTO, []string) {
+func (worker *k8sDiscoveryWorker) buildNodeDTOs(nodes []*api.Node, nodesPods map[string][]string,
+	podsToControllers map[string]string) ([]*proto.EntityDTO, []string) {
 	// SetUp nodeName to nodeId mapping
 	stitchingManager := worker.stitchingManager
 	for _, node := range nodes {
@@ -414,7 +416,8 @@ func (worker *k8sDiscoveryWorker) buildNodeDTOs(nodes []*api.Node, nodesPods map
 	}
 	// Build entity DTOs for nodes
 	return dtofactory.NewNodeEntityDTOBuilder(worker.sink, stitchingManager).
-		WithClusterKeyInjected(worker.config.clusterKeyInjected).BuildEntityDTOs(nodes, nodesPods)
+		WithClusterKeyInjected(worker.config.clusterKeyInjected).
+		BuildEntityDTOs(nodes, nodesPods, podsToControllers)
 }
 
 // Build DTOs for running pods
@@ -443,7 +446,9 @@ func (worker *k8sDiscoveryWorker) buildPodDTOs(currTask *task.Task) ([]*proto.En
 		WithClusterKeyInjected(worker.config.clusterKeyInjected).
 		// map of mirror pods to daemon flags
 		WithMirrorPodToDaemonMap(cluster.MirrorPodToDaemonMap).
-		BuildEntityDTOs(currTask.PodsWithAffinities())
+		WithPodsWithAffinities(currTask.PodsWithAffinities()).
+		WithPodsToControllers(currTask.PodstoControllers()).
+		BuildEntityDTOs()
 
 	var podDTOs []*proto.EntityDTO
 	var runningPods []*api.Pod


### PR DESCRIPTION
**Intent**
This implements one of the improvements aimed at reducing the number of commodities that are added pertaining to k8s affinity rules.

**Background**
We traditionally were seeing huge kubetubro side discovery delays which we drilled down to affinity processing logic and improved the same in https://github.com/turbonomic/kubeturbo/pull/791. After this we saw Turbo server side performance issues in super large enviroments which we could attribute to large number of commodities that are added as a result of kubeturbo side affinity processing. This PR makes one such improvement by using the workload controller unique name in place of the pod unique name as the key in these commodities. This will reduce the total number of commodities by the ratio of average number of replicas per workload in the given cluster.
Please note that this particular mechanism will not work for the spread workload replicas(pod antiaffinity to itself to ensure spread across topology). This PR is WIP to address that particular scenario and implement an alternative handling of the same.