### PR TITLE
Disable Openshift test in the integration test temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ script:
   - ./hack/download_test_binaries.sh
   - ./hack/create_kind_cluster.sh
   - ./hack/deploy_istio.sh
-  - ./hack/generate_ocp_context.sh
+  # - ./hack/generate_ocp_context.sh
   - make integration
   - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
   - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -istio-enabled=true -ginkgo.focus=Istio -ginkgo.focus=teardown -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
-  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=rosa -openshift-tests=true -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
+  # - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=rosa -openshift-tests=true -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
   - make product
 
 after_success:


### PR DESCRIPTION
# Background
The integration test is falling on Openshift cases, as the ROSA cluster where those Openshift cases are tested is experiencing a fatal problem that blocks the pod from being created.  

# Changes
Disable all of Openshift cases temporarily 