### PR TITLE
[TRB-43505]: Integrate Kubeturbo operator automation test with Jenkins/Travis

### DIFF
--- a/deploy/kubeturbo-operator/Makefile
+++ b/deploy/kubeturbo-operator/Makefile
@@ -310,13 +310,29 @@ catalog-push: ## Push a catalog image.
 
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 REPO_NAME ?= icr.io/cpopen
+OPERATOR_IMG_BASE ?= $(REPO_NAME)/kubeturbo-operator
 .PHONY: docker-buildx
-docker-buildx:
+docker-buildx: operator-image-test
+	echo "Build and Push Kubeturbo operator image $(VERSION) to $(OPERATOR_IMG_BASE)"
 	docker buildx create --name kubeturbo-operator-builder
 	- docker buildx use kubeturbo-operator-builder
-	- docker buildx build --platform=$(PLATFORMS) --label "git-commit=$(GIT_COMMIT)" --label "git-version=$(VERSION)" --provenance=false --push --tag $(REPO_NAME)/kubeturbo-operator:$(VERSION) --build-arg VERSION=$(VERSION) .
+	- docker buildx build --platform=$(PLATFORMS) --label "git-commit=$(GIT_COMMIT)" --label "git-version=$(VERSION)" --provenance=false --push --tag $(OPERATOR_IMG_BASE):$(VERSION) --build-arg VERSION=$(VERSION) .
 	docker buildx rm kubeturbo-operator-builder
 
-.PHONY: test
-test:
+# build latest Kubeturbo operator image for testing purpose
+TEST_VERSION=tmp
+.PHONY: docker-buildx-test-image
+docker-buildx-test-image:
+	echo "Building test kubeturbo operator image"
+	docker buildx create --name kubeturbo-operator-builder-test
+	- docker buildx use kubeturbo-operator-builder-test
+	- docker buildx build --platform=$(PLATFORMS) --label "git-commit=$(GIT_COMMIT)" --label "git-version=$(TEST_VERSION)" --provenance=false --push --tag $(OPERATOR_IMG_BASE):$(TEST_VERSION) --build-arg VERSION=$(TEST_VERSION) .
+	docker buildx rm kubeturbo-operator-builder-test
+
+# run automation test against the latest-built Kubeturbo operator image
+.PHONY: operator-image-test
+operator-image-test: docker-buildx-test-image
+	echo "Start testing latest Kubeturbo operator image"
+	export OPERATOR_IMG_VERSION=$(TEST_VERSION) && \
+	export OPERATOR_IMG_BASE=$(OPERATOR_IMG_BASE) && \
 	bash ./test.sh

--- a/deploy/kubeturbo-operator/test.sh
+++ b/deploy/kubeturbo-operator/test.sh
@@ -3,8 +3,10 @@
 SCRIPT_DIR="$(cd "$(dirname $0)" && pwd)"
 ERR_LOG=$(mktemp --suffix _kube.errlog)
 WAIT_FOR_DEPLOYMENT=20
-OPERATOR_IMAGE_VERSION="8.9.5-SNAPSHOT"
-OPERATOR_IMAGE="icr.io\/cpopen\/kubeturbo-operator:${OPERATOR_IMAGE_VERSION}"
+OPERATOR_IMAGE_VERSION=${OPERATOR_IMG_VERSION-"8.9.5-SNAPSHOT"}
+OPERATOR_IMAGE_BASE=${OPERATOR_IMG_BASE-"icr.io/cpopen/kubeturbo-operator"}
+OPERATOR_IMAGE="${OPERATOR_IMAGE_BASE}:${OPERATOR_IMAGE_VERSION}"
+OPERATOR_IMAGE_STR=$(printf '%s\n' "${OPERATOR_IMAGE}" | sed -e 's/[\/&]/\\&/g')
 
 # turbonomic is the default namespace that matches the xl setup
 # please change the value according to your set up
@@ -20,7 +22,7 @@ function install_operator {
 	kubectl apply -f ${SCRIPT_DIR}/deploy/role_binding.yaml
 
 	# dynamically apply the image version
-	sed "s/image:.*/image: ${OPERATOR_IMAGE}/g" ${SCRIPT_DIR}/deploy/operator.yaml > ${SCRIPT_DIR}/deploy/updated_operator.yaml
+	sed "s/image:.*/image: ${OPERATOR_IMAGE_STR}/g" ${SCRIPT_DIR}/deploy/operator.yaml > ${SCRIPT_DIR}/deploy/updated_operator.yaml
 	kubectl apply -f ${SCRIPT_DIR}/deploy/updated_operator.yaml -n ${NS}
 }
 
@@ -83,6 +85,8 @@ function create_cr {
 	  targetConfig:
 	    targetName: ${CR_SURFIX}
 	  roleName: ${CLUSTER_ROLE}
+	  image:
+	    tag: ${XL_VERSION}
 	EOT
 }
 

--- a/deploy/kubeturbo-operator/test.sh
+++ b/deploy/kubeturbo-operator/test.sh
@@ -56,7 +56,7 @@ function create_cr {
 	fi
 
 	command -v xl_version &> /dev/null
-	[ $? -gt 0 ] && echo -e "Failed to invoke xl_version from environemnt" | tee -a ${ERR_LOG} && exit 1
+	[ $? -gt 0 ] && echo -e "Failed to invoke xl_version from environment" | tee -a ${ERR_LOG} && exit 1
 	XL_VERSION_DETAIL=$(xl_version)
 
 	# generated testing cr file based on the given input

--- a/deploy/kubeturbo-operator/test.sh
+++ b/deploy/kubeturbo-operator/test.sh
@@ -10,13 +10,17 @@ OPERATOR_IMAGE_STR=$(printf '%s\n' "${OPERATOR_IMAGE}" | sed -e 's/[\/&]/\\&/g')
 TURBO_HOST_IP=${TURBO_HOST_IP-"127.0.0.1"}
 KUBETURBO_VERSION=${KUBETURBO_VERSION-"8.9.5-SNAPSHOT"}
 
-function k8s {
-	kubectl $@
-}
-
 # turbonomic is the default namespace that matches the xl setup
 # please change the value according to your set up
 export namespace=turbonomic
+
+function k8s {
+	if [ -z "${KUBE_CONFIG}" ]; then
+		kubectl $@
+	else
+		kubectl --kubeconfig ${KUBE_CONFIG} $@
+	fi
+}
 
 function install_operator {
 	NS=$1

--- a/deploy/kubeturbo-operator/test.sh
+++ b/deploy/kubeturbo-operator/test.sh
@@ -7,6 +7,8 @@ OPERATOR_IMAGE_VERSION=${OPERATOR_IMG_VERSION-"8.9.5-SNAPSHOT"}
 OPERATOR_IMAGE_BASE=${OPERATOR_IMG_BASE-"icr.io/cpopen/kubeturbo-operator"}
 OPERATOR_IMAGE="${OPERATOR_IMAGE_BASE}:${OPERATOR_IMAGE_VERSION}"
 OPERATOR_IMAGE_STR=$(printf '%s\n' "${OPERATOR_IMAGE}" | sed -e 's/[\/&]/\\&/g')
+HOST_IP="127.0.0.1"
+KUBETURBO_VERSION=${KUBETURBO_VERSION-"8.9.5-SNAPSHOT"}
 
 # turbonomic is the default namespace that matches the xl setup
 # please change the value according to your set up
@@ -42,9 +44,6 @@ function create_cr {
 	CR_SURFIX=$1
 	CLUSTER_ROLE=${2-"cluster-admin"}
 
-	HOST_IP="127.0.0.1"
-	XL_VERSION="8.9.5-SNAPSHOT"
-
 	# username and password for the local ops-manager
 	OPS_MANAGER_USERNAME=administrator
 	OPS_MANAGER_PASSWORD=administrator
@@ -66,8 +65,8 @@ function create_cr {
 		HOST_IP=$(echo -e "${XL_VERSION_DETAIL}" | grep "Server:" | awk '{print $2}')
 		[ -z "${HOST_IP}" ] && echo -e "Failed to get exposed XL IP" | tee -a ${ERR_LOG} && exit 1
 
-		XL_VERSION=$(echo -e "${XL_VERSION_DETAIL}" | grep "Version:" | awk '{print $2}')
-		[ -z "${XL_VERSION}" ] && echo -e "Failed to get exposed XL version" | tee -a ${ERR_LOG} && exit 1
+		KUBETURBO_VERSION=$(echo -e "${XL_VERSION_DETAIL}" | grep "Version:" | awk '{print $2}')
+		[ -z "${KUBETURBO_VERSION}" ] && echo -e "Failed to get exposed XL version" | tee -a ${ERR_LOG} && exit 1
   fi
 
 	CR_FILEPATH=$(mktemp "${TMPDIR:-/tmp}/kubeturbo_cr_${CR_SURFIX}_XXXXXXX")
@@ -80,7 +79,7 @@ function create_cr {
 	  name: kubeturbo-${CR_SURFIX}
 	spec:
 	  serverMeta:
-	    version: ${XL_VERSION}
+	    version: ${KUBETURBO_VERSION}
 	    turboServer: https://${HOST_IP}
 	  restAPIConfig:
 	    turbonomicCredentialsSecretName: "turbonomic-credentials"
@@ -90,7 +89,7 @@ function create_cr {
 	    targetName: ${CR_SURFIX}
 	  roleName: ${CLUSTER_ROLE}
 	  image:
-	    tag: ${XL_VERSION}
+	    tag: ${KUBETURBO_VERSION}
 	EOT
 }
 


### PR DESCRIPTION
# Intent

Integrate Kubeturbo operator automation test with Jenkins's `xl-staging-kubeturbo-build`

- bring Kubeturbo operator test automation logic into the [make docker-buildx](https://github.com/turbonomic/kubeturbo/blob/master/deploy/kubeturbo-operator/Makefile#L311-L318) cmd
- build and push `tmp` kubeturbo operator image to the registry
- run the test against the fresh-build test image
- if the test pass, increment image version for kubeturbo operator

# Background

[TRB-43505](https://jsw.ibm.com/browse/TRB-43505) Integrate Kubeturbo operator automation test with Jenkins's `xl-staging-kubeturbo-build`

# Testing
[Jenkins buile #422](https://hyc-turbo-devops-team-jenkins.swg-devops.com/view/XL%20Staging/view/All/job/xl-staging-kubeturbo-build/422)
