### PR TITLE
[TRB-40504] Additional logging for affinities, taints, labels and node topologies

### DIFF
--- a/pkg/discovery/k8s_discovery_client.go
+++ b/pkg/discovery/k8s_discovery_client.go
@@ -327,7 +327,7 @@ func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*prot
 			start := time.Now()
 			namespaceLister, err := podaffinity.NewNamespaceLister(dc.k8sClusterScraper.Clientset, clusterSummary)
 			if err != nil {
-				glog.Errorf("error creating affinity processor: %v", err)
+				glog.Errorf("Error creating affinity processor: %v", err)
 			} else {
 				affinityProcessor, err := podaffinity.New(clusterSummary,
 					podaffinity.NewNodeInfoLister(clusterSummary), namespaceLister)
@@ -338,6 +338,14 @@ func (dc *K8sDiscoveryClient) DiscoverWithNewFramework(targetID string) ([]*prot
 				}
 				glog.V(2).Infof("Successfully processed affinities.")
 				glog.V(3).Infof("Processing affinities with new algorithm took %s", time.Since(start))
+				if glog.V(3) {
+					nodeCommsTotal := 0
+					for node, pods := range nodesPods {
+						nodeCommsTotal += len(pods)
+						glog.Infof("Node %s will sell %v affinity related commodities.", node, len(pods))
+					}
+					glog.Infof("Total %v affinity related commodities will be sold by all nodes.", nodeCommsTotal)
+				}
 				glog.V(6).Infof("\n\nProcessed affinity result: \n\n %++v \n\n %++v \n\n",
 					nodesPods, podsWithAffinities)
 			}

--- a/pkg/discovery/worker/compliance/podaffinity/filtering.go
+++ b/pkg/discovery/worker/compliance/podaffinity/filtering.go
@@ -26,6 +26,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/golang/glog"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -242,6 +244,17 @@ func (pr *PodAffinityProcessor) PreFilter(ctx context.Context, pod *v1.Pod) (*pr
 	s.existingAntiAffinityCounts = pr.getExistingAntiAffinityCounts(ctx, pod, s.namespaceLabels, nodesWithRequiredAntiAffinityPods)
 	s.affinityCounts, s.antiAffinityCounts = pr.getIncomingAffinityAntiAffinityCounts(ctx, s.podInfo, allNodes)
 
+	if glog.V(3) {
+		// We don't want to waste time setting the map up if verbosity < 3
+		defer pr.Unlock()
+		pr.Lock()
+		for _, term := range s.podInfo.ActualAffinityTerms {
+			pr.uniqueAffinityTerms.Insert(term.String())
+		}
+		for _, term := range s.podInfo.ActualAntiAffinityTerms {
+			pr.uniqueAntiAffinityTerms.Insert(term.String())
+		}
+	}
 	return s, nil
 }
 


### PR DESCRIPTION
**Intent**
Implements https://jsw.ibm.com/browse/TRB-40073 The details that are added in the logs are listed in the story

A point to note is that all the numbers are logged if the glog level is set to 3 or more and actual lists of items/rules is logged if the level is set to 5 or more

**Testing**
Pasting a set of logs relevant to affinities from a small cluster
```
I0526 00:24:28.000526   80087 processor.go:190] Cluster has 13 total pods with All Affinities.
I0526 00:24:28.000561   80087 processor.go:191] Cluster has 10 total pods with node Affinities.
I0526 00:24:28.000573   80087 processor.go:192] Cluster has 4 pods with pod to pod Affinities/AntiAffinities.
I0526 00:24:28.000535   80087 remote_mediation_client.go:377] Sent keep alive response 7377
I0526 00:24:28.064671   80087 processor.go:193] Cluster has 0 pods with volumes that specify Node AntiAffinities.
I0526 00:24:28.000548   80087 remote_mediation_client.go:241] [probeCallback] received response on probe channel 0xc0007da060
 
I0526 00:24:28.064687   80087 processor.go:194] Cluster has 1 total unique Affinity terms by rule string.
I0526 00:24:28.064693   80087 processor.go:195] Cluster has 1 total unique AntiAffinity terms by rule string.
I0526 00:24:28.064698   80087 processor.go:196] Cluster has 15 total unique label key=value pairs on pods.
I0526 00:24:28.064696   80087 client_protobuf_endpoint.go:78] [ServerRequestEndpoint] : Sending protobuf message
I0526 00:24:28.064702   80087 processor.go:197] Cluster has 12 total unique label key=value pairs (topologies) on nodes.
I0526 00:24:28.126764   80087 processor.go:200] Pods with Affinities: 
[kube-system/kube-proxy-ncnww default/affine-to-spread-qk6xn-5576444577-pqtfp kube-system/kindnet-j9crl default/dep-spread-2zwnh-6d5c4bb47-6pbtc kube-system/kube-proxy-fz756 kube-system/kube-proxy-j8vnn kube-system/kindnet-vb99f kube-system/kindnet-bkltj kube-system/kube-proxy-6bwhj kube-system/kindnet-rpmlp kube-system/coredns-565d847f94-btrcf default/node-affinity-kzzkj-7c76c5595-2kxpz kube-system/coredns-565d847f94-5r9p2]
I0526 00:24:28.126789   80087 processor.go:201] Pods with node Affinities: 
[kube-system/kube-proxy-ncnww kube-system/kube-proxy-fz756 kube-system/kube-proxy-j8vnn default/node-affinity-kzzkj-7c76c5595-2kxpz kube-system/kindnet-bkltj kube-system/kube-proxy-6bwhj kube-system/kindnet-j9crl kube-system/kindnet-rpmlp kube-system/kindnet-vb99f default/affine-to-spread-qk6xn-5576444577-pqtfp]
I0526 00:24:28.126799   80087 processor.go:202] Pods with pod to pod Affinities/AntiAffinities: 
[default/dep-spread-2zwnh-6d5c4bb47-6pbtc kube-system/coredns-565d847f94-btrcf kube-system/coredns-565d847f94-5r9p2 default/affine-to-spread-qk6xn-5576444577-pqtfp]
I0526 00:24:28.126815   80087 processor.go:203] Pods with volumes that specify Node AntiAffinities: 
[]
I0526 00:24:28.126822   80087 processor.go:204] Unique Affinity terms by rule string: 
[&PodAffinityTerm{LabelSelector:&v1.LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:app,Operator:In,Values:[store],},},},Namespaces:[],TopologyKey:kubernetes.io/hostname,NamespaceSelector:nil,}]
I0526 00:24:28.126829   80087 processor.go:205] Unique AntiAffinity terms by rule string: 
[&PodAffinityTerm{LabelSelector:&v1.LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:app,Operator:In,Values:[store],},},},Namespaces:[default],TopologyKey:kubernetes.io/hostname,NamespaceSelector:nil,}]
I0526 00:24:28.126837   80087 processor.go:206] Unique label pairs on pods: 
 [pod-template-hash=565d847f94 tier=node k8s-app=kube-proxy app=store app=perf pod-template-hash=7c76c5595 k8s-app=kindnet pod-template-hash=5576444577 dep=affine-to-spread k8s-app=kube-dns app=kindnet controller-revision-hash=85b64c944d pod-template-generation=1 controller-revision-hash=55c79b8759 pod-template-hash=6d5c4bb47]
```