### PR TITLE
[TRB-40216] Integration test falling on openshift cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ script:
   - ./hack/download_test_binaries.sh
   - ./hack/create_kind_cluster.sh
   - ./hack/deploy_istio.sh
-  # - ./hack/generate_ocp_context.sh
+  - ./hack/generate_ocp_context.sh
   - make integration
   - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
   - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -istio-enabled=true -ginkgo.focus=Istio -ginkgo.focus=teardown -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
-  # - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=rosa -openshift-tests=true -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
+  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=rosa -openshift-tests=true -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
   - make product
 
 after_success:

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/turbonomic/orm v0.0.0-20230515224524-8f968dcc8f2e
 	github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20230607193533-764251e890b8
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20230710083128-36d2c50585d7
 	github.com/turbonomic/turbo-policy v0.0.0-20230328195608-0556e3cbe9b3
 	github.com/xanzy/go-gitlab v0.74.0
 	k8s.io/klog/v2 v2.80.1
@@ -60,7 +60,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
-	github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa // indirect
+	github.com/turbonomic/turbo-api v0.0.0-20230707140005-7608899ba463 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -834,12 +834,12 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/turbonomic/orm v0.0.0-20230515224524-8f968dcc8f2e h1:N6br9lWLjfB4oMersUw+oBeARrkCLSL/DFMCiuLpQqM=
 github.com/turbonomic/orm v0.0.0-20230515224524-8f968dcc8f2e/go.mod h1:59pNzaqkfqn9+n4NGbhld5hIc0oM4ngel+JXX6qwgX4=
-github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa h1:x7AkF/BAbvyJWeUd69UGqGIU96Izlz9oy9rpvsonqVI=
-github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+github.com/turbonomic/turbo-api v0.0.0-20230707140005-7608899ba463 h1:xQ+L9wlncoo82ZN0SW9548/0qBzBrA3FXZF+5wUNXJE=
+github.com/turbonomic/turbo-api v0.0.0-20230707140005-7608899ba463/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3 h1:R/3tmGlz0R2NakwJqoigcMNYN0jTYYXz1ngTFs0nD9M=
 github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3/go.mod h1:HAD6GcQFpgDGHOwhuCCjxQQWDjK2wv6gUvd5J3ZNU2g=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20230607193533-764251e890b8 h1:Y9geiMxTG9iVd5KesZWuTpJAKuBfdhVlWvKXlRX71fU=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20230607193533-764251e890b8/go.mod h1:RWvXz62oL7Yhkw+WRdDRdOEZSsm8f0vR3xvsgSU9ohM=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20230710083128-36d2c50585d7 h1:ICwhjo0zwbtZHt9KiThSgvbEJIsGOdfT1LIdB7NV8zQ=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20230710083128-36d2c50585d7/go.mod h1:8UfhMfnFLw0uq5zu9xWiPYEL6SaHc639ETZkbY97kSE=
 github.com/turbonomic/turbo-policy v0.0.0-20230328195608-0556e3cbe9b3 h1:KQkPBU3uKH87s4FjMrtxT4sYQCFab1kC7tTv46FZerE=
 github.com/turbonomic/turbo-policy v0.0.0-20230328195608-0556e3cbe9b3/go.mod h1:FlrjRrIlIT5MbFh9HmWiW8ZJ6qHCcuXNOJ6wCe6bFJ0=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -471,12 +471,12 @@ var _ = Describe("Action Executor ", func() {
 
 		// Check one pod with scc which has lower scc level then default anyuid
 		It("move action on a pod with restricted scc creates the new pod with the same scc level", func() {
-			clientForSccLevel, err := getDesiredUserImpersonationClient(namespace, "restricted", kubeConfig)
+			clientForSccLevel, err := getDesiredUserImpersonationClient(namespace, "restricted-v2", kubeConfig)
 			framework.ExpectNoError(err, "Error getting impersonation client")
 			pod, err := createBarePod(clientForSccLevel, genSimpleBarePodUsingSA(namespace,
 				fmt.Sprintf("%srestricted", util.KubeturboSCCPrefix), false))
 			framework.ExpectNoError(err, "Error creating bare pod")
-			validatePodGetsDesiredScc(namespace, "restricted", pod, kubeClient)
+			validatePodGetsDesiredScc(namespace, "restricted-v2", pod, kubeClient)
 
 			targetNodeName := getTargetSENodeName(f, pod)
 			if targetNodeName == "" {
@@ -488,7 +488,7 @@ var _ = Describe("Action Executor ", func() {
 				newTargetSEFromPod(pod), newHostSEFromNodeName(targetNodeName)), nil, &mockProgressTrack{})
 			framework.ExpectNoError(err, "Bare pod move with scc level failed")
 			newPod := validateMovedPod(kubeClient, pod.Name, "barepod", namespace, targetNodeName)
-			validatePodGetsDesiredScc(namespace, "restricted", newPod, clientForSccLevel)
+			validatePodGetsDesiredScc(namespace, "restricted-v2", newPod, clientForSccLevel)
 		})
 
 		// Check one pod with scc which has higher scc level then default anyuid

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -257,14 +257,14 @@ github.com/turbonomic/orm/api/v1alpha1
 github.com/turbonomic/orm/kubernetes
 github.com/turbonomic/orm/registry
 github.com/turbonomic/orm/utils
-# github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa
+# github.com/turbonomic/turbo-api v0.0.0-20230707140005-7608899ba463
 ## explicit
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
 # github.com/turbonomic/turbo-gitops v0.0.0-20221208150810-105a2d5244b3
 ## explicit; go 1.19
 github.com/turbonomic/turbo-gitops/api/v1alpha1
-# github.com/turbonomic/turbo-go-sdk v0.0.0-20230607193533-764251e890b8
+# github.com/turbonomic/turbo-go-sdk v0.0.0-20230710083128-36d2c50585d7
 ## explicit; go 1.13
 github.com/turbonomic/turbo-go-sdk/pkg
 github.com/turbonomic/turbo-go-sdk/pkg/builder


### PR DESCRIPTION

# Intent

Fixed the failing openshift test cases that were blocking PR merges. 

# Background

New Openshift test cluster is running OCP 4.13; as of 4.11+, restricted scc is legacy and is replaced by restricted-v2.

# Testing

![image](https://github.com/turbonomic/kubeturbo/assets/133919393/c35e40fe-21d2-4b98-91f7-6d3c7c42529c)

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [x] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [x] No unlicensed images, no third-party code (such as from StackOverflow)
    - [x] Integration tests added / updated
    - [ ] Manual testing done (and described)
    - [x] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.
