### PR TITLE
[TRB-44002]: Added nil check for controller replicas to avoid a nil pointer dereference.

### DIFF
--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go
@@ -82,7 +82,9 @@ func (builder *workloadControllerDTOBuilder) BuildDTOs() ([]*proto.EntityDTO, er
 			controller, found := builder.clusterSummary.ControllerMap[workloadControllerId]
 			if found {
 				entityDTOBuilder.WithProperties(property.BuildLabelAnnotationProperties(controller.Labels, controller.Annotations, detectors.AWWorkloadController))
-				replicas = int32(*controller.Replicas)
+				if controller.Replicas != nil {
+					replicas = int32(*controller.Replicas)
+				}
 			}
 		}
 

--- a/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
+++ b/pkg/discovery/dtofactory/workload_controller_entity_dto_builder_test.go
@@ -47,6 +47,7 @@ var (
 	testKubeController1 = createKubeController(testClusterName, testNamespace, "controller1", util.KindDeployment,
 		"controller1-UID", testAllocationResources)
 	testKubeController2 = repository.NewKubeController(testClusterName, testNamespace, "controller2", testCustomControllerType, "controller2-UID")
+	testKubeController3 = repository.NewKubeController(testClusterName, testNamespace, "controller3", util.KindCronJob, "controller3-UID")
 
 	kubeCluster        = repository.KubeCluster{Name: clusterId}
 	kubeClusterSummary = repository.ClusterSummary{KubeCluster: &kubeCluster}
@@ -55,6 +56,7 @@ var (
 		map[string]*repository.KubeController{
 			"controller1-UID": testKubeController1,
 			"controller2-UID": testKubeController2,
+			"controller3-UID": testKubeController3,
 		},
 		map[string]string{
 			testNamespace: testNamespaceUID,
@@ -76,7 +78,7 @@ func TestBuildDTOs(t *testing.T) {
 		)
 		if controller.UID == testKubeController1.UID {
 			k8sController.WithReplicas(int64(deploymentReplicaCount))
-		} else {
+		} else if controller.UID == testKubeController2.UID {
 			k8sController.WithReplicas(int64(customControllerReplicaCount))
 		}
 		kubeCluster.ControllerMap[controller.UID] = k8sController


### PR DESCRIPTION
# Intent

Fix possible nil pointer deference error for Workload Controllers that do not have a replicas property.

# Background

Customer reported Kubeturbo crashing due to the following error. 

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1c47301]
goroutine 1847 [running]:
github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory.(*workloadControllerDTOBuilder).BuildDTOs(0xc0114b52d0)
	/workspace/pkg/discovery/dtofactory/workload_controller_entity_dto_builder.go:85 +0xd81
github.com/turbonomic/kubeturbo/pkg/discovery/worker.(*K8sControllerDiscoveryWorker).Do(0xc0114b5710, 0xc00af03b80, {0xc00511e000, 0x872, 0xc0114b57f8?})
	/workspace/pkg/discovery/worker/controller_discovery_worker.go:57 +0x2d7
github.com/turbonomic/kubeturbo/pkg/discovery.(*K8sDiscoveryClient).DiscoverWithNewFramework(0xc000dd3040, {0xc0004ca000, 0x16})
	/workspace/pkg/discovery/k8s_discovery_client.go:394 +0xcd2
github.com/turbonomic/kubeturbo/pkg/discovery.(*K8sDiscoveryClient).Discover(0xc000194380?, {0xc000194380, 0x6, 0x13?})
	/workspace/pkg/discovery/k8s_discovery_client.go:293 +0x285
github.com/turbonomic/turbo-go-sdk/pkg/probe.(*TurboProbe).DiscoverTarget(0xc0012a0930, {0xc000194380?, 0x6, 0x8})
	/workspace/vendor/github.com/turbonomic/turbo-go-sdk/pkg/probe/turbo_probe.go:116 +0x27d
github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*DiscoveryRequestHandler).HandleMessage(0xc001181f20, {{{}, {}, {}, 0xc00032d648}, 0x0, {0x0, 0x0, 0x0}, {0x2670fa0, ...}, ...}, ...)
	/workspace/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go:348 +0x2b4
created by github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*remoteMediationClient).RunServerMessageHandler
	/workspace/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go:223 +0x530 
```

# Testing

Was able to reproduce the error above by deploying a long running CronJob. Added a nil check on the replicas and was able to complete discovery without crashing.

Updated the associated unit test to test with a mock CronJob entity.

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [x] Full build with unit tests and fmt and vet checks
    - [x] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [x] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

@ading1977 

