### PR TITLE
[TRB-41754] Fix a bug where smallest CPU and Memory limit is not recognized

### DIFF
--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -68,10 +68,10 @@ func genMemQuantity(numKB int64) resource.Quantity {
 }
 
 func buildResource(cores float32, numMB int64) api.ResourceList {
-	resourceList := make(api.ResourceList)
-	resourceList[api.ResourceCPU] = genCPUQuantity(cores)
-	resourceList[api.ResourceMemory] = genMemQuantity(numMB * 1024)
-	return resourceList
+	return api.ResourceList{
+		api.ResourceCPU:    genCPUQuantity(cores),
+		api.ResourceMemory: genMemQuantity(numMB * 1024),
+	}
 }
 
 func mockContainer(name string, requestCores, limitCores float32,

--- a/pkg/discovery/monitoring/master/cluster_monitor_test.go
+++ b/pkg/discovery/monitoring/master/cluster_monitor_test.go
@@ -22,13 +22,13 @@ var expectedMetrics = map[string]float64{
 	"Node-mynode-Memory-Capacity":        8.388608e+06,
 	"Node-mynode-CPURequest-Capacity":    1900,
 	"Node-mynode-MemoryRequest-Capacity": 7.340032e+06,
-	"Node-mynode-CPURequest-Used":        260,
+	"Node-mynode-CPURequest-Used":        261,
 	"Node-mynode-MemoryRequest-Used":     262144,
 
 	// Pod metrics
 	"Pod-default/mypod-CPU-Capacity":       2000,
 	"Pod-default/mypod-Memory-Capacity":    8.388608e+06,
-	"Pod-default/mypod-CPURequest-Used":    260,
+	"Pod-default/mypod-CPURequest-Used":    261,
 	"Pod-default/mypod-MemoryRequest-Used": 262144,
 
 	// Container metrics
@@ -48,11 +48,15 @@ var expectedMetrics = map[string]float64{
 	"Container-default/mypod/istio-proxy-CPURequestQuota-Used":           10,
 	"Container-default/mypod/istio-proxy-MemoryLimitQuota-Used":          8.388608e+06,
 	"Container-default/mypod/istio-proxy-MemoryRequestQuota-Used":        0,
+	"Container-default/mypod/filebeat-sidecar-CPULimitQuota-Used":        1,
+	"Container-default/mypod/filebeat-sidecar-CPURequestQuota-Used":      1,
+	"Container-default/mypod/filebeat-sidecar-MemoryLimitQuota-Used":     8.388608e+06,
+	"Container-default/mypod/filebeat-sidecar-MemoryRequestQuota-Used":   0,
 }
 
 func genCPUQuantity(cores float32) resource.Quantity {
-	cpuTime := int(cores * 1000)
-	result, _ := resource.ParseQuantity(fmt.Sprintf("%dm", cpuTime))
+	cpuTime := cores * 1000
+	result, _ := resource.ParseQuantity(fmt.Sprintf("%fm", cpuTime))
 	glog.V(3).Infof("result = %+v", result)
 	return result
 }
@@ -64,10 +68,10 @@ func genMemQuantity(numKB int64) resource.Quantity {
 }
 
 func buildResource(cores float32, numMB int64) api.ResourceList {
-	resource := make(api.ResourceList)
-	resource[api.ResourceCPU] = genCPUQuantity(cores)
-	resource[api.ResourceMemory] = genMemQuantity(numMB * 1024)
-	return resource
+	resourceList := make(api.ResourceList)
+	resourceList[api.ResourceCPU] = genCPUQuantity(cores)
+	resourceList[api.ResourceMemory] = genMemQuantity(numMB * 1024)
+	return resourceList
 }
 
 func mockContainer(name string, requestCores, limitCores float32,
@@ -109,6 +113,8 @@ func mockPod(name string) *api.Pod {
 			Containers: []api.Container{
 				mockContainer("twitter-cass-tweet", 0.25, 0.25, 256, 256),
 				mockContainer("istio-proxy", 0.01, 2.0, 0, 8192),
+				// Test that 0.5 mCore will be rounded up to 1 mCore
+				mockContainer("filebeat-sidecar", 0.0005, 0.0005, 0, 0),
 			},
 		},
 	}
@@ -155,7 +161,7 @@ func TestGenNodeResourceMetrics(t *testing.T) {
 	clusterMonitor.nodePodMap = make(map[string][]*api.Pod)
 	clusterMonitor.nodePodMap["mynode"] = pods
 	// Collect node/pod/container metrics
-	clusterMonitor.findNodeStates()
+	_ = clusterMonitor.findNodeStates()
 	for name, value := range expectedMetrics {
 		metric, err := clusterMonitor.sink.GetMetric(name)
 		if err != nil {


### PR DESCRIPTION
## Problem
Today we mistakenly treat 1 mCore or 1 byte as invalid CPU and Memory limit, and set node capacity instead. This causes analysis error.

## Fix
Recognize that the minimum CPU and Memory limit is 1. 

## Test
* Updated unit test
* Create the following resource quota and deployment in a namespace called `quota`:
```shell
meng@mengs-mbp$ kubectl -n quota get resourcequota
NAME           AGE   REQUEST                                               LIMIT
mem-cpu-demo   95m   requests.cpu: 1m/100m, requests.memory: 128Mi/256Mi   limits.cpu: 1m/100m, limits.memory: 256Mi/512Mi
```

```shell
apiVersion: apps/v1
kind: Deployment
metadata:
...
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: nginx
...
...
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx:1.14.2
        imagePullPolicy: IfNotPresent
        name: nginx
        ports:
        - containerPort: 80
          protocol: TCP
        resources:
          limits:
            cpu: 1m
            memory: 256Mi
          requests:
            cpu: 1m
            memory: 128Mi
...
...
```

* Run an OCC plan on this cluster, and check the log and confirm the exception:

```shell
market-5b6746f6df-w29m6: 2023-06-22 19:15:05,056 ERROR [market-runner-35] [Suspension]	: Analysis Exception occurred for Suspension. Exception: expenses = -0.0014229999639841793
market-5b6746f6df-w29m6: java.lang.IllegalArgumentException: expenses = -0.0014229999639841793
market-5b6746f6df-w29m6: 	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:220)
market-5b6746f6df-w29m6: 	at com.vmturbo.platform.analysis.ledger.IncomeStatement.setExpenses(IncomeStatement.java:76)
market-5b6746f6df-w29m6: 	at com.vmturbo.platform.analysis.ledger.Ledger.calculateExpensesForSeller(Ledger.java:383)
market-5b6746f6df-w29m6: 	at com.vmturbo.platform.analysis.ledger.Ledger.calculateExpRevForTraderAndGetTopRevenue(Ledger.java:286)
market-5b6746f6df-w29m6: 	at com.vmturbo.platform.analysis.ledger.Ledger.calculateExpRevForTradersInEconomy(Ledger.java:342)
market-5b6746f6df-w29m6: 	at com.vmturbo.platform.analysis.ede.Suspension.suspensionDecisions(Suspension.java:148)
market-5b6746f6df-w29m6: 	at com.vmturbo.platform.analysis.ede.Ede.generateActions(Ede.java:419)
market-5b6746f6df-w29m6: 	at com.vmturbo.platform.analysis.ede.Ede.generateActions(Ede.java:518)
market-5b6746f6df-w29m6: 	at com.vmturbo.market.topology.TopologyEntitiesHandler.performAnalysis(TopologyEntitiesHandler.java:277)
market-5b6746f6df-w29m6: 	at com.vmturbo.market.runner.Analysis.execute(Analysis.java:611)
market-5b6746f6df-w29m6: 	at com.vmturbo.market.runner.MarketRunner.runAnalysis(MarketRunner.java:351)
market-5b6746f6df-w29m6: 	at com.vmturbo.market.runner.MarketRunner.lambda$scheduleAnalysis$2(MarketRunner.java:233)
market-5b6746f6df-w29m6: 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
market-5b6746f6df-w29m6: 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
market-5b6746f6df-w29m6: 	at java.base/java.lang.Thread.run(Unknown Source)
```

* Confirm that the plan result does not suspend any node
  
  ![image](https://github.com/turbonomic/kubeturbo/assets/10012486/e0eafd99-67b4-47e1-8c8a-55b0a22c24c0)
 
* Deploy the new `kubeturbo`
* Run the plan again, and make sure node suspend actions are generated:

```
market-5b6746f6df-w29m6: 2023-06-22 19:38:52,498  INFO [market-runner-38] [Ede]	: PLAN-215769306786608-75031818442576 Analysis completed in 0 sec with 31 RESIZE (CONTAINER|VMEM_REQUEST:4, CONTAINER|VCPU_REQUEST:15, CONTAINER|VMEM:7, CONTAINER|VCPU:5), 10 DEACTIVATE (CONTAINER_POD:8, VIRTUAL_MACHINE:2), 14 MOVE (VIRTUAL_MACHINE:14) [analysisId=75031818442576]
```

  ![image](https://github.com/turbonomic/kubeturbo/assets/10012486/bb6e814b-f2eb-4e2b-be58-43ee022d5880)