### PR TITLE
[TRB-35519]: Support for new merged SLO action in Action executor

### DIFF
--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -252,7 +252,7 @@ func (h *ActionHandler) getRelatedPod(actionItem *proto.ActionItemDTO) (*api.Pod
 	switch actionType {
 	case turboActionContainerResize:
 		podEntity = actionItem.GetHostedBySE()
-	case turboActionPodMove, turboActionPodProvision, turboActionPodSuspend:
+	case turboActionPodMove:
 		podEntity = actionItem.GetTargetSE()
 	case turboActionPodProvision, turboActionPodSuspend:
 		// pod horizontal scale (provision/suspension) merged into controller. No need for pod information.

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -33,6 +33,8 @@ type turboActionType struct {
 }
 
 var (
+	turboActionPodProvision     = turboActionType{proto.ActionItemDTO_PROVISION, proto.EntityDTO_CONTAINER_POD}
+	turboActionPodSuspend       = turboActionType{proto.ActionItemDTO_SUSPEND, proto.EntityDTO_CONTAINER_POD}
 	turboActionControllerScale  = turboActionType{proto.ActionItemDTO_HORIZONTAL_SCALE, proto.EntityDTO_WORKLOAD_CONTROLLER}
 	turboActionPodMove          = turboActionType{proto.ActionItemDTO_MOVE, proto.EntityDTO_CONTAINER_POD}
 	turboActionContainerResize  = turboActionType{proto.ActionItemDTO_RIGHT_SIZE, proto.EntityDTO_CONTAINER}
@@ -139,6 +141,8 @@ func (h *ActionHandler) registerActionExecutors() {
 	h.actionExecutors[turboActionPodMove] = reScheduler
 
 	horizontalScaler := executor.NewHorizontalScaler(ae)
+	h.actionExecutors[turboActionPodProvision] = horizontalScaler
+	h.actionExecutors[turboActionPodSuspend] = horizontalScaler
 	h.actionExecutors[turboActionControllerScale] = horizontalScaler
 
 	containerResizer := executor.NewContainerResizer(ae, c.kubeletClient, c.sccAllowedSet)
@@ -250,7 +254,7 @@ func (h *ActionHandler) getRelatedPod(actionItem *proto.ActionItemDTO) (*api.Pod
 	switch actionType {
 	case turboActionContainerResize:
 		podEntity = actionItem.GetHostedBySE()
-	case turboActionPodMove:
+	case turboActionPodMove, turboActionPodProvision, turboActionPodSuspend:
 		podEntity = actionItem.GetTargetSE()
 	case turboActionControllerScale:
 		// pod horizontal scale (provision/suspension) action was merged into controller. No need for pod information.

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -33,8 +33,7 @@ type turboActionType struct {
 }
 
 var (
-	turboActionPodProvision     = turboActionType{proto.ActionItemDTO_PROVISION, proto.EntityDTO_WORKLOAD_CONTROLLER}
-	turboActionPodSuspend       = turboActionType{proto.ActionItemDTO_SUSPEND, proto.EntityDTO_WORKLOAD_CONTROLLER}
+	turboActionControllerScale  = turboActionType{proto.ActionItemDTO_SCALE, proto.EntityDTO_WORKLOAD_CONTROLLER}
 	turboActionPodMove          = turboActionType{proto.ActionItemDTO_MOVE, proto.EntityDTO_CONTAINER_POD}
 	turboActionContainerResize  = turboActionType{proto.ActionItemDTO_RIGHT_SIZE, proto.EntityDTO_CONTAINER}
 	turboActionMachineProvision = turboActionType{proto.ActionItemDTO_PROVISION, proto.EntityDTO_VIRTUAL_MACHINE}
@@ -140,8 +139,7 @@ func (h *ActionHandler) registerActionExecutors() {
 	h.actionExecutors[turboActionPodMove] = reScheduler
 
 	horizontalScaler := executor.NewHorizontalScaler(ae)
-	h.actionExecutors[turboActionPodProvision] = horizontalScaler
-	h.actionExecutors[turboActionPodSuspend] = horizontalScaler
+	h.actionExecutors[turboActionControllerScale] = horizontalScaler
 
 	containerResizer := executor.NewContainerResizer(ae, c.kubeletClient, c.sccAllowedSet)
 	h.actionExecutors[turboActionContainerResize] = containerResizer
@@ -254,8 +252,8 @@ func (h *ActionHandler) getRelatedPod(actionItem *proto.ActionItemDTO) (*api.Pod
 		podEntity = actionItem.GetHostedBySE()
 	case turboActionPodMove:
 		podEntity = actionItem.GetTargetSE()
-	case turboActionPodProvision, turboActionPodSuspend:
-		// pod horizontal scale (provision/suspension) merged into controller. No need for pod information.
+	case turboActionControllerScale:
+		// pod horizontal scale (provision/suspension) action was merged into controller. No need for pod information.
 		return nil, nil
 	case turboActionMachineProvision, turboActionMachineSuspend:
 		// This branch is not called right now. Implement for the sake of completeness.

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -33,7 +33,7 @@ type turboActionType struct {
 }
 
 var (
-	turboActionControllerScale  = turboActionType{proto.ActionItemDTO_SCALE, proto.EntityDTO_WORKLOAD_CONTROLLER}
+	turboActionControllerScale  = turboActionType{proto.ActionItemDTO_HORIZONTAL_SCALE, proto.EntityDTO_WORKLOAD_CONTROLLER}
 	turboActionPodMove          = turboActionType{proto.ActionItemDTO_MOVE, proto.EntityDTO_CONTAINER_POD}
 	turboActionContainerResize  = turboActionType{proto.ActionItemDTO_RIGHT_SIZE, proto.EntityDTO_CONTAINER}
 	turboActionMachineProvision = turboActionType{proto.ActionItemDTO_PROVISION, proto.EntityDTO_VIRTUAL_MACHINE}

--- a/pkg/action/action_handler.go
+++ b/pkg/action/action_handler.go
@@ -33,8 +33,8 @@ type turboActionType struct {
 }
 
 var (
-	turboActionPodProvision     = turboActionType{proto.ActionItemDTO_PROVISION, proto.EntityDTO_CONTAINER_POD}
-	turboActionPodSuspend       = turboActionType{proto.ActionItemDTO_SUSPEND, proto.EntityDTO_CONTAINER_POD}
+	turboActionPodProvision     = turboActionType{proto.ActionItemDTO_PROVISION, proto.EntityDTO_WORKLOAD_CONTROLLER}
+	turboActionPodSuspend       = turboActionType{proto.ActionItemDTO_SUSPEND, proto.EntityDTO_WORKLOAD_CONTROLLER}
 	turboActionPodMove          = turboActionType{proto.ActionItemDTO_MOVE, proto.EntityDTO_CONTAINER_POD}
 	turboActionContainerResize  = turboActionType{proto.ActionItemDTO_RIGHT_SIZE, proto.EntityDTO_CONTAINER}
 	turboActionMachineProvision = turboActionType{proto.ActionItemDTO_PROVISION, proto.EntityDTO_VIRTUAL_MACHINE}
@@ -254,6 +254,9 @@ func (h *ActionHandler) getRelatedPod(actionItem *proto.ActionItemDTO) (*api.Pod
 		podEntity = actionItem.GetHostedBySE()
 	case turboActionPodMove, turboActionPodProvision, turboActionPodSuspend:
 		podEntity = actionItem.GetTargetSE()
+	case turboActionPodProvision, turboActionPodSuspend:
+		// pod horizontal scale (provision/suspension) merged into controller. No need for pod information.
+		return nil, nil
 	case turboActionMachineProvision, turboActionMachineSuspend:
 		// This branch is not called right now. Implement for the sake of completeness.
 		return nil, nil

--- a/pkg/action/action_handler_test.go
+++ b/pkg/action/action_handler_test.go
@@ -31,8 +31,8 @@ func TestActionHandler_registerActionExecutors(t *testing.T) {
 
 	h.registerActionExecutors()
 
-	supportedActions := [...]turboActionType{turboActionControllerScale, turboActionPodMove,
-		turboActionContainerResize, turboActionControllerResize,
+	supportedActions := [...]turboActionType{turboActionPodProvision, turboActionControllerScale, turboActionPodMove,
+		turboActionContainerResize, turboActionPodSuspend, turboActionControllerResize,
 		turboActionMachineProvision, turboActionMachineSuspend}
 	m := h.actionExecutors
 	if len(m) != len(supportedActions) {

--- a/pkg/action/action_handler_test.go
+++ b/pkg/action/action_handler_test.go
@@ -31,8 +31,8 @@ func TestActionHandler_registerActionExecutors(t *testing.T) {
 
 	h.registerActionExecutors()
 
-	supportedActions := [...]turboActionType{turboActionPodProvision, turboActionPodMove,
-		turboActionContainerResize, turboActionPodSuspend, turboActionControllerResize,
+	supportedActions := [...]turboActionType{turboActionControllerScale, turboActionPodMove,
+		turboActionContainerResize, turboActionControllerResize,
 		turboActionMachineProvision, turboActionMachineSuspend}
 	m := h.actionExecutors
 	if len(m) != len(supportedActions) {

--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -59,12 +59,12 @@ func getReplicaDiff(action *proto.ActionItemDTO) (int32, error) {
 
 	currentCom := action.GetCurrentComm()
 	if currentCom == nil || currentCom.GetCommodityType() != proto.CommodityDTO_NUMBER_REPLICAS {
-		return 0, fmt.Errorf("NUMBER_REPLICAS not found in currentCommodity")
+		return 0, fmt.Errorf("NUMBER_REPLICAS not found in currentCommodity of action DTO")
 	}
 
 	newCom := action.GetNewComm()
 	if newCom == nil || newCom.GetCommodityType() != proto.CommodityDTO_NUMBER_REPLICAS {
-		return 0, fmt.Errorf("NUMBER_REPLICAS not found in currentCommodity")
+		return 0, fmt.Errorf("NUMBER_REPLICAS not found in currentCommodity of action DTO")
 	}
 
 	oldReplicas := currentCom.GetCapacity()

--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -21,6 +21,8 @@ func NewHorizontalScaler(ae TurboK8sActionExecutor) *HorizontalScaler {
 
 func (h *HorizontalScaler) Execute(input *TurboActionExecutorInput) (*TurboActionExecutorOutput, error) {
 	actionItem := input.ActionItems[0]
+	actionType := actionItem.GetActionType()
+	pod := input.Pod
 
 	//1. Get replica diff
 	diff, err := getReplicaDiff(actionItem)
@@ -29,30 +31,49 @@ func (h *HorizontalScaler) Execute(input *TurboActionExecutorInput) (*TurboActio
 		return nil, err
 	}
 	//2. Prepare controllerUpdater
-	namespace, controllerName, kind, err := getWorkloadControllerInfo(actionItem.GetTargetSE())
-	if err != nil {
-		glog.Errorf("Failed to get controller information: %v", err)
-		return &TurboActionExecutorOutput{}, err
+	// for SLO pod provision and suspension
+	var controllerUpdater *k8sControllerUpdater
+	var updaterErr error
+	var targetFullName string
+	if pod != nil && actionType != proto.ActionItemDTO_HORIZONTAL_SCALE {
+		targetFullName = util.BuildIdentifier(pod.Namespace, pod.Name)
+		controllerUpdater, updaterErr = newK8sControllerUpdaterViaPod(h.clusterScraper,
+			pod, h.ormClient, h.gitConfig, h.k8sClusterId)
+	} else {
+		namespace, controllerName, kind, err := getWorkloadControllerInfo(actionItem.GetTargetSE())
+		if err != nil {
+			glog.Errorf("Failed to get controller information: %v", err)
+			return &TurboActionExecutorOutput{}, err
+		}
+		targetFullName = util.BuildIdentifier(namespace, controllerName)
+		controllerUpdater, updaterErr = newK8sControllerUpdater(h.clusterScraper, h.ormClient, kind, controllerName,
+			"", namespace, h.k8sClusterId, nil, h.gitConfig)
 	}
-	controllerUpdater, err := newK8sControllerUpdater(h.clusterScraper, h.ormClient, kind, controllerName,
-		"", namespace, h.k8sClusterId, nil, h.gitConfig)
-	if err != nil {
-		glog.Errorf("Failed to create controllerUpdater: %v", err)
-		return &TurboActionExecutorOutput{}, err
+
+	if updaterErr != nil {
+		glog.Errorf("Failed to create controllerUpdater: %v", updaterErr)
+		return &TurboActionExecutorOutput{}, updaterErr
 	}
 	//3. Execute the action to update replica diff of the controller
-	controllerFullName := util.BuildIdentifier(namespace, controllerName)
 	err = controllerUpdater.updateWithRetry(&controllerSpec{replicasDiff: diff})
 	if err != nil {
-		glog.Errorf("Failed to scale %s: %v", controllerFullName, err)
+		glog.Errorf("Failed to scale %s: %v", targetFullName, err)
 		return &TurboActionExecutorOutput{}, err
 	}
-	glog.V(2).Infof("Action HorizontalScale for workload controller[%v] succeeded.", controllerFullName)
+	glog.V(2).Infof("Action HorizontalScale for workload controller[%v] succeeded.", targetFullName)
 	return &TurboActionExecutorOutput{Succeeded: true}, nil
 }
 
 func getReplicaDiff(action *proto.ActionItemDTO) (int32, error) {
 	atype := action.GetActionType()
+	if atype == proto.ActionItemDTO_PROVISION {
+		// Scale out, increase the replica. diff = 1.
+		return 1, nil
+	} else if atype == proto.ActionItemDTO_SUSPEND {
+		// Scale in, decrease the replica. diff = -1.
+		return -1, nil
+	}
+
 	if atype != proto.ActionItemDTO_HORIZONTAL_SCALE {
 		return 0, fmt.Errorf("action %v is not a horizontal scaling action", atype.String())
 	}

--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -29,7 +29,7 @@ func (h *HorizontalScaler) Execute(input *TurboActionExecutorInput) (*TurboActio
 		return nil, err
 	}
 	//2. Prepare controllerUpdater
-	namespace, controllerName, kind, err := getControllerInfo(actionItem.GetTargetSE())
+	namespace, controllerName, kind, err := getWorkloadControllerInfo(actionItem.GetTargetSE())
 	if err != nil {
 		glog.Errorf("Failed to get controller information: %v", err)
 		return &TurboActionExecutorOutput{}, err

--- a/pkg/action/executor/workload_controller_resizer.go
+++ b/pkg/action/executor/workload_controller_resizer.go
@@ -127,6 +127,12 @@ func (r *WorkloadControllerResizer) Execute(input *TurboActionExecutorInput) (*T
 	}, nil
 }
 
+// getControllerInfo retrieves information about a workload controller based on the provided target entity.
+// @param {proto.EntityDTO} targetSE - The target entity for which to retrieve controller information.
+// @returns {string} namespace - The namespace of the workload controller.
+// @returns {string} controllerName - The name of the workload controller.
+// @returns {string} kind - The type of the workload controller.
+// @returns {error} error - An error if any occurred during the retrieval process.
 func getControllerInfo(targetSE *proto.EntityDTO) (string, string, string, error) {
 	if targetSE == nil {
 		return "", "", "", fmt.Errorf("workload controller action item does not have a valid target entity")

--- a/pkg/action/executor/workload_controller_resizer.go
+++ b/pkg/action/executor/workload_controller_resizer.go
@@ -128,12 +128,18 @@ func (r *WorkloadControllerResizer) Execute(input *TurboActionExecutorInput) (*T
 }
 
 // getControllerInfo retrieves information about a workload controller based on the provided target entity.
-// @param {proto.EntityDTO} targetSE - The target entity for which to retrieve controller information.
-// @returns {string} namespace - The namespace of the workload controller.
-// @returns {string} controllerName - The name of the workload controller.
-// @returns {string} kind - The type of the workload controller.
-// @returns {error} error - An error if any occurred during the retrieval process.
-func getControllerInfo(targetSE *proto.EntityDTO) (string, string, string, error) {
+//
+// Parameters:
+//
+//	targetSE - The target entity for which to retrieve controller information.
+//
+// Returns:
+//
+//	namespace - The namespace of the workload controller.
+//	controllerName - The name of the workload controller.
+//	kind - The type of the workload controller.
+//	error - An error if any occurred during the retrieval process.
+func getWorkloadControllerInfo(targetSE *proto.EntityDTO) (string, string, string, error) {
 	if targetSE == nil {
 		return "", "", "", fmt.Errorf("workload controller action item does not have a valid target entity")
 	}
@@ -177,10 +183,26 @@ func getControllerInfo(targetSE *proto.EntityDTO) (string, string, string, error
 	return namespace, controllerName, kind, nil
 }
 
+// getWorkloadControllerDetails retrieves details about a workload controller for the given action item.
+//
+// Parameters:
+//
+//	actionItem - The action item containing the workload controller details.
+//
+// Returns:
+//
+//	controllerName - The name of the workload controller.
+//	kind - The type of the workload controller.
+//	namespace - The namespace of the workload controller.
+//	podSpec - The Pod specification of the workload controller.
+//	managerApp - The manager application associated with the workload controller.
+//	replicasNum - The number of replicas for the workload controller.
+//	isOwnerSet - Indicates whether the workload controller has an owner set.
+//	error - An error if any occurred during the retrieval process.
 func (r *WorkloadControllerResizer) getWorkloadControllerDetails(actionItem *proto.ActionItemDTO) (string,
 	string, string, *k8sapi.PodSpec, *repository.K8sApp, int64, bool, error) {
 	targetSE := actionItem.GetTargetSE()
-	namespace, controllerName, kind, err := getControllerInfo(targetSE)
+	namespace, controllerName, kind, err := getWorkloadControllerInfo(targetSE)
 	if err != nil {
 		return "", "", "", nil, nil, 0, false, err
 	}

--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -382,16 +382,6 @@ var _ = Describe("Action Executor ", func() {
 			if err != nil {
 				framework.Failf("The replica number is incorrect after executing provision action")
 			}
-
-			// Test the suspend action
-			aeDTO = newHorizontalScaleActionExecutionDTO(targetSE, 3, 2)
-			_, err = actionHandler.ExecuteAction(aeDTO, nil, &mockProgressTrack{})
-			framework.ExpectNoError(err, "Failed to execute suspend action")
-			// The current replica is 3, new replica should be 2 after the action
-			_, err = waitForDeploymentToUpdateReplica(kubeClient, dep.Name, dep.Namespace, 2)
-			if err != nil {
-				framework.Failf("The replica number is incorrect after executing suspend action")
-			}
 		})
 	})
 


### PR DESCRIPTION
Support for new merged SLO action in Action executor.

This is the code change for the SLO action merge in kubeturbo action execution.
The background wiki: https://vmturbo.atlassian.net/wiki/spaces/AE/pages/3668901989/SLO+Horizontal+Scale+Action+Merging#Replicas-Represented-as-Attribute-on-WorkloadController

I am still waiting for @amd-ibm to finalize on his code to send action from server to the kubeturbo to be executed.
So this is just a initial draft to get some feedback.

Developer Checks
[x] Full build with unit tests and Checkstyle / SpotBugs tests
[x] Unit tests added / updated
[x]No unlicensed images, no third-party code (such as from StackOverflow)
Integration (Robot Framework) tests added / updated
Manual testing done (and described)
Product sweep run and passed
Developer wiki updated (and linked to this description)