### PR TITLE
[TRB-40216] Integration test falling on openshift cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ script:
   - ./hack/download_test_binaries.sh
   - ./hack/create_kind_cluster.sh
   - ./hack/deploy_istio.sh
-  # - ./hack/generate_ocp_context.sh
+  - ./hack/generate_ocp_context.sh
   - make integration
   - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
   - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=kind-kind -istio-enabled=true -ginkgo.focus=Istio -ginkgo.focus=teardown -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
-  # - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=rosa -openshift-tests=true -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
+  - ./build/integration.test -k8s-kubeconfig=$HOME/.kube/config -k8s-context=rosa -openshift-tests=true -docker-user-name=${DOCKER_USERNAME} -docker-user-password=${DOCKER_PASSWORD}
   - make product
 
 after_success:

--- a/test/integration/action_execution.go
+++ b/test/integration/action_execution.go
@@ -471,12 +471,12 @@ var _ = Describe("Action Executor ", func() {
 
 		// Check one pod with scc which has lower scc level then default anyuid
 		It("move action on a pod with restricted scc creates the new pod with the same scc level", func() {
-			clientForSccLevel, err := getDesiredUserImpersonationClient(namespace, "restricted", kubeConfig)
+			clientForSccLevel, err := getDesiredUserImpersonationClient(namespace, "restricted-v2", kubeConfig)
 			framework.ExpectNoError(err, "Error getting impersonation client")
 			pod, err := createBarePod(clientForSccLevel, genSimpleBarePodUsingSA(namespace,
 				fmt.Sprintf("%srestricted", util.KubeturboSCCPrefix), false))
 			framework.ExpectNoError(err, "Error creating bare pod")
-			validatePodGetsDesiredScc(namespace, "restricted", pod, kubeClient)
+			validatePodGetsDesiredScc(namespace, "restricted-v2", pod, kubeClient)
 
 			targetNodeName := getTargetSENodeName(f, pod)
 			if targetNodeName == "" {
@@ -488,7 +488,7 @@ var _ = Describe("Action Executor ", func() {
 				newTargetSEFromPod(pod), newHostSEFromNodeName(targetNodeName)), nil, &mockProgressTrack{})
 			framework.ExpectNoError(err, "Bare pod move with scc level failed")
 			newPod := validateMovedPod(kubeClient, pod.Name, "barepod", namespace, targetNodeName)
-			validatePodGetsDesiredScc(namespace, "restricted", newPod, clientForSccLevel)
+			validatePodGetsDesiredScc(namespace, "restricted-v2", newPod, clientForSccLevel)
 		})
 
 		// Check one pod with scc which has higher scc level then default anyuid


### PR DESCRIPTION
# Intent

Fixed the failing openshift test cases that were blocking PR merges. 

# Background

New Openshift test cluster is running OCP 4.13; as of 4.11+, restricted scc is legacy and is replaced by restricted-v2.

# Testing

![image](https://github.com/turbonomic/kubeturbo/assets/133919393/c35e40fe-21d2-4b98-91f7-6d3c7c42529c)

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [x] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [x] No unlicensed images, no third-party code (such as from StackOverflow)
    - [x] Integration tests added / updated
    - [ ] Manual testing done (and described)
    - [x] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.
