### PR TITLE
[TRB-39717] Stitching volumes from AWS to kubeturbo fails for manually created volumes

### DIFF
--- a/build/Dockerfile.delve
+++ b/build/Dockerfile.delve
@@ -1,11 +1,11 @@
-FROM ubuntu:latest
+FROM --platform=linux/amd64 ubuntu:latest
 
-ENV GO_VER=1.12.5
+ENV GO_VER=1.20.4
 ENV FILE=go${GO_VER}.linux-amd64.tar.gz
 ENV GOROOT=/root/go
 ENV GOPATH=/root
 
 RUN apt update -y && apt install -y git curl && \
-cd ${GOPATH} && curl -k -s -O https://dl.google.com/go/${FILE} && \
-gunzip -c ${FILE} | tar xf - && rm -f ${FILE} && \
-${GOROOT}/bin/go get -u github.com/go-delve/delve/cmd/dlv
+    cd ${GOPATH} && curl -k -s -O https://dl.google.com/go/${FILE} && \
+    gunzip -c ${FILE} | tar xf - && rm -f ${FILE} 
+RUN ${GOROOT}/bin/go install github.com/go-delve/delve/cmd/dlv@latest

--- a/pkg/discovery/stitching/volume_stitching_manager.go
+++ b/pkg/discovery/stitching/volume_stitching_manager.go
@@ -227,10 +227,10 @@ func extractAWSVolumeUuid(volID string, vol *api.PersistentVolume) (string, erro
 					zone = labelV
 				}
 			}
-			if region != "" {
-				parts[0] = region
-			} else if zone != "" {
-				parts[0] = zone + "-"
+			if zone != "" {
+				parts[0] = zone
+			} else if region != "" {
+				parts[0] = region + "-"
 			}
 		}
 	}

--- a/pkg/discovery/stitching/volume_stitching_manager.go
+++ b/pkg/discovery/stitching/volume_stitching_manager.go
@@ -198,16 +198,41 @@ func (aws *awsVolumeUUIDGetter) GetVolumeUUID(vol *api.PersistentVolume) (string
 		return "", fmt.Errorf("not a valid AWS provisioned volume: %v", vol.Name)
 	}
 
-	return extractAWSVolumeUuid(vol.Spec.AWSElasticBlockStore.VolumeID, vol.Name)
+	return extractAWSVolumeUuid(vol.Spec.AWSElasticBlockStore.VolumeID, vol)
 }
 
-func extractAWSVolumeUuid(volID, volName string) (string, error) {
+func extractAWSVolumeUuid(volID string, vol *api.PersistentVolume) (string, error) {
+	volName := vol.Name
 	//1. split the suffix into two parts:
 	// aws://us-east-2c/vol-0e4eaa3ef79bcb5a9 -> [us-east-2c, vol-0e4eaa3ef79bcb5a9]
-	suffix := volID[len(awsVolPrefix):]
+	suffix := volID
+	if strings.HasPrefix(volID, awsVolPrefix) {
+		suffix = volID[len(awsVolPrefix):]
+	}
+
 	parts := strings.Split(suffix, "/")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("failed to split uuid (%d): %v, for volume %v", len(parts), parts, volName)
+	if len(parts) < 2 {
+		if vol.Labels == nil || len(vol.Labels) < 1 {
+			return "", fmt.Errorf("failed to split uuid (%d): %v, for volume %v", len(parts), parts, volName)
+		} else {
+			parts = append(parts, parts[0])
+			parts[0] = ""
+			region := ""
+			zone := ""
+			for labelKey, labelV := range vol.Labels {
+				if strings.HasSuffix(labelKey, "region") {
+					region = labelV
+				}
+				if strings.HasSuffix(labelKey, "zone") {
+					zone = labelV
+				}
+			}
+			if region != "" {
+				parts[0] = region
+			} else if zone != "" {
+				parts[0] = zone + "-"
+			}
+		}
 	}
 
 	//2. get region by removing the zone suffix
@@ -279,7 +304,7 @@ func (csi *csiVolumeUUIDGetter) GetVolumeUUID(vol *api.PersistentVolume) (string
 	// We will need evidence for this name to be something else in some installation.
 	// If we get that then it will become necessary to have this configured with the kuebturbo install.
 	if strings.Contains(driverName, "aws") && strings.Contains(driverName, "csi") {
-		return extractAWSVolumeUuid(volumeHandle, vol.Name)
+		return extractAWSVolumeUuid(volumeHandle, vol)
 	}
 
 	// The csi based volume driver names for azure generally are disk.csi.azure.com.

--- a/pkg/discovery/stitching/volume_stitching_manager.go
+++ b/pkg/discovery/stitching/volume_stitching_manager.go
@@ -212,26 +212,28 @@ func extractAWSVolumeUuid(volID string, vol *api.PersistentVolume) (string, erro
 
 	parts := strings.Split(suffix, "/")
 	if len(parts) < 2 {
+		// Try to extract the zone information from the volume labels if they exist
+		// "topology.kubernetes.io/region": "us-east-2"
+		// "topology.kubernetes.io/zone": "us-east-2c"
 		if vol.Labels == nil || len(vol.Labels) < 1 {
 			return "", fmt.Errorf("failed to split uuid (%d): %v, for volume %v", len(parts), parts, volName)
-		} else {
-			parts = append(parts, parts[0])
-			parts[0] = ""
-			region := ""
-			zone := ""
-			for labelKey, labelV := range vol.Labels {
-				if strings.HasSuffix(labelKey, "region") {
-					region = labelV
-				}
-				if strings.HasSuffix(labelKey, "zone") {
-					zone = labelV
-				}
+		}
+		parts = append(parts, parts[0])
+		parts[0] = ""
+		region := ""
+		zone := ""
+		for labelKey, labelV := range vol.Labels {
+			if strings.HasSuffix(labelKey, "region") {
+				region = labelV
 			}
-			if zone != "" {
-				parts[0] = zone
-			} else if region != "" {
-				parts[0] = region + "-"
+			if strings.HasSuffix(labelKey, "zone") {
+				zone = labelV
 			}
+		}
+		if zone != "" {
+			parts[0] = zone
+		} else if region != "" {
+			parts[0] = region + "-"
 		}
 	}
 

--- a/pkg/discovery/stitching/volume_stitching_manager_test.go
+++ b/pkg/discovery/stitching/volume_stitching_manager_test.go
@@ -57,12 +57,12 @@ func TestAWSVolumeUUIDGetter_GetUUID(t *testing.T) {
 			false,
 		},
 		{
-			args{"vol-0e4eaa3ef79bcb5a9", map[string]string{"topology.kubernetes.io/zone": "us-east-2"}},
+			args{"vol-0e4eaa3ef79bcb5a9", map[string]string{"topology.kubernetes.io/zone": "us-east-2c"}},
 			"aws::us-east-2::VL::vol-0e4eaa3ef79bcb5a9",
 			false,
 		},
 		{
-			args{"vol-0e4eaa3ef79bcb5a9", map[string]string{"topology.kubernetes.io/region": "us-east-2c"}},
+			args{"vol-0e4eaa3ef79bcb5a9", map[string]string{"topology.kubernetes.io/region": "us-east-2"}},
 			"aws::us-east-2::VL::vol-0e4eaa3ef79bcb5a9",
 			false,
 		},

--- a/pkg/discovery/stitching/volume_stitching_manager_test.go
+++ b/pkg/discovery/stitching/volume_stitching_manager_test.go
@@ -42,17 +42,33 @@ func mockCSIAzureVolume(volID string) *api.PersistentVolume {
 }
 
 func TestAWSVolumeUUIDGetter_GetUUID(t *testing.T) {
-	tests := [][]string{
+	tests := []struct {
+		volumeID string
+		labels   map[string]string
+		want     string
+	}{
 		{
 			"aws://us-east-2c/vol-0e4eaa3ef79bcb5a9",
+			map[string]string{},
+			"aws::us-east-2::VL::vol-0e4eaa3ef79bcb5a9",
+		},
+		{
+			"vol-0e4eaa3ef79bcb5a9",
+			map[string]string{"topology.kubernetes.io/zone": "us-east-2"},
+			"aws::us-east-2::VL::vol-0e4eaa3ef79bcb5a9",
+		},
+		{
+			"vol-0e4eaa3ef79bcb5a9",
+			map[string]string{"topology.kubernetes.io/region": "us-east-2c"},
 			"aws::us-east-2::VL::vol-0e4eaa3ef79bcb5a9",
 		},
 	}
 
 	getter := &awsVolumeUUIDGetter{}
 
-	for _, pair := range tests {
-		vol := mockAWSVolume(pair[0])
+	for _, test := range tests {
+		vol := mockAWSVolume(test.volumeID)
+		vol.Labels = test.labels
 		result, err := getter.GetVolumeUUID(vol)
 
 		if err != nil {
@@ -60,8 +76,8 @@ func TestAWSVolumeUUIDGetter_GetUUID(t *testing.T) {
 			continue
 		}
 
-		if strings.Compare(result, pair[1]) != 0 {
-			t.Errorf("Wrong volume stitching UUID %v Vs. %v", result, pair[1])
+		if strings.Compare(result, test.want) != 0 {
+			t.Errorf("Wrong volume stitching UUID %v Vs. %v", result, test.want)
 		}
 	}
 }


### PR DESCRIPTION
https://jsw.ibm.com/browse/TRB-39717
For AWS:
Original code requires that a volume ID is in the format `aws://us-east-2c/vol-0e4eaa3ef79bcb5a9`

This PR aims to remove this restriction as discussed in the bug report.
Try to extract volume id by parsing Labels if the volume ID doesn't explicitly contain the zone identifier

Before the fix is applied:
The volume "stitching-bug-validation" appears twice and total number of volumes is 4

After the fix is applied:
Total number of volumes is 3

![image](https://github.com/turbonomic/kubeturbo/assets/124801688/9f6c7bfa-a920-4398-8b6e-aad65e1c0b95)

![image](https://github.com/turbonomic/kubeturbo/assets/124801688/9f9bc5b2-e10e-4c13-9dd5-377714cfc4d3)


