### PR TITLE
[TRB-40987]:Improve kubeturbo-operator to support OCP311

### DIFF
--- a/deploy/kubeturbo-operator/Makefile
+++ b/deploy/kubeturbo-operator/Makefile
@@ -5,6 +5,7 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 DEFAULT_VERSION=8.8.0
 VERSION=$(or $(KUBETURBO_VERSION), $(DEFAULT_VERSION))
+GIT_COMMIT=$(shell git rev-parse HEAD)
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -188,7 +189,7 @@ REPO_NAME ?= icr.io/cpopen
 docker-buildx:
 	docker buildx create --name kubeturbo-operator-builder
 	- docker buildx use kubeturbo-operator-builder
-	- docker buildx build --platform=$(PLATFORMS) --push --tag $(REPO_NAME)/kubeturbo-operator:$(VERSION) --build-arg VERSION=$(VERSION) .
+	- docker buildx build --platform=$(PLATFORMS) --label "git-commit=$(GIT_COMMIT)" --label "git-version=$(VERSION)" --provenance=false --push --tag $(REPO_NAME)/kubeturbo-operator:$(VERSION) --build-arg VERSION=$(VERSION) .
 	docker buildx rm kubeturbo-operator-builder
 
 .PHONY: test


### PR DESCRIPTION
# Intent

Improve Kubeturbo-operator to support Openshit 3.11

# Background

The current Kubeturbo-operator is having the `OCI` format which isn't supported by `docker-shim` on the OCP311,  but we still have some customers running OCP311, they might switch to using the operator to deploy Kubeturbo.

# Testing

```
[root@dev4kev-leader.fyre.ibm.com ~]# k version
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.3+k3s1", GitCommit:"01ea3ff27be0b04f945179171cec5a8e11a14f7b", GitTreeState:"clean", BuildDate:"2023-03-27T22:23:17Z", GoVersion:"go1.19.7", Compiler:"gc", Platform:"linux/amd64"}
Kustomize Version: v4.5.7
Server Version: version.Info{Major:"1", Minor:"11+", GitVersion:"v1.11.0+d4cacc0", GitCommit:"d4cacc0", GitTreeState:"clean", BuildDate:"2022-08-30T19:30:51Z", GoVersion:"go1.10.8", Compiler:"gc", Platform:"linux/amd64"}
WARNING: version difference between client (1.26) and server (1.11) exceeds the supported minor version skew of +/-1
[root@dev4kev-leader.fyre.ibm.com ~]# k describe pods xxx-7579499b88-s245f 
Name:             xxx-7579499b88-s245f
Namespace:        turbo
Priority:         0
Service Account:  default
Node:             ae-ocp-3112.fyre.ibm.com/10.21.72.135
Start Time:       Wed, 28 Jun 2023 14:46:15 -0700
Labels:           app=xxx
                  pod-template-hash=3135055644
Annotations:      openshift.io/scc: restricted
Status:           Running
IP:               10.129.0.36
IPs:              <none>
Controlled By:    ReplicaSet/xxx-7579499b88
Containers:
  kubeturbo-operator:
    Container ID:  docker://a47d7a4f306293298d48ea1cf2ac2d533c6554859f7908318a9489ef7475fc17
    Image:         docker.io/kevin0204/kubeturbo-operator:894-OPR311
    Image ID:      docker-pullable://docker.io/kevin0204/kubeturbo-operator@sha256:0cc7af38b31a13bbda3858fabb95ce3b4c9cd21bccd817d412f1ebbdf65a72a2
    Port:          <none>
    Host Port:     <none>
    Command:
      sleep
      1d
    State:          Running
      Started:      Wed, 28 Jun 2023 14:46:18 -0700
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-klbxp (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  default-token-klbxp:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-klbxp
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  node-role.kubernetes.io/compute=true
Tolerations:     <none>
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  22s   default-scheduler  Successfully assigned turbo/xxx-7579499b88-s245f to ae-ocp-3112.fyre.ibm.com
  Normal  Pulling    20s   kubelet            pulling image "docker.io/kevin0204/kubeturbo-operator:894-OPR311"
  Normal  Pulled     19s   kubelet            Successfully pulled image "docker.io/kevin0204/kubeturbo-operator:894-OPR311"
  Normal  Created    19s   kubelet            Created container
  Normal  Started    19s   kubelet            Started container
```

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [x] Full build with unit tests and fmt and vet checks
    ~~- [ ] Unit tests added / updated~~
    - [x] No unlicensed images, no third-party code (such as from StackOverflow)
    ~~- [ ] Integration tests added / updated~~
    - [x] Manual testing done (and described)
    ~~- [ ] Product sweep run and passed~~
    ~~- [ ] Developer wiki updated (and linked to this description)~~
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

_(@ mention any `review/...` groups or people that should be aware of this merge request)_