### PR TITLE
Add controller type information in containerPodData in kubeturbo discovery

### DIFF
--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/stitching"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	"github.com/turbonomic/kubeturbo/pkg/features"
+	commonutil "github.com/turbonomic/kubeturbo/pkg/util"
 
 	sdkbuilder "github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
@@ -638,4 +639,66 @@ func AppendNewLabelCommodityToList(commoditiesList []*proto.CommodityDTO, key st
 	}
 	commoditiesList = append(commoditiesList, labelComm)
 	return commoditiesList, nil
+}
+
+// CreateWorkloadControllerDataByControllerType creates and returns a *proto.EntityDTO_WorkloadControllerData
+// based on the provided controller kind.
+//
+// The supported controller kinds are:
+//   - KindCronJob
+//   - KindDaemonSet
+//   - KindDeployment
+//   - KindJob
+//   - KindReplicaSet
+//   - KindReplicationController
+//   - KindStatefulSet
+//
+// If the provided kind does not match any known controller type, it returns nil.
+func CreateWorkloadControllerDataByControllerType(kind string) *proto.EntityDTO_WorkloadControllerData {
+	switch kind {
+	case commonutil.KindCronJob:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_CronJobData{
+				CronJobData: &proto.EntityDTO_CronJobData{},
+			},
+		}
+	case commonutil.KindDaemonSet:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_DaemonSetData{
+				DaemonSetData: &proto.EntityDTO_DaemonSetData{},
+			},
+		}
+	case commonutil.KindDeployment:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_DeploymentData{
+				DeploymentData: &proto.EntityDTO_DeploymentData{},
+			},
+		}
+	case commonutil.KindJob:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_JobData{
+				JobData: &proto.EntityDTO_JobData{},
+			},
+		}
+	case commonutil.KindReplicaSet:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_ReplicaSetData{
+				ReplicaSetData: &proto.EntityDTO_ReplicaSetData{},
+			},
+		}
+	case commonutil.KindReplicationController:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_ReplicationControllerData{
+				ReplicationControllerData: &proto.EntityDTO_ReplicationControllerData{},
+			},
+		}
+	case commonutil.KindStatefulSet:
+		return &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_StatefulSetData{
+				StatefulSetData: &proto.EntityDTO_StatefulSetData{},
+			},
+		}
+	default:
+		return nil
+	}
 }

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder.go
@@ -613,13 +613,14 @@ func (builder *podEntityDTOBuilder) createContainerPodData(pod *api.Pod) *proto.
 		// Could be custom controller. We do not bulk process custom controller.
 		glog.V(3).Infof("add cumtomer controller data of controller %v/%v for pod %v/%v: controller not cached.",
 			ownerInfo.Kind, ownerInfo.Name, pod.Namespace, pod.Name)
-	} else {
-		controllerData :=CreateWorkloadControllerDataByControllerType(controller.Kind)
-		if controllerData != nil {
-			podData.
+		podData.ControllerData = &proto.EntityDTO_WorkloadControllerData{
+			ControllerType: &proto.EntityDTO_WorkloadControllerData_CustomControllerData{
+				CustomControllerData: &proto.EntityDTO_CustomControllerData{},
+			},
 		}
-
-
+	} else {
+		controllerData := CreateWorkloadControllerDataByControllerType(controller.Kind)
+		podData.ControllerData = controllerData
 	}
 
 	return podData

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
-	commonutil "github.com/turbonomic/kubeturbo/pkg/util"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"k8s.io/apiserver/pkg/util/feature"
 )
@@ -576,78 +575,4 @@ func Test_getPodCommoditiesBought_PodAntiAffinity(t *testing.T) {
 	assert.NotEmpty(t, commoditiesBought)
 	assert.Equal(t, 1, len(commoditiesBought))
 	assert.Equal(t, proto.CommodityDTO_LABEL, *commoditiesBought[0].CommodityType)
-}
-
-func TestCreateContainerPodDataByControllerType(t *testing.T) {
-	// Test cases for supported controller kinds
-	testCases := []struct {
-		kind       string
-		assertFunc func(*testing.T, *proto.EntityDTO_WorkloadControllerData)
-	}{
-		{
-			kind: commonutil.KindCronJob,
-			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
-				assert.NotNil(t, data.GetCronJobData())
-				assert.Nil(t, data.GetDaemonSetData())
-			},
-		},
-		{
-			kind: commonutil.KindDaemonSet,
-			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
-				assert.NotNil(t, data.GetDaemonSetData())
-				assert.Nil(t, data.GetCronJobData())
-			},
-		},
-		// Add test cases for other supported controller kinds
-		{
-			kind: commonutil.KindDeployment,
-			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
-				assert.NotNil(t, data.GetDeploymentData())
-				// Add additional assertions if needed
-			},
-		},
-		{
-			kind: commonutil.KindJob,
-			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
-				assert.NotNil(t, data.GetJobData())
-				// Add additional assertions if needed
-			},
-		},
-		{
-			kind: commonutil.KindReplicaSet,
-			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
-				assert.NotNil(t, data.GetReplicaSetData())
-				// Add additional assertions if needed
-			},
-		},
-		{
-			kind: commonutil.KindReplicationController,
-			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
-				assert.NotNil(t, data.GetReplicationControllerData())
-				// Add additional assertions if needed
-			},
-		},
-		{
-			kind: commonutil.KindStatefulSet,
-			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
-				assert.NotNil(t, data.GetStatefulSetData())
-				// Add additional assertions if needed
-			},
-		},
-	}
-
-	// Run test cases
-	for _, tc := range testCases {
-		t.Run(tc.kind, func(t *testing.T) {
-			data := CreateWorkloadControllerDataByControllerType(tc.kind)
-			tc.assertFunc(t, data)
-		})
-	}
-
-	// Test case for unsupported controller kind
-	t.Run("UnsupportedKind", func(t *testing.T) {
-		kind := "UnsupportedKind"
-		data := CreateWorkloadControllerDataByControllerType(kind)
-		assert.Nil(t, data)
-	})
 }

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/turbonomic/kubeturbo/pkg/discovery/metrics"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	commonutil "github.com/turbonomic/kubeturbo/pkg/util"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"k8s.io/apiserver/pkg/util/feature"
 )
@@ -575,4 +576,78 @@ func Test_getPodCommoditiesBought_PodAntiAffinity(t *testing.T) {
 	assert.NotEmpty(t, commoditiesBought)
 	assert.Equal(t, 1, len(commoditiesBought))
 	assert.Equal(t, proto.CommodityDTO_LABEL, *commoditiesBought[0].CommodityType)
+}
+
+func TestCreateContainerPodDataByControllerType(t *testing.T) {
+	// Test cases for supported controller kinds
+	testCases := []struct {
+		kind       string
+		assertFunc func(*testing.T, *proto.EntityDTO_WorkloadControllerData)
+	}{
+		{
+			kind: commonutil.KindCronJob,
+			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
+				assert.NotNil(t, data.GetCronJobData())
+				assert.Nil(t, data.GetDaemonSetData())
+			},
+		},
+		{
+			kind: commonutil.KindDaemonSet,
+			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
+				assert.NotNil(t, data.GetDaemonSetData())
+				assert.Nil(t, data.GetCronJobData())
+			},
+		},
+		// Add test cases for other supported controller kinds
+		{
+			kind: commonutil.KindDeployment,
+			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
+				assert.NotNil(t, data.GetDeploymentData())
+				// Add additional assertions if needed
+			},
+		},
+		{
+			kind: commonutil.KindJob,
+			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
+				assert.NotNil(t, data.GetJobData())
+				// Add additional assertions if needed
+			},
+		},
+		{
+			kind: commonutil.KindReplicaSet,
+			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
+				assert.NotNil(t, data.GetReplicaSetData())
+				// Add additional assertions if needed
+			},
+		},
+		{
+			kind: commonutil.KindReplicationController,
+			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
+				assert.NotNil(t, data.GetReplicationControllerData())
+				// Add additional assertions if needed
+			},
+		},
+		{
+			kind: commonutil.KindStatefulSet,
+			assertFunc: func(t *testing.T, data *proto.EntityDTO_WorkloadControllerData) {
+				assert.NotNil(t, data.GetStatefulSetData())
+				// Add additional assertions if needed
+			},
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		t.Run(tc.kind, func(t *testing.T) {
+			data := CreateWorkloadControllerDataByControllerType(tc.kind)
+			tc.assertFunc(t, data)
+		})
+	}
+
+	// Test case for unsupported controller kind
+	t.Run("UnsupportedKind", func(t *testing.T) {
+		kind := "UnsupportedKind"
+		data := CreateWorkloadControllerDataByControllerType(kind)
+		assert.Nil(t, data)
+	})
 }

--- a/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/pod_entity_dto_builder_test.go
@@ -197,7 +197,7 @@ func TestContainerMetricsAvailability(t *testing.T) {
 	sink.AddNewMetricEntries(containerMetricsAvailableMetric, containerMetricsNotAvailableMetric)
 	// pod3 does not have any isAvailability metrics created, we consider it as powerON
 
-	podDTOBuilder := NewPodEntityDTOBuilder(sink, nil)
+	podDTOBuilder := NewPodEntityDTOBuilder(sink, nil, nil)
 	for _, test := range tests {
 		assert.Equal(t, podDTOBuilder.isContainerMetricsAvailable(test.pod), test.expectedMetricsAvailable)
 	}
@@ -251,7 +251,7 @@ func TestGetRegionZoneLabelCommodity(t *testing.T) {
 	}
 
 	sink := metrics.NewEntityMetricSink()
-	podDTOBuilder := NewPodEntityDTOBuilder(sink, nil).WithPodToVolumesMap(pod2PvMap).WithNodeNameToNodeMap(nodeNameToNodeMap)
+	podDTOBuilder := NewPodEntityDTOBuilder(sink, nil, nil).WithPodToVolumesMap(pod2PvMap).WithNodeNameToNodeMap(nodeNameToNodeMap)
 	var commoditiesBought []*proto.CommodityDTO
 	var err error
 	commoditiesBought, err = podDTOBuilder.getRegionZoneLabelCommodity(testPod1, commoditiesBought)

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
@@ -177,67 +177,86 @@ func getActiveReplicaCount(kubeController *repository.KubeController) int32 {
 	return int32(replicaCount)
 }
 
-func (builder *workloadControllerDTOBuilder) createWorkloadControllerData(kubeController *repository.KubeController) *proto.EntityDTO_WorkloadControllerData {
-	controllerType := kubeController.ControllerType
-	replicaCount := getActiveReplicaCount(kubeController)
-	switch controllerType {
+// CreateWorkloadControllerDataByControllerType creates and returns a *proto.EntityDTO_WorkloadControllerData
+// based on the provided controller kind.
+//
+// The supported controller kinds are:
+//   - KindCronJob
+//   - KindDaemonSet
+//   - KindDeployment
+//   - KindJob
+//   - KindReplicaSet
+//   - KindReplicationController
+//   - KindStatefulSet
+//
+// If the provided kind does not match any known controller type, it returns CustomControllerData with its type specified.
+func CreateWorkloadControllerDataByControllerType(kind string) *proto.EntityDTO_WorkloadControllerData {
+	var data *proto.EntityDTO_WorkloadControllerData
+
+	switch kind {
 	case util.KindCronJob:
-		return &proto.EntityDTO_WorkloadControllerData{
+		data = &proto.EntityDTO_WorkloadControllerData{
 			ControllerType: &proto.EntityDTO_WorkloadControllerData_CronJobData{
 				CronJobData: &proto.EntityDTO_CronJobData{},
 			},
-			ReplicaCount: &replicaCount,
 		}
 	case util.KindDaemonSet:
-		return &proto.EntityDTO_WorkloadControllerData{
+		data = &proto.EntityDTO_WorkloadControllerData{
 			ControllerType: &proto.EntityDTO_WorkloadControllerData_DaemonSetData{
 				DaemonSetData: &proto.EntityDTO_DaemonSetData{},
 			},
-			ReplicaCount: &replicaCount,
 		}
 	case util.KindDeployment:
-		return &proto.EntityDTO_WorkloadControllerData{
+		data = &proto.EntityDTO_WorkloadControllerData{
 			ControllerType: &proto.EntityDTO_WorkloadControllerData_DeploymentData{
 				DeploymentData: &proto.EntityDTO_DeploymentData{},
 			},
-			ReplicaCount: &replicaCount,
 		}
 	case util.KindJob:
-		return &proto.EntityDTO_WorkloadControllerData{
+		data = &proto.EntityDTO_WorkloadControllerData{
 			ControllerType: &proto.EntityDTO_WorkloadControllerData_JobData{
 				JobData: &proto.EntityDTO_JobData{},
 			},
-			ReplicaCount: &replicaCount,
 		}
 	case util.KindReplicaSet:
-		return &proto.EntityDTO_WorkloadControllerData{
+		data = &proto.EntityDTO_WorkloadControllerData{
 			ControllerType: &proto.EntityDTO_WorkloadControllerData_ReplicaSetData{
 				ReplicaSetData: &proto.EntityDTO_ReplicaSetData{},
 			},
-			ReplicaCount: &replicaCount,
 		}
 	case util.KindReplicationController:
-		return &proto.EntityDTO_WorkloadControllerData{
+		data = &proto.EntityDTO_WorkloadControllerData{
 			ControllerType: &proto.EntityDTO_WorkloadControllerData_ReplicationControllerData{
 				ReplicationControllerData: &proto.EntityDTO_ReplicationControllerData{},
 			},
-			ReplicaCount: &replicaCount,
 		}
 	case util.KindStatefulSet:
-		return &proto.EntityDTO_WorkloadControllerData{
+		data = &proto.EntityDTO_WorkloadControllerData{
 			ControllerType: &proto.EntityDTO_WorkloadControllerData_StatefulSetData{
 				StatefulSetData: &proto.EntityDTO_StatefulSetData{},
 			},
-			ReplicaCount: &replicaCount,
 		}
 	default:
-		return &proto.EntityDTO_WorkloadControllerData{
+		data = &proto.EntityDTO_WorkloadControllerData{
 			ControllerType: &proto.EntityDTO_WorkloadControllerData_CustomControllerData{
 				CustomControllerData: &proto.EntityDTO_CustomControllerData{
-					CustomControllerType: &controllerType,
+					CustomControllerType: &kind,
 				},
 			},
-			ReplicaCount: &replicaCount,
 		}
 	}
+
+	return data
+}
+
+func (builder *workloadControllerDTOBuilder) createWorkloadControllerData(kubeController *repository.KubeController) *proto.EntityDTO_WorkloadControllerData {
+	controllerType := kubeController.ControllerType
+	data := CreateWorkloadControllerDataByControllerType(controllerType)
+
+	if data != nil {
+		replicaCount := getActiveReplicaCount(kubeController)
+		data.ReplicaCount = &replicaCount
+	}
+
+	return data
 }

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -427,7 +427,7 @@ func (worker *k8sDiscoveryWorker) buildPodDTOs(currTask *task.Task) ([]*proto.En
 		return nil, nil, nil, nil
 	}
 	runningPodDTOs, pendingPodDTOs, podsWithVolumes, mirrorPodUids := dtofactory.
-		NewPodEntityDTOBuilder(worker.sink, worker.stitchingManager).
+		NewPodEntityDTOBuilder(worker.sink, worker.stitchingManager, cluster).
 		// Node providers
 		WithNodeNameUIDMap(cluster.NodeNameUIDMap).
 		// Quota providers

--- a/pkg/discovery/worker/k8s_discovery_worker.go
+++ b/pkg/discovery/worker/k8s_discovery_worker.go
@@ -426,8 +426,9 @@ func (worker *k8sDiscoveryWorker) buildPodDTOs(currTask *task.Task) ([]*proto.En
 		glog.Errorf("Failed to build pod DTOs: cluster summary object is null for worker %s", worker.id)
 		return nil, nil, nil, nil
 	}
+
 	runningPodDTOs, pendingPodDTOs, podsWithVolumes, mirrorPodUids := dtofactory.
-		NewPodEntityDTOBuilder(worker.sink, worker.stitchingManager, cluster).
+		NewPodEntityDTOBuilder(worker.sink, worker.stitchingManager, worker.k8sClusterScraper).
 		// Node providers
 		WithNodeNameUIDMap(cluster.NodeNameUIDMap).
 		// Quota providers


### PR DESCRIPTION
I have merged this PR https://github.com/turbonomic/kubeturbo/pull/863 in kubeturbo to update protobuf from go-sdk to create SLO action merge spec. This is the follow up PR for using controller type information in containerPodData for exclusion filter of certain containerPod from SLO merge action.

Developer Checks
[x] Full build with unit tests and Checkstyle / SpotBugs tests
[x] Unit tests added / updated
[x]No unlicensed images, no third-party code (such as from StackOverflow)
Integration (Robot Framework) tests added / updated
Manual testing done (and described)
Product sweep run and passed
Developer wiki updated (and linked to this description)