### PR TITLE
[OM-101542] Support rollout of deploymentconfig  when triggers are not set

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -15,6 +15,7 @@ import (
 
 	set "github.com/deckarep/golang-set"
 	"github.com/golang/glog"
+	osclient "github.com/openshift/client-go/apps/clientset/versioned"
 	clusterclient "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/pflag"
@@ -372,6 +373,12 @@ func (s *VMTServer) Run() {
 		glog.Fatalf("Failed to create controller runtime client: %v.", err)
 	}
 
+	// Openshift client for deploymentconfig resize forced rollouts
+	osClient, err := osclient.NewForConfig(kubeConfig)
+	if err != nil {
+		glog.Fatalf("Failed to generate openshift client for kubernetes target: %v", err)
+	}
+
 	// TODO: Replace dynamicClient with runtimeClient
 	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
 	if err != nil {
@@ -462,6 +469,7 @@ func (s *VMTServer) Run() {
 		WithORMClientManager(ormClientManager).
 		WithKubeletClient(kubeletClient).
 		WithClusterAPIClient(caClient).
+		WithOpenshiftClient(osClient).
 		WithVMPriority(s.VMPriority).
 		WithVMIsBase(s.VMIsBase).
 		UsingUUIDStitch(s.UseUUID).

--- a/pkg/action/action_handler_test.go
+++ b/pkg/action/action_handler_test.go
@@ -113,7 +113,7 @@ func newActionHandlerConfig() *ActionHandlerConfig {
 
 	config.StopEverything = make(chan struct{})
 	config.clusterScraper = cluster.NewClusterScraper(nil, &client.Clientset{}, nil, nil,
-		false, nil, "")
+		nil, false, nil, "")
 	config.kubeletClient = &kubeclient.KubeletClient{}
 
 	return config

--- a/pkg/action/executor/k8s_controller_updater.go
+++ b/pkg/action/executor/k8s_controller_updater.go
@@ -73,6 +73,7 @@ func newK8sControllerUpdater(clusterScraper *cluster.ClusterScraper,
 		controller: &parentController{
 			clients: kubeClients{
 				typedClient:         clusterScraper.Clientset,
+				osClient:            clusterScraper.OsClient,
 				dynClient:           clusterScraper.DynamicClient,
 				dynNamespacedClient: clusterScraper.DynamicClient.Resource(res).Namespace(namespace),
 			},

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	osclient "github.com/openshift/client-go/apps/clientset/versioned"
 	machinev1beta1api "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	capiclient "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
 	policyv1alpha1 "github.com/turbonomic/turbo-policy/api/v1alpha1"
@@ -71,6 +72,7 @@ type ClusterScraper struct {
 	caClient                *capiclient.Clientset
 	capiNamespace           string
 	DynamicClient           dynamic.Interface
+	OsClient                *osclient.Clientset
 	ControllerRuntimeClient runtimeclient.Client
 	cache                   turbostore.ITurboCache
 	GitOpsConfigCache       map[string][]*gitopsv1alpha1.Configuration
@@ -78,11 +80,12 @@ type ClusterScraper struct {
 }
 
 func NewClusterScraper(restConfig *restclient.Config, kclient *client.Clientset, dynamicClient dynamic.Interface,
-	rtClient runtimeclient.Client, capiEnabled bool, caClient *capiclient.Clientset, capiNamespace string) *ClusterScraper {
+	rtClient runtimeclient.Client, osClient *osclient.Clientset, capiEnabled bool, caClient *capiclient.Clientset, capiNamespace string) *ClusterScraper {
 	clusterScraper := &ClusterScraper{
 		Clientset:               kclient,
 		RestConfig:              restConfig,
 		DynamicClient:           dynamicClient,
+		OsClient:                osClient,
 		ControllerRuntimeClient: rtClient,
 		// Create cache with expiration duration as defaultCacheTTL, which means the cached data will be cleaned up after
 		// defaultCacheTTL.

--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -150,7 +150,7 @@ func TestGenNodeResourceMetrics(t *testing.T) {
 		t.Errorf("Failed to create clusterMonitor: %v", err)
 	}
 	clusterMonitor.clusterClient = cluster.NewClusterScraper(nil, &client.Clientset{}, nil, nil,
-		false, nil, "")
+		nil, false, nil, "")
 	clusterMonitor.sink = metrics.NewEntityMetricSink()
 	clusterMonitor.node = node
 	clusterMonitor.nodePodMap = make(map[string][]*api.Pod)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -53,12 +53,14 @@ const (
 	// Pagination support for list API calls to API server querying workload controllers
 	// Without this feature gate the whole list is requested in a single list API call.
 	GoMemLimit featuregate.Feature = "GoMemLimit"
+
 	// AllowIncreaseNsQuota4Resizing owner: @kevinwang
 	// alpha:
 	//
 	// This gate will enable the temporary namespace quota increase when
 	// kubeturbo execute a resize action on a workload controller
 	AllowIncreaseNsQuota4Resizing featuregate.Feature = "AllowIncreaseNsQuota4Resizing"
+
 	// IgnoreAffinities owner: @irfanurrehman
 	// alpha:
 	//
@@ -68,12 +70,24 @@ const (
 	// in out code, where affinity processing alone takes a really long time.
 	// https://vmturbo.atlassian.net/browse/OM-93635?focusedCommentId=771727
 	IgnoreAffinities featuregate.Feature = "IgnoreAffinities"
+
 	// NewAffinityProcessing owner: @irfanurrehman
 	// alpha:
 	//
 	// This gate will use the optimised affinity processing algorithm which in turn
 	// will ensure that the affinity processing can happen within a single discovery cycle.
 	NewAffinityProcessing featuregate.Feature = "NewAffinityProcessing"
+
+	// DeploymentConfigForcedRollout owner: @irfanurrehman
+	// alpha:
+	//
+	// This gate is used to force the rollout of deployment configs on resize actions, if
+	// its found that the "spec.triggers" is explicitly set to empty ie. "[]".
+	// This is an explicit type of setup we have seen in some customer environments where
+	// users are expected to manually rollout the deployment config after any change to the
+	// same. More details in warning note here ->
+	// https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/basic_deployment_operations.html#triggers
+	ForceDeploymentConfigRollout featuregate.Feature = "ForceDeploymentConfigRollout"
 )
 
 func init() {
@@ -96,4 +110,5 @@ var DefaultKubeturboFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	AllowIncreaseNsQuota4Resizing: {Default: true, PreRelease: featuregate.Alpha},
 	IgnoreAffinities:              {Default: false, PreRelease: featuregate.Alpha},
 	NewAffinityProcessing:         {Default: true, PreRelease: featuregate.Beta},
+	ForceDeploymentConfigRollout:  {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/k8s_tap_service.go
+++ b/pkg/k8s_tap_service.go
@@ -189,8 +189,8 @@ func createProbeConfigOrDie(c *Config) *configs.ProbeConfig {
 	kubeletMonitoringConfig := kubelet.NewKubeletMonitorConfig(c.KubeletClient, c.KubeClient)
 
 	// Create cluster monitoring
-	clusterScraper := cluster.NewClusterScraper(c.RestConfig, c.KubeClient,
-		c.DynamicClient, c.ControllerRuntimeClient, c.clusterAPIEnabled, c.CAClient, c.CAPINamespace)
+	clusterScraper := cluster.NewClusterScraper(c.RestConfig, c.KubeClient, c.DynamicClient,
+		c.ControllerRuntimeClient, c.OsClient, c.clusterAPIEnabled, c.CAClient, c.CAPINamespace)
 	masterMonitoringConfig := master.NewClusterMonitorConfig(clusterScraper)
 
 	// TODO for now kubelet is the only monitoring source. As we have more sources, we should choose what to be added into the slice here.

--- a/pkg/kubeturbo_service_config.go
+++ b/pkg/kubeturbo_service_config.go
@@ -1,6 +1,7 @@
 package kubeturbo
 
 import (
+	osclient "github.com/openshift/client-go/apps/clientset/versioned"
 	"github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
 	"k8s.io/client-go/dynamic"
 	kubeclient "k8s.io/client-go/kubernetes"
@@ -29,6 +30,7 @@ type Config struct {
 	DynamicClient dynamic.Interface
 	KubeletClient *kubeletclient.KubeletClient
 	CAClient      *versioned.Clientset
+	OsClient      *osclient.Clientset
 	// ORMClient builds operator resource mapping templates fetched from OperatorResourceMapping CR in discovery client
 	// and provides the capability to update the corresponding CR for an Operator managed resource in action execution client.
 	ORMClientManager *resourcemapping.ORMClientManager
@@ -90,6 +92,11 @@ func (c *Config) WithKubeConfig(config *restclient.Config) *Config {
 
 func (c *Config) WithDynamicClient(client dynamic.Interface) *Config {
 	c.DynamicClient = client
+	return c
+}
+
+func (c *Config) WithOpenshiftClient(client *osclient.Clientset) *Config {
+	c.OsClient = client
 	return c
 }
 

--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -34,6 +34,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property"
 	"github.com/turbonomic/kubeturbo/pkg/util"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 const (
@@ -79,7 +80,7 @@ var _ = Describe("Action Executor ", func() {
 			}
 
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(kubeConfig, kubeClient, dynamicClient, nil, false, nil, ""),
+				cluster.NewClusterScraper(kubeConfig, kubeClient, dynamicClient, nil, osClient, false, nil, ""),
 				[]string{"*"}, nil, false, true, 60, gitops.GitConfig{}, "test-cluster-id")
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 		}
@@ -165,7 +166,7 @@ var _ = Describe("Action Executor ", func() {
 
 			// TODO: The storageclass can be taken as a configurable parameter from commandline
 			// For now this will need to be updated when running against the given cluster
-			dc, err := createDCResource(osClient, genDeploymentConfigWithResources(namespace, "", 1, 1, false, true))
+			dc, err := createDCResource(osClient, genDeploymentConfigWithResources(namespace, "", 1, 1, false, true), false)
 			framework.ExpectNoError(err, "Error creating test resources")
 
 			pod, err := getDeploymentConfigsPod(kubeClient, dc.Name, namespace, "")
@@ -198,7 +199,7 @@ var _ = Describe("Action Executor ", func() {
 			// TODO: The storageclass can be taken as a configurable parameter from commandline
 			// For now this will need to be updated when running against the given cluster
 			pvc, err := createVolumeClaim(kubeClient, namespace, "gp2")
-			dc, err := createDCResource(osClient, genDeploymentConfigWithResources(namespace, pvc.Name, 1, 1, true, true))
+			dc, err := createDCResource(osClient, genDeploymentConfigWithResources(namespace, pvc.Name, 1, 1, true, true), false)
 			framework.ExpectNoError(err, "Error creating test resources")
 
 			pod, err := getDeploymentConfigsPod(kubeClient, dc.Name, namespace, "")
@@ -228,7 +229,7 @@ var _ = Describe("Action Executor ", func() {
 			if !framework.TestContext.IsOpenShiftTest {
 				Skip("Ignoring resize multiple containers for the deploymentconfig.")
 			}
-			dc, err := createDCResource(osClient, genDeploymentConfigWithResources(namespace, "", 2, 1, false, false))
+			dc, err := createDCResource(osClient, genDeploymentConfigWithResources(namespace, "", 2, 1, false, false), false)
 			framework.ExpectNoError(err, "Error creating test resources")
 
 			targetSE := newResizeWorkloadControllerTargetSE(dc)
@@ -239,6 +240,43 @@ var _ = Describe("Action Executor ", func() {
 			_, err = waitForWorkloadControllerToUpdateResource(osClient, dc, desiredPodSpec)
 			if err != nil {
 				framework.Failf("Failed to check the change of the resource/request in the new deploymentconfig with multiple containers: %s", err)
+			}
+		})
+	})
+
+	// Deploymentconfig resize action with empty triggers
+	Describe("executing resize action on a deploymentconfig with empty triggers", func() {
+		It("should automatically rollout the updated deploymentconfig if featureflag ForceDeploymentConfigRollout=true", func() {
+			if !framework.TestContext.IsOpenShiftTest {
+				Skip("Ignoring resize action on a deploymentconfig with empty triggers.")
+			}
+
+			features := map[string]bool{"ForceDeploymentConfigRollout": true}
+			err := utilfeature.DefaultMutableFeatureGate.SetFromMap(features)
+			framework.ExpectNoError(err, "Could not set Feature Gates")
+
+			dc := genDeploymentConfigWithResources(namespace, "", 1, 1, false, false)
+			// empty triggers should mean no automatic rollout
+			dc.Spec.Triggers = []osv1.DeploymentTriggerPolicy{}
+			dc, err = createDCResource(osClient, dc, true)
+			framework.ExpectNoError(err, "Error creating test resources")
+
+			targetSE := newResizeWorkloadControllerTargetSE(dc)
+			resizeAction, desiredPodSpec := newResizeActionExecutionDTO(targetSE, &dc.Spec.Template.Spec, "test-cont-1")
+			_, err = actionHandler.ExecuteAction(resizeAction, nil, &mockProgressTrack{})
+			framework.ExpectNoError(err, "Resize action Deploymentconfig with empty triggers failed")
+
+			// action execution updates the deploymentconfig
+			_, err = waitForWorkloadControllerToUpdateResource(osClient, dc, desiredPodSpec)
+			if err != nil {
+				framework.Failf("Failed to check the change of the resource/request in the new deploymentconfig with empty triggers: %s", err)
+			}
+
+			// action execution also rolls out the deploymenconfig
+			// compare the spec of the child pod to match the desired pod
+			err = waitForDCPodWithSpecificSpec(kubeClient, dc.Name, dc.Namespace, desiredPodSpec)
+			if err != nil {
+				framework.Failf("Failed to find the pod resource/request updated for deploymentconfig with empty triggers: %s", err)
 			}
 		})
 	})
@@ -691,10 +729,15 @@ func addGCLabelRS(rs *appsv1.ReplicaSet) {
 	rs.SetLabels(labels)
 }
 
-func createDCResource(client *osclient.Clientset, dc *osv1.DeploymentConfig) (*osv1.DeploymentConfig, error) {
+func createDCResource(client *osclient.Clientset, dc *osv1.DeploymentConfig, rollout bool) (*osv1.DeploymentConfig, error) {
 	newDc, err := createDeploymentConfig(client, dc)
 	if err != nil {
 		return nil, err
+	}
+	if rollout {
+		if err := rolloutDeploymentConfig(client, newDc); err != nil {
+			return nil, err
+		}
 	}
 	return waitForDeploymentConfig(client, newDc.Name, newDc.Namespace)
 }
@@ -1004,6 +1047,38 @@ func waitForWorkloadControllerToUpdateResource(client interface{}, workloadContr
 		return nil, waitErr
 	}
 	return newControllerObj, nil
+}
+
+func rolloutDeploymentConfig(client osclient.Interface, dc *osv1.DeploymentConfig) error {
+	// This will fail if the DC is already paused because of whatever reason
+	name := dc.GetName()
+	ns := dc.GetNamespace()
+	glog.V(3).Infof("Starting (Instantiating) the deploymentconfig %s/%s rollout", ns, name)
+	deployRequest := osv1.DeploymentRequest{Name: name, Latest: true, Force: true}
+	_, err := client.AppsV1().DeploymentConfigs(ns).
+		Instantiate(context.TODO(), name, &deployRequest, metav1.CreateOptions{})
+	if err == nil {
+		glog.V(3).Infof("Rolled out (Instantiated) the deploymentconfig %s/%s", ns, name)
+	}
+
+	return err
+}
+
+func waitForDCPodWithSpecificSpec(kubeClient kubeclientset.Interface, dcName, dcNamespace string, desiredPodSpec *corev1.PodSpec) error {
+	if waitErr := wait.PollImmediate(framework.PollInterval, framework.TestContext.SingleCallTimeout, func() (bool, error) {
+		pod, err := getDeploymentConfigsPod(kubeClient, dcName, dcNamespace, "")
+		if err != nil {
+			glog.Errorf("Unexpected error while getting pod for deploymentspec: %v", err)
+			return false, err
+		}
+		if reflect.DeepEqual(pod.Spec.Containers[0].Resources, desiredPodSpec.Containers[0].Resources) {
+			return true, nil
+		}
+		return false, nil
+	}); waitErr != nil {
+		return waitErr
+	}
+	return nil
 }
 
 func waitForBarePod(client kubeclientset.Interface, podName, namespace string) (*corev1.Pod, error) {

--- a/test/integration/discovery.go
+++ b/test/integration/discovery.go
@@ -923,7 +923,7 @@ func assertCommoditySame(commI, commJ *proto.CommodityDTO, entityDTO *proto.Enti
 func createProbeConfigOrDie(kubeClient *kubeclientset.Clientset, kubeletClient *kubeletclient.KubeletClient,
 	dynamicClient dynamic.Interface, runtimeClient runtimeclient.Client) *configs.ProbeConfig {
 	kubeletMonitoringConfig := kubelet.NewKubeletMonitorConfig(kubeletClient, kubeClient)
-	clusterScraper := cluster.NewClusterScraper(nil, kubeClient, dynamicClient, runtimeClient, false, nil, "")
+	clusterScraper := cluster.NewClusterScraper(nil, kubeClient, dynamicClient, runtimeClient, nil, false, nil, "")
 	masterMonitoringConfig := master.NewClusterMonitorConfig(clusterScraper)
 	monitoringConfigs := []monitoring.MonitorWorkerConfig{
 		kubeletMonitoringConfig,

--- a/test/integration/orm_action_execution.go
+++ b/test/integration/orm_action_execution.go
@@ -97,7 +97,7 @@ var _ = Describe("Action Executor ", func() {
 				aggregation.DefaultContainerUsageDataAggStrategy, ormClient, app.DefaultDiscoveryWorkers, app.DefaultDiscoveryTimeoutSec,
 				app.DefaultDiscoverySamples, app.DefaultDiscoverySampleIntervalSec, 0)
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(nil, kubeClient, dynamicClient, nil, false, nil, ""),
+				cluster.NewClusterScraper(nil, kubeClient, dynamicClient, nil, nil, false, nil, ""),
 				[]string{"*"}, ormClient, false, true, 60, gitops.GitConfig{}, "test-cluster-id")
 
 			actionHandler = action.NewActionHandler(actionHandlerConfig)

--- a/test/integration/pod_move_with_quota.go
+++ b/test/integration/pod_move_with_quota.go
@@ -81,7 +81,7 @@ spec:
 			}
 
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(nil, kubeClient, dynamicClient, nil, false, nil, ""),
+				cluster.NewClusterScraper(nil, kubeClient, dynamicClient, nil, nil, false, nil, ""),
 				[]string{"*"}, nil, false, true, 60, gitops.GitConfig{}, "test-cluster-id")
 			actionHandler = action.NewActionHandler(actionHandlerConfig)
 
@@ -122,7 +122,7 @@ spec:
 
 		It("should fail the action if the quota-update is disabled", func() {
 			actionHandlerConfig := action.NewActionHandlerConfig("", nil, nil,
-				cluster.NewClusterScraper(nil, kubeClient, dynamicClient, nil, false, nil, ""),
+				cluster.NewClusterScraper(nil, kubeClient, dynamicClient, nil, nil, false, nil, ""),
 				[]string{"*"}, nil, false, false, 60, gitops.GitConfig{}, "test-cluster-id")
 			actionHandler := action.NewActionHandler(actionHandlerConfig)
 


### PR DESCRIPTION
**Intent**
This addresses the ask from one of the customers the details of which are listed in [TRB-24014](https://jsw.ibm.com/browse/TRB-24014) ([OM-101542](https://vmturbo.atlassian.net/browse/OM-101542))

~~This is currently pushed as WIP to simply show what is involved as part of this work and for early review. I am working on the integration tests to complete the same.~~

This is now complete and updated with an integration test to test the main scenarion that we are interested in, ie being able to successfully run a resize action on a deploymentconfig with empty triggers.

**Testing**
With the feature flag set 
![image](https://github.com/turbonomic/kubeturbo/assets/10027921/157eb3a7-59cf-4b9a-80d3-e91990d87758)

A deployment config with empty triggers is rolled out 
```
opt get dc -n irf beekman-dc-1 -o yaml
apiVersion: apps.openshift.io/v1
kind: DeploymentConfig
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps.openshift.io/v1","kind":"DeploymentConfig","metadata":{"annotations":{},"labels":{"app":"bee"},"name":"beekman-dc-1","namespace":"irf"},"spec":{"replicas":2,"selector":{"app":"bee"},"template":{"metadata":{"labels":{"app":"bee"}},"spec":{"containers":[{"env":[{"name":"RUN_TYPE","value":"cpu"},{"name":"CPU_PERCENT","value":"100"}],"image":"beekman9527/cpumemload:latest","name":"beekman-1","resources":{"limits":{"cpu":"20m","memory":"20Mi"},"requests":{"cpu":"15m","memory":"10Mi"}}}]}},"test":false,"triggers":[]}}
  creationTimestamp: "2023-05-08T15:34:16Z"
  generation: 10
  labels:
    app: bee
  name: beekman-dc-1
  namespace: irf
  resourceVersion: "371513731"
  selfLink: /apis/apps.openshift.io/v1/namespaces/irf/deploymentconfigs/beekman-dc-1
  uid: caa34e2f-edb5-11ed-9ea2-005056803aed
spec:
  replicas: 2
  revisionHistoryLimit: 10
  selector:
    app: bee
  strategy:
    activeDeadlineSeconds: 21600
    resources: {}
    rollingParams:
      intervalSeconds: 1
      maxSurge: 25%
      maxUnavailable: 25%
      timeoutSeconds: 600
      updatePeriodSeconds: 1
    type: Rolling
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: bee
    spec:
      containers:
      - env:
        - name: RUN_TYPE
          value: cpu
        - name: CPU_PERCENT
          value: "100"
        image: beekman9527/cpumemload:latest
        imagePullPolicy: Always
        name: beekman-1
        resources:
          limits:
            cpu: 200m
            memory: 20Mi
          requests:
            cpu: 15m
            memory: 10Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
  test: false
  triggers: []
```

Before Action
<img width="1881" alt="image" src="https://github.com/turbonomic/kubeturbo/assets/10027921/36522e1f-4e66-41c3-a98d-a4f853e0d130">

```

opt get pod -n irf
NAME                         READY   STATUS    RESTARTS   AGE
beekman-dc-1-4-2qpt6         1/1     Running   0          1h
beekman-dc-1-4-ztz42         1/1     Running   0          1h
beekman-dc-2-3-gqgvj         1/1     Running   0          2h
beekman-dc-2-3-vc4s2         1/1     Running   0          2h
beekman-dc-5-1-9xwkn         1/1     Running   0          34m
beekman-dc-5-1-vcj8d         1/1     Running   0          34m
kubeturbo-5bc4848494-mptnd   1/1     Running   0          13m
```

After Action
<img width="735" alt="image" src="https://github.com/turbonomic/kubeturbo/assets/10027921/a62881c7-e4ed-4a89-91c9-568e357136f8">


opt get pod -n irf
NAME                         READY   STATUS        RESTARTS   AGE
beekman-dc-1-4-2qpt6         1/1     Terminating   0          1h
beekman-dc-1-4-ztz42         1/1     Terminating   0          1h
beekman-dc-1-5-9k87j         1/1     Running       0          16s
beekman-dc-1-5-vmvsk         1/1     Running       0          9s
beekman-dc-2-3-gqgvj         1/1     Running       0          2h
beekman-dc-2-3-vc4s2         1/1     Running       0          2h
beekman-dc-5-1-9xwkn         1/1     Running       0          35m
beekman-dc-5-1-vcj8d         1/1     Running       0          35m
kubeturbo-5bc4848494-mptnd   1/1     Running       0          14m

-----------

A deployment config with trigger type as `ImageChange` is also rolled out 

```
opt get dc -n irf beekman-dc-5 -oyaml
apiVersion: apps.openshift.io/v1
kind: DeploymentConfig
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps.openshift.io/v1","kind":"DeploymentConfig","metadata":{"annotations":{},"labels":{"app":"bee"},"name":"beekman-dc-5","namespace":"irf"},"spec":{"replicas":2,"revisionHistoryLimit":10,"selector":{"app":"bee"},"template":{"metadata":{"labels":{"app":"bee"}},"spec":{"containers":[{"env":[{"name":"RUN_TYPE","value":"cpu"},{"name":"CPU_PERCENT","value":"100"}],"image":"beekman-imagestream:latest","imagePullPolicy":"Always","name":"beekman-1","resources":{"limits":{"cpu":"20m","memory":"20Mi"},"requests":{"cpu":"15m","memory":"10Mi"}}}]}},"test":false,"triggers":[{"imageChangeParams":{"automatic":true,"containerNames":["beekman-1"],"from":{"kind":"ImageStreamTag","name":"beekman-imagestream:latest","namespace":"irf"}},"type":"ImageChange"}]}}
  creationTimestamp: "2023-05-23T14:18:28Z"
  generation: 2
  labels:
    app: bee
  name: beekman-dc-5
  namespace: irf
  resourceVersion: "371517762"
  selfLink: /apis/apps.openshift.io/v1/namespaces/irf/deploymentconfigs/beekman-dc-5
  uid: b017da34-f974-11ed-a992-005056803aed
spec:
  replicas: 2
  revisionHistoryLimit: 10
  selector:
    app: bee
  strategy:
    activeDeadlineSeconds: 21600
    resources: {}
    rollingParams:
      intervalSeconds: 1
      maxSurge: 25%
      maxUnavailable: 25%
      timeoutSeconds: 600
      updatePeriodSeconds: 1
    type: Rolling
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: bee
    spec:
      containers:
      - env:
        - name: RUN_TYPE
          value: cpu
        - name: CPU_PERCENT
          value: "100"
        image: docker.io/beekman9527/cpumemload@sha256:42172a45b5e9822e23f0bc330978a97a20b4050aed1614ac30ebeb25d2c86932
        imagePullPolicy: Always
        name: beekman-1
        resources:
          limits:
            cpu: 20m
            memory: 20Mi
          requests:
            cpu: 15m
            memory: 10Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
  test: false
  triggers:
  - imageChangeParams:
      automatic: true
      containerNames:
      - beekman-1
      from:
        kind: ImageStreamTag
        name: beekman-imagestream:latest
        namespace: irf
      lastTriggeredImage: docker.io/beekman9527/cpumemload@sha256:42172a45b5e9822e23f0bc330978a97a20b4050aed1614ac30ebeb25d2c86932
    type: ImageChange
```

Before action 
<img width="1910" alt="image" src="https://github.com/turbonomic/kubeturbo/assets/10027921/67eae0a0-6852-4c63-8c29-ab195ba04adf">


```
opt get pod -n irf
NAME                         READY   STATUS    RESTARTS   AGE
beekman-dc-1-5-9k87j         1/1     Running   0          3m
beekman-dc-1-5-vmvsk         1/1     Running   0          3m
beekman-dc-2-3-gqgvj         1/1     Running   0          2h
beekman-dc-2-3-vc4s2         1/1     Running   0          2h
beekman-dc-5-1-9xwkn         1/1     Running   0          38m
beekman-dc-5-1-vcj8d         1/1     Running   0          38m
kubeturbo-5bc4848494-mptnd   1/1     Running   0          17m
```

After action

<img width="1278" alt="image" src="https://github.com/turbonomic/kubeturbo/assets/10027921/ec802e75-03ee-487a-bf20-8ec2ab8c1c8e">


```
opt get pod -n irf
NAME                         READY   STATUS        RESTARTS   AGE
beekman-dc-1-5-9k87j         1/1     Running       0          5m
beekman-dc-1-5-vmvsk         1/1     Running       0          4m
beekman-dc-2-3-gqgvj         1/1     Running       0          2h
beekman-dc-2-3-vc4s2         1/1     Running       0          2h
beekman-dc-5-1-9xwkn         1/1     Running       0          40m
beekman-dc-5-1-vcj8d         1/1     Terminating   0          40m
beekman-dc-5-2-deploy        1/1     Running       0          22s
beekman-dc-5-2-xwct2         1/1     Running       0          6s
kubeturbo-5bc4848494-mptnd   1/1     Running       0          18m
```
