### PR TITLE
[OM-100967]:  update kubeurb with change in go sdk add guard for NPE …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/turbonomic/orm v0.0.0-20230411145227-4dccb88ccbac
 	github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20230426193838-3d42e481fec9
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20230502171353-11200efd6308
 	github.com/turbonomic/turbo-policy v0.0.0-20230328195608-0556e3cbe9b3
 	github.com/xanzy/go-gitlab v0.74.0
 	k8s.io/klog/v2 v2.80.1

--- a/go.sum
+++ b/go.sum
@@ -877,6 +877,8 @@ github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3 h1:R/3tmGl
 github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3/go.mod h1:HAD6GcQFpgDGHOwhuCCjxQQWDjK2wv6gUvd5J3ZNU2g=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20230426193838-3d42e481fec9 h1:drCOeXNVkAEm/FNngouf6mS3237eKZPc1EXn10KSqi8=
 github.com/turbonomic/turbo-go-sdk v0.0.0-20230426193838-3d42e481fec9/go.mod h1:RWvXz62oL7Yhkw+WRdDRdOEZSsm8f0vR3xvsgSU9ohM=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20230502171353-11200efd6308 h1:Bh4Iv2XSzYmCDaHALtpjek7g8h96ruIam/QWbG6rfXU=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20230502171353-11200efd6308/go.mod h1:RWvXz62oL7Yhkw+WRdDRdOEZSsm8f0vR3xvsgSU9ohM=
 github.com/turbonomic/turbo-policy v0.0.0-20230328195608-0556e3cbe9b3 h1:KQkPBU3uKH87s4FjMrtxT4sYQCFab1kC7tTv46FZerE=
 github.com/turbonomic/turbo-policy v0.0.0-20230328195608-0556e3cbe9b3/go.mod h1:FlrjRrIlIT5MbFh9HmWiW8ZJ6qHCcuXNOJ6wCe6bFJ0=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go
@@ -142,11 +142,18 @@ func (wsTransport *ClientWebSocketTransport) closeAndResetWebSocket() {
 	wsTransport.status = Closed
 }
 
+// write sends a WebSocket message with the given type and payload data.
+// It returns an error if the WebSocket connection is unavailable or the write operation fails.
 func (wsTransport *ClientWebSocketTransport) write(mtype int, payload []byte) error {
 	wsTransport.wsMux.Lock()
 	defer wsTransport.wsMux.Unlock()
-	wsTransport.ws.SetWriteDeadline(time.Now().Add(writeWaitTimeout))
-	return wsTransport.ws.WriteMessage(mtype, payload)
+
+	ws := wsTransport.ws
+	if ws == nil {
+		return errors.New("websocket connection unavailable")
+	}
+	ws.SetWriteDeadline(time.Now().Add(writeWaitTimeout))
+	return ws.WriteMessage(mtype, payload)
 }
 
 // keep sending Ping msg to make sure the websocket connection is alive

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -264,7 +264,7 @@ github.com/turbonomic/turbo-api/pkg/client
 # github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3
 ## explicit; go 1.19
 github.com/turbonomic/turbo-gitops/api/v1alpha1
-# github.com/turbonomic/turbo-go-sdk v0.0.0-20230426193838-3d42e481fec9
+# github.com/turbonomic/turbo-go-sdk v0.0.0-20230502171353-11200efd6308
 ## explicit; go 1.13
 github.com/turbonomic/turbo-go-sdk/pkg
 github.com/turbonomic/turbo-go-sdk/pkg/builder


### PR DESCRIPTION
…in websocket write method

This is the update needed in kubeturbo for the PR merged in turbo-go-sdk: https://github.com/turbonomic/turbo-go-sdk/pull/148