### PR TITLE
kubeturbo operator minimum cluster role

### DIFF
--- a/deploy/kubeturbo-operator/deploy/kubeturbo-operator-cluster-role.yaml
+++ b/deploy/kubeturbo-operator/deploy/kubeturbo-operator-cluster-role.yaml
@@ -1,0 +1,67 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeturbo-operator
+rules:
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+      - apps
+      - extensions
+    resources:
+      - nodes
+      - pods
+      - configmaps
+      - deployments
+      - replicasets
+      - replicationcontrollers
+      - serviceaccounts
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+      - apps
+      - extensions
+      - policy
+    resources:
+      - services
+      - endpoints
+      - namespaces
+      - limitranges
+      - resourcequotas
+      - daemonsets
+      - persistentvolumes
+      - persistentvolumeclaims
+      - poddisruptionbudget
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - nodes/spec
+      - nodes/stats
+  - verbs:
+      - '*'
+    apiGroups:
+      - charts.helm.k8s.io
+    resources:
+      - '*'
+  - verbs:
+      - '*'
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+  - verbs:
+      - create
+      - get
+      - list
+      - update
+    apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases


### PR DESCRIPTION
Allow a user deploying kubeturbo operator manually (outside of OpenShift Operator Hub) to use a cluster role that is not cluster-admin.