### PR TITLE
[TRB-35519]: Scale the controller without suspending the old pod in S…

### DIFF
--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -442,7 +442,7 @@ var _ = Describe("Action Executor ", func() {
 			framework.ExpectNoError(err, "Failed to execute provision action")
 
 			// The current replica is 2, new replica should be 1 after the action
-			_, err = waitForDeploymentToUpdateReplica(kubeClient, dep.Name, dep.Namespace, 3)
+			_, err = waitForDeploymentToUpdateReplica(kubeClient, dep.Name, dep.Namespace, 1)
 			if err != nil {
 				framework.Failf("The replica number is incorrect after executing provision action")
 			}


### PR DESCRIPTION
…LO merged scale down action
 
make sure suspending pod of the merged action only when pod and namespace are specified.
I still maintained the old logic of controller suspension action so the code will still work if in the future we would like to have the old logic of suspend the optimal pod from the market analysis before decrease the replicas of the controller.

Developer Checks
[x] Full build with unit tests and Checkstyle / SpotBugs tests
 Unit tests added / updated
[x]No unlicensed images, no third-party code (such as from StackOverflow)
[x]Integration (Robot Framework) tests added / updated
Manual testing done (and described)
Product sweep run and passed
Developer wiki updated (and linked to this description)