### PR TITLE
[TRB-39636]:Set provenance flag to false to build the docker format image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,5 +75,5 @@ multi-archs:
 docker-buildx:
 	docker buildx create --name kubeturbo-builder
 	- docker buildx use kubeturbo-builder
-	- docker buildx build --platform=$(PLATFORMS) --label "git-commit=$(GIT_COMMIT)" --push --tag $(REPO_NAME)/kubeturbo:$(VERSION) -f build/Dockerfile.multi-archs --build-arg VERSION=$(VERSION) .
+	- docker buildx build --platform=$(PLATFORMS) --label "git-commit=$(GIT_COMMIT)" --provenance=false --push --tag $(REPO_NAME)/kubeturbo:$(VERSION) -f build/Dockerfile.multi-archs --build-arg VERSION=$(VERSION) .
 	docker buildx rm kubeturbo-builder


### PR DESCRIPTION
@Billy get the build(with the provenance flag set to false) passed on the local by running `make docker-buildx`.  We want to give it a shot in the pipeline. 
```
[root@api.ocp410kev.cp.fyre.ibm.com ~]# docker manifest inspect icr.io/cpopen/turbonomic/kubeturbo:8.9.2-test
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2267,
         "digest": "sha256:970edaa1e4e7a47246a7fec5c0054512a733048ff414edfd1aeb4f64982f4f03",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2267,
         "digest": "sha256:1bbbad4718446eecc9c0eef22968bc7f1222249ac86f219fadefe2e59fe687d1",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2267,
         "digest": "sha256:8f09eb26964fc55453f79812e9b12fc39b4adc083684a2415599aa385c95c0cf",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2267,
         "digest": "sha256:f9cbd5f18b7b08210cb7d90590451e048798b7fdc374b0ede4b449c8c6a3ea09",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      }
   ]
}
```