### PR TITLE
[TRB-42879]: Upgrade go version to 1.20.5 to fix cve-2023-29404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - docker
 
 go:
-  - 1.20.4
+  - 1.20.5
  
 go_import_path: github.com/turbonomic/kubeturbo
 

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,5 +1,5 @@
 # Building base image
-FROM --platform=$BUILDPLATFORM golang:1.20.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.20.5 AS builder
 ARG VERSION TARGETOS TARGETARCH
 ENV KUBETURBO_VERSION $VERSION
 WORKDIR /workspace


### PR DESCRIPTION
# Intent
- Upgrade go version to 1.20.5 to solve the [CVE issue](https://jsw.ibm.com/browse/TRB-42879)

# Testing

Build dev image with the changes and scan it with twistlock, vulnerability issue resolved
`./tt images pull-and-scan --user xxxxx --url "https://w3twistlock.sos.ibm.com" --control-group public docker.io/sumanthkodali/kubeturbo-cve:8.9.4`

[twistlock-scan-results-20230703-181402-N-UTC-045969F5.results.csv](https://github.com/turbonomic/kubeturbo/files/11940079/twistlock-scan-results-20230703-181402-N-UTC-045969F5.results.csv)
