### PR TITLE
[TRB-41478]: Make corrections to images that pointing to old artifactory

### DIFF
--- a/deploy/kubeturbo-operator/config/manager/manager.yaml
+++ b/deploy/kubeturbo-operator/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: kubeturbo-operator
-        image: turbonomic/kubeturbo-operator:8.5
+        image: icr.io/cpopen/kubeturbo-operator:8.9.2
         args:
         - --leader-elect
         - --leader-election-id=kubeturbo-operator

--- a/deploy/kubeturbo-operator/deploy/operator.yaml
+++ b/deploy/kubeturbo-operator/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: kubeturbo-operator
           # Replace this with the built image name
-          image: turbonomic/kubeturbo-operator:8.6.1
+          image: icr.io/cpopen/kubeturbo-operator:8.9.2
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/kubeturbo_yamls/turbo_kubeturbo_full.yaml
+++ b/deploy/kubeturbo_yamls/turbo_kubeturbo_full.yaml
@@ -100,7 +100,7 @@ spec:
       containers:
       - name: kubeturbo
         # Replace the image with desired version:8.7.6 or latest
-        image: turbonomic/kubeturbo:8.7.6
+        image: icr.io/cpopen/turbonomic/kubeturbo:8.7.6
         env:
           - name: KUBETURBO_NAMESPACE
             valueFrom:


### PR DESCRIPTION
## Description for [TRB-41478](https://jsw.ibm.com/browse/TRB-41478) 

There are several places in kubeturbo still pull images from the old artifactory. E.g:

* image: turbonomic/kubeturbo-operator
* image: turbonomic/kubeturbo
 

Need to correct images to use the right artfactory. E.g

* turbonomic/kubeturbo-operator -> icr.io/cpopen/turbonomic/kubeturbo
* turbonomic/kubeturbo -> icr.io/cpopen/turbonomic/kubeturbo