### PR TITLE
[100430]: Update kubeturbo deployment with new registration related configuration

### DIFF
--- a/deploy/kubeturbo-operator/config/crd/bases/charts.helm.k8s.io_kubeturboes.yaml
+++ b/deploy/kubeturbo-operator/config/crd/bases/charts.helm.k8s.io_kubeturboes.yaml
@@ -125,6 +125,16 @@ spec:
                   opsManagerPassword:
                     description: Turbo admin user password
                     type: string
+              sdkProtocolConfig:
+                description: Configurations to register probe with Turbo Server
+                type: object
+                properties:
+                  registrationTimeoutSec:
+                    description: Time in seconds to wait for registration response from the Turbo Server
+                    type: integer
+                  restartOnRegistrationTimeout:
+                    description: Restart probe container on registration timeout
+                    type: boolean
               featureGates:
                 type: object
                 description: Enable or disable features

--- a/deploy/kubeturbo-operator/config/samples/charts_v1_kubeturbo.yaml
+++ b/deploy/kubeturbo-operator/config/samples/charts_v1_kubeturbo.yaml
@@ -24,6 +24,9 @@ spec:
     opsManagerPassword: Turbo_password
     opsManagerUserName: Turbo_username
     turbonomicCredentialsSecretName: turbonomic-credentials
+  sdkProtocolConfig:
+    registrationTimeoutSec: 600
+    restartOnRegistrationTimeout: true
   roleBinding: turbo-all-binding
   roleName: cluster-admin
   serverMeta:

--- a/deploy/kubeturbo-operator/config/samples/charts_v1_kubeturbo.yaml
+++ b/deploy/kubeturbo-operator/config/samples/charts_v1_kubeturbo.yaml
@@ -25,8 +25,8 @@ spec:
     opsManagerUserName: Turbo_username
     turbonomicCredentialsSecretName: turbonomic-credentials
   sdkProtocolConfig:
-    registrationTimeoutSec: 600
-    restartOnRegistrationTimeout: true
+    registrationTimeoutSec: 300
+    restartOnRegistrationTimeout: false
   roleBinding: turbo-all-binding
   roleName: cluster-admin
   serverMeta:

--- a/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_cr.yaml
+++ b/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_cr.yaml
@@ -25,6 +25,12 @@ spec:
   #  opsManagerUserName: Turbo_username
   #  opsManagerPassword: Turbo_password
 
+  # Configurations to register probe with Turbo Server
+  #sdkProtocolConfig:
+  #  registrationTimeoutSec: 600
+  #  restartOnRegistrationTimeout: true
+
+
   # Uncomment out lines to configure HA Node to ESX policies by node role. Default is master
   # Add more roles using format "\"foo\"\,\"bar\""
   #HANodeConfig:

--- a/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_cr.yaml
+++ b/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_cr.yaml
@@ -27,9 +27,8 @@ spec:
 
   # Configurations to register probe with Turbo Server
   #sdkProtocolConfig:
-  #  registrationTimeoutSec: 600
-  #  restartOnRegistrationTimeout: true
-
+  #  registrationTimeoutSec: 300
+  #  restartOnRegistrationTimeout: false
 
   # Uncomment out lines to configure HA Node to ESX policies by node role. Default is master
   # Add more roles using format "\"foo\"\,\"bar\""

--- a/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
+++ b/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
@@ -125,6 +125,16 @@ spec:
                   opsManagerPassword:
                     description: Turbo admin user password
                     type: string
+              sdkProtocolConfig:
+                description: Configurations to register probe with Turbo Server
+                type: object
+                properties:
+                  registrationTimeoutSec:
+                    description: Time in seconds to wait for registration response from the Turbo Server
+                    type: integer
+                  restartOnRegistrationTimeout:
+                    description: Restart probe container on registration timeout
+                    type: boolean
               featureGates:
                 type: object
                 description: Enable or disable features

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -18,8 +18,8 @@ data:
           "opsManagerPassword": "{{ .Values.restAPIConfig.opsManagerPassword }}"
         },
         "sdkProtocolConfig": {
-           "registrationTimeoutSec": "{{ .Values.sdkProtocolConfig.registrationTimeoutSec }}",
-           "restartOnRegistrationTimeout": "{{ .Values.sdkProtocolConfig.restartOnRegistrationTimeout }}"
+           "registrationTimeoutSec": {{ .Values.sdkProtocolConfig.registrationTimeoutSec }},
+           "restartOnRegistrationTimeout": {{ .Values.sdkProtocolConfig.restartOnRegistrationTimeout }}
         }
       },
       {{- if .Values.featureGates }}

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -16,6 +16,10 @@ data:
         "restAPIConfig": {
           "opsManagerUserName": "{{ .Values.restAPIConfig.opsManagerUserName }}",
           "opsManagerPassword": "{{ .Values.restAPIConfig.opsManagerPassword }}"
+        },
+        "sdkProtocolConfig": {
+           "registrationTimeoutSec": "{{ .Values.sdkProtocolConfig.registrationTimeoutSec }}",
+           "restartOnRegistrationTimeout": "{{ .Values.sdkProtocolConfig.restartOnRegistrationTimeout }}"
         }
       },
       {{- if .Values.featureGates }}

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -52,6 +52,11 @@ restAPIConfig:
   opsManagerUserName: Turbo_username
   opsManagerPassword: Turbo_password
 
+# Turbo server registration process configuration
+sdkProtocolConfig:
+  registrationTimeoutSec: 300
+  restartOnRegistrationTimeout: false
+
 # For targetConfig, targetName provides better group naming to identify k8s clusters in UI
 # - If no targetConfig is specified, a default targetName will be created from the apiserver URL in
 #   the kubeconfig.

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -18,8 +18,8 @@ data:
           "opsManagerPassword": "{{ .Values.restAPIConfig.opsManagerPassword }}"
         },
         "sdkProtocolConfig": {
-           "registrationTimeoutSec": "{{ .Values.sdkProtocolConfig.registrationTimeoutSec }}",
-           "restartOnRegistrationTimeout": "{{ .Values.sdkProtocolConfig.restartOnRegistrationTimeout }}"
+           "registrationTimeoutSec": {{ .Values.sdkProtocolConfig.registrationTimeoutSec }},
+           "restartOnRegistrationTimeout": {{ .Values.sdkProtocolConfig.restartOnRegistrationTimeout }}
         }
       },
       {{- if .Values.featureGates }}

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -16,6 +16,10 @@ data:
         "restAPIConfig": {
           "opsManagerUserName": "{{ .Values.restAPIConfig.opsManagerUserName }}",
           "opsManagerPassword": "{{ .Values.restAPIConfig.opsManagerPassword }}"
+        },
+        "sdkProtocolConfig": {
+           "registrationTimeoutSec": "{{ .Values.sdkProtocolConfig.registrationTimeoutSec }}",
+           "restartOnRegistrationTimeout": "{{ .Values.sdkProtocolConfig.restartOnRegistrationTimeout }}"
         }
       },
       {{- if .Values.featureGates }}

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -40,6 +40,11 @@ restAPIConfig:
   opsManagerUserName: Turbo_username
   opsManagerPassword: Turbo_password
 
+# Turbo server registration process configuration
+sdkProtocolConfig:
+  registrationTimeoutSec: 300
+  restartOnRegistrationTimeout: false
+
 # For targetConfig, targetName provides better group naming to identify k8s clusters in UI
 # - If no targetConfig is specified, a default targetName will be created from the apiserver URL in
 #   the kubeconfig.

--- a/deploy/kubeturbo_yamls/step4_turbo_configMap_sample.yaml
+++ b/deploy/kubeturbo_yamls/step4_turbo_configMap_sample.yaml
@@ -37,6 +37,10 @@ data:
             "restAPIConfig": {
                 "opsManagerUserName": "<Turbo_username_plaintext>",
                 "opsManagerPassword": "<Turbo_password_plaintext>"
+            },
+            "sdkProtocolConfig": {
+                "registrationTimeoutSec": 300,
+                "restartOnRegistrationTimeout": false
             }
         },
         "targetConfig": {


### PR DESCRIPTION
#847 and #https://github.com/turbonomic/turbo-go-sdk/pull/147 added new configuration options to probes during registration with server. 
This PR exposes these options to the users during deployment with operators and helm charts.
- Updated the Kubeturbo operator CRD
- Updated the default values provided in the Helm charts

```
# Turbo server registration process configuration
sdkProtocolConfig:
  registrationTimeoutSec: 300
  restartOnRegistrationTimeout: false
```
- Updated the `configmap` template in the Helm Charts
```
{
      "communicationConfig": {
        "serverMeta": {
        {{- if .Values.serverMeta.proxy }}
          "proxy": "{{ .Values.serverMeta.proxy }}",
        {{- end }}
          "version": "{{ .Values.serverMeta.version }}",
          "turboServer": "{{ .Values.serverMeta.turboServer }}"
        },
        "restAPIConfig": {
          "opsManagerUserName": "{{ .Values.restAPIConfig.opsManagerUserName }}",
          "opsManagerPassword": "{{ .Values.restAPIConfig.opsManagerPassword }}"
        },
        "sdkProtocolConfig": {
           "registrationTimeoutSec": {{ .Values.sdkProtocolConfig.registrationTimeoutSec }},
           "restartOnRegistrationTimeout": {{ .Values.sdkProtocolConfig.restartOnRegistrationTimeout }}
        }
      },
```
- Changes made in the` deploy/kubeturbo-operator `as well as `deploy/kubeturbo`

# Testing
- Built new Kubeturbo operator image and pushed it
`docker buildx build -f Dockerfile --platform linux/amd64,linux/arm64,linux/s390x --label "8.8.6" --push -t pallavidebnath/kubeturbo-operator-sdk-config . `

- Change the Kubeturbo operator updates to manual in your k8s cluster


Following [this wiki ](https://github.com/turbonomic/kubeturbo/wiki/Operator-Details), 
- First deploy the new Kubeturbo CRD
- Deploy Kubeturbo operators yamls in a separate namespace ( not 'turbo') - `serviceaccount.yaml`, `rolebinding.yaml`, `operator.yaml`
- Modify the Kubeturbo CR  `deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_cr.yaml`
Update turbo server communication related data and additionally the new config to ensure that is passed on to the probe.
 **Configurations to register probe with Turbo Server**
 ```
 sdkProtocolConfig:
    registrationTimeoutSec: 100
    restartOnRegistrationTimeout: true
```
- Wait to see the Kubeturbo pod start up and check the logs and validate that the configuration values are read by the probe.

