### PR TITLE
[TRB-40879]: Unique ClusterRoleBinding name. Change Samples.

### DIFF
--- a/deploy/kubeturbo-operator/config/samples/charts_v1_kubeturbo.yaml
+++ b/deploy/kubeturbo-operator/config/samples/charts_v1_kubeturbo.yaml
@@ -29,7 +29,8 @@ spec:
     restartOnRegistrationTimeout: false
   targetConfig:
     targetName: Cluster_Name
-  roleBinding: turbo-all-binding
+  # The name should be unique for Kubeturbo instance  
+  roleBinding: turbo-all-binding-Kubeturbo_name-Kubeturbo_namespace
   roleName: cluster-admin
   serverMeta:
     turboServer: https://Turbo_server_URL

--- a/deploy/kubeturbo_yamls/pasadena_kubeturbo.yaml
+++ b/deploy/kubeturbo_yamls/pasadena_kubeturbo.yaml
@@ -12,7 +12,8 @@ metadata:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1    
 metadata:
-  name: turbo-all-binding
+  # The name should be unique for Kubeturbo instance
+  name: turbo-all-binding-kubeturbo-iks
   namespace: iks
 subjects:
 - kind: ServiceAccount

--- a/deploy/kubeturbo_yamls/step3_turbo_serviceAccountRoleBinding_admin_sample.yaml
+++ b/deploy/kubeturbo_yamls/step3_turbo_serviceAccountRoleBinding_admin_sample.yaml
@@ -6,7 +6,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # use this yaml to create a binding that will assign cluster-admin to your turbo ServiceAccount 
   # Provide a value for the binding name: and update namespace if needed
-  name: turbo-all-binding
+  # The name should be unique for Kubeturbo instance
+  name: turbo-all-binding-kubeturbo-turbo
 subjects:
 - kind: ServiceAccount
   # Provide the correct value for service account name: and namespace if needed

--- a/deploy/kubeturbo_yamls/turbo_kubeturbo_full.yaml
+++ b/deploy/kubeturbo_yamls/turbo_kubeturbo_full.yaml
@@ -16,7 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # use this yaml to create a binding that will assign cluster-admin to your turbo ServiceAccount 
   # Provide a value for the binding name: and update namespace if needed
-  name: turbo-all-binding
+  # The name should be unique for Kubeturbo instance
+  name: turbo-all-binding-kubeturbo-turbo
   namespace: turbo
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
Intent:

We should be able to run multiple Kubeturbos on the same cluster.

Fix:

Make ClusterRoleBinding unique in sample files.

