### PR TITLE
[TRB-39520]:Change to use new ROSA cluster for integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - make integration
   - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
   - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -istio-enabled=true -ginkgo.focus=Istio -ginkgo.focus=teardown -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
-  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=ocp47 -openshift-tests=true -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
+  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=rosa -openshift-tests=true -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
   - make product
 
 after_success:

--- a/hack/generate_ocp_context.sh
+++ b/hack/generate_ocp_context.sh
@@ -11,6 +11,6 @@ function check-cluster-ready() {
 }
 
 echo "Log in the OpenShift cluster"
-${oc_path} login --server=${OCP47_SERVER_ADDR} --username=${OCP47_USERNAME} --password=${OCP47_PASSWORD} --insecure-skip-tls-verify=true
+${oc_path} login --server=${OCP_SERVER_ADDR} --username=${OCP_USERNAME} --password=${OCP_PASSWORD} --insecure-skip-tls-verify=true
 check-cluster-ready
-${oc_path} config rename-context $(${oc_path} config current-context) ocp47
+${oc_path} config rename-context $(${oc_path} config current-context) rosa


### PR DESCRIPTION
# Intent
Change the Openshift cluster used by the integration test to a new one 

# Background
The old Openshift cluster doesn't work well now.  

# Implementation
Set up the new cluster with the deployment as the old one has, and update the kubeconfig context in the Travis job setting.
