### PR TITLE
[TRB-43185] automation test for dynamic logging 

### DIFF
--- a/deploy/kubeturbo-operator/Makefile
+++ b/deploy/kubeturbo-operator/Makefile
@@ -319,4 +319,4 @@ docker-buildx:
 
 .PHONY: test
 test:
-	bash ./test.sh
+	OPERATOR_IMAGE_VERSION=${VERSION} KUBETURBO_IMAGE_VERSION=${VERSION} bash ./test.sh

--- a/deploy/kubeturbo-operator/test.sh
+++ b/deploy/kubeturbo-operator/test.sh
@@ -204,7 +204,7 @@ function wait_for_logging_update {
 		echo "Wait for 10s for log level changes to be reflected..."
 		sleep 10
 		MSG=$($KUBECTL -n ${NAMESPACE} logs ${POD_NAME} | grep "Logging level is changed from")
-		if [ $COUNT -eq 10 ]; then
+		if [ $COUNT -eq 15 ]; then
 			echo "Timed out waiting for log level changes..." | tee -a ${ERR_LOG} && return
 		fi
 		COUNT+=1

--- a/deploy/kubeturbo-operator/test.sh
+++ b/deploy/kubeturbo-operator/test.sh
@@ -23,7 +23,7 @@ function rediscover_target {
 	response=$(curl -k -s --cookie "JSESSIONID=$cookie"-X GET "https://$ip/vmturbo/rest/targets?q=$DISPLAY_NAME&target_category=Cloud%20Native&order_by=validation_status&ascending=true&query_method=regex" -H "accept: application/json")
     target_uuid=$(echo "$response" | jq '. | .[] | "\(.uuid)"' | tr -d '"')
 	# rediscover
-	result=$(curl -k -s --cookie "JSESSIONID=$cookie"-X POST "https://${ip}/vmturbo/rest/targets/${target_uuid}?rediscover=true" -H "accept: application/json" -d '')
+	curl -k -s --cookie "JSESSIONID=$cookie"-X POST "https://${ip}/vmturbo/rest/targets/${target_uuid}?rediscover=true" -H "accept: application/json" -d '' > /dev/null
 }
 
 function install_operator {

--- a/deploy/kubeturbo-operator/test.sh
+++ b/deploy/kubeturbo-operator/test.sh
@@ -6,7 +6,7 @@ WAIT_FOR_DEPLOYMENT=30
 OPERATOR_IMAGE_VERSION="8.9.5-SNAPSHOT"
 OPERATOR_IMAGE="icr.io\/cpopen\/kubeturbo-operator:${OPERATOR_IMAGE_VERSION}"
 KUBETURBO_IMAGE_VERSION="8.9.5-SNAPSHOT"
-KUBETURBO_IMAGE_REPO="icr.io/cpopen/kubeturbo"
+KUBETURBO_IMAGE_REPO="icr.io/cpopen/turbonomic/kubeturbo"
 KUBECTL=kubectl
 # username and password for the local ops-manager
 OPS_MANAGER_USERNAME=administrator
@@ -185,7 +185,7 @@ function update_cr_for_logging {
 	CR_FILE1=$2
 	LOGGING_LEVEL=$3
 	echo -e "Updating CR to add logging level..."
-	# old method: adding spec.args.logginglevel causes pod to restart
+	# existing method: adding spec.args.logginglevel causes pod to restart
 	# sed -i -e "$ a\  args:" $CR_FILE1
 	# sed -i -e "$ a\    logginglevel: 4" $CR_FILE1
 	# new method: adding spec.logging.level should not cause a restart
@@ -322,6 +322,4 @@ function main {
 }
 
 
-# uninstall_cr testns1 /tmp/tmp.aa9qujUvuO_kubeturbo_cr_testcr1.yaml && uninstall_operator turbo
 main
-# rediscover_target Kubernetes-testcr1

--- a/deploy/kubeturbo-operator/test.sh
+++ b/deploy/kubeturbo-operator/test.sh
@@ -2,47 +2,55 @@
 
 SCRIPT_DIR="$(cd "$(dirname $0)" && pwd)"
 ERR_LOG=$(mktemp --suffix _kube.errlog)
-WAIT_FOR_DEPLOYMENT=20
+WAIT_FOR_DEPLOYMENT=30
 OPERATOR_IMAGE_VERSION="8.9.5-SNAPSHOT"
 OPERATOR_IMAGE="icr.io\/cpopen\/kubeturbo-operator:${OPERATOR_IMAGE_VERSION}"
+KUBETURBO_IMAGE_VERSION="8.9.5-SNAPSHOT"
+KUBETURBO_IMAGE_REPO="icr.io/cpopen/kubeturbo"
+KUBECTL=kubectl
+# username and password for the local ops-manager
+OPS_MANAGER_USERNAME=administrator
+OPS_MANAGER_PASSWORD=administrator
 
 # turbonomic is the default namespace that matches the xl setup
 # please change the value according to your set up
 export namespace=turbonomic
 
+function rediscover_target {
+	DISPLAY_NAME=$1
+    ip=$($KUBECTL get services --no-headers -n $namespace | grep nginx | awk '{print $4; exit}' | cut -d "," -f 1)
+    cookie=$(curl -k -s -v "https://$ip/vmturbo/rest/login" --data "username=$OPS_MANAGER_USERNAME&password=$OPS_MANAGER_PASSWORD" 2>&1 | grep JSESSION | awk -F'=' '{print $2}' | awk -F';' '{print $1}')
+	response=$(curl -k -s --cookie "JSESSIONID=$cookie"-X GET "https://$ip/vmturbo/rest/targets?q=$DISPLAY_NAME&target_category=Cloud%20Native&order_by=validation_status&ascending=true&query_method=regex" -H "accept: application/json")
+    target_uuid=$(echo "$response" | jq '. | .[] | "\(.uuid)"' | tr -d '"')
+	# rediscover
+	result=$(curl -k -s --cookie "JSESSIONID=$cookie"-X POST "https://${ip}/vmturbo/rest/targets/${target_uuid}?rediscover=true" -H "accept: application/json" -d '')
+}
+
 function install_operator {
 	NS=$1
 	[ -z "${NS}" ] && echo -e "Operator namespace not provided" | tee -a ${ERR_LOG} && exit 1
-	kubectl create ns ${NS}
-	kubectl delete -f ${SCRIPT_DIR}/deploy/crds/*crd.yaml
-	kubectl apply -f ${SCRIPT_DIR}/deploy/crds/*crd.yaml
-	kubectl apply -f ${SCRIPT_DIR}/deploy/service_account.yaml -n ${NS}
-	kubectl apply -f ${SCRIPT_DIR}/deploy/role_binding.yaml
-
-	# dynamically apply the image version
+	$KUBECTL create ns ${NS}
+	$KUBECTL delete -f ${SCRIPT_DIR}/deploy/crds/*crd.yaml
+	$KUBECTL apply -f ${SCRIPT_DIR}/deploy/crds/*crd.yaml
+	$KUBECTL apply -f ${SCRIPT_DIR}/deploy/service_account.yaml -n ${NS}
+	$KUBECTL apply -f ${SCRIPT_DIR}/deploy/role_binding.yaml
 	sed "s/image:.*/image: ${OPERATOR_IMAGE}/g" ${SCRIPT_DIR}/deploy/operator.yaml > ${SCRIPT_DIR}/deploy/updated_operator.yaml
-	kubectl apply -f ${SCRIPT_DIR}/deploy/updated_operator.yaml -n ${NS}
+	$KUBECTL apply -f ${SCRIPT_DIR}/deploy/updated_operator.yaml -n ${NS}
 }
 
 function uninstall_operator {
 	NS=$1
 	[ -z "${NS}" ] && echo -e "Operator namespace not provided" | tee -a ${ERR_LOG} && exit 1
-
-	kubectl delete -f ${SCRIPT_DIR}/deploy/updated_operator.yaml -n ${NS}
+	$KUBECTL delete -f ${SCRIPT_DIR}/deploy/updated_operator.yaml -n ${NS}
 	rm ${SCRIPT_DIR}/deploy/updated_operator.yaml
-
-	kubectl delete -f ${SCRIPT_DIR}/deploy/role_binding.yaml
-	kubectl delete -f ${SCRIPT_DIR}/deploy/service_account.yaml -n ${NS}
-	kubectl delete ns ${NS}
+	$KUBECTL delete -f ${SCRIPT_DIR}/deploy/role_binding.yaml
+	$KUBECTL delete -f ${SCRIPT_DIR}/deploy/service_account.yaml -n ${NS}
+	$KUBECTL delete ns ${NS}
 }
 
 function create_cr {
 	CR_SURFIX=$1
 	CLUSTER_ROLE=${2-"cluster-admin"}
-
-	# username and password for the local ops-manager
-	OPS_MANAGER_USERNAME=administrator
-	OPS_MANAGER_PASSWORD=administrator
 
 	# if we have .turbocreds pull the credentials from it instead
 	FILE="~/.turbocreds"
@@ -83,6 +91,10 @@ function create_cr {
 	  targetConfig:
 	    targetName: ${CR_SURFIX}
 	  roleName: ${CLUSTER_ROLE}
+	  image:
+	    repository: ${KUBETURBO_IMAGE_REPO}
+	    tag: ${KUBETURBO_IMAGE_VERSION}
+	    pullPolicy: Always
 	EOT
 }
 
@@ -96,17 +108,17 @@ function install_cr {
 	[ ! -f "${CR_FILE}" ] && echo "CR file ${CR_FILE} not provided" | tee -a ${ERR_LOG} && return
 
 	echo -e "> Start testing for ${TEST_DESC}"
-	kubectl create ns ${NS}
-	kubectl apply -f ${CR_FILE} -n ${NS} && echo -e "Wait for ${WAIT_FOR_DEPLOYMENT}s to finish container creation"
+	$KUBECTL create ns ${NS}
+	$KUBECTL apply -f ${CR_FILE} -n ${NS} && echo -e "Wait for ${WAIT_FOR_DEPLOYMENT}s to finish container creation"
 	sleep ${WAIT_FOR_DEPLOYMENT}
 
 	# check if the kubeturbo deployment get generated
 	FAILED=0
-	CR_DEPLOY=$(kubectl get deploy -n ${NS} -o NAME)
+	CR_DEPLOY=$($KUBECTL get deploy -n ${NS} -o NAME)
 	if [ -z "${CR_DEPLOY}" ]; then
 		echo -e "> ${TEST_DESC}........FAILED" | tee -a ${ERR_LOG}
 		return
-	elif [ -z "$(kubectl rollout status ${CR_DEPLOY} -n ${NS} | grep successfully)" ]; then
+	elif [ -z "$($KUBECTL rollout status ${CR_DEPLOY} -n ${NS} | grep successfully)" ]; then
 		FAILED=$((${FAILED}+1))
 		echo -e ">  Deployment ${CR_DEPLOY} cr check........FAILED" | tee -a ${ERR_LOG}
 	else
@@ -114,18 +126,18 @@ function install_cr {
 	fi
 
 	# check if the cluster log is healthy
-	if [ $(kubectl logs ${CR_DEPLOY} -n ${NS} | grep "Successfully" | wc -l) -lt 2 ]; then
+	if [ $($KUBECTL logs ${CR_DEPLOY} -n ${NS} | grep "Successfully" | wc -l) -lt 2 ]; then
 		FAILED=$((${FAILED}+1))
 		echo -e ">  Deployment ${CR_DEPLOY} log check........FAILED" | tee -a ${ERR_LOG}
 	else
 		echo -e ">  Deployment ${CR_DEPLOY} log check........PASSED"
 	fi
 
-	CR_DEPLOY_NAME=$(kubectl get ${CR_DEPLOY} -n ${NS} -o jsonpath={.metadata.name})
+	CR_DEPLOY_NAME=$($KUBECTL get ${CR_DEPLOY} -n ${NS} -o jsonpath={.metadata.name})
 
 	# check if the correct cluster role binding get generated
 	TARGET_ROLEBINDING="turbo-all-binding-${CR_DEPLOY_NAME}-${NS}"
-	kubectl get ClusterRoleBinding "${TARGET_ROLEBINDING}" >/dev/null
+	$KUBECTL get ClusterRoleBinding "${TARGET_ROLEBINDING}" >/dev/null
 	if [ $? -gt 0 ]; then
 		FAILED=$((${FAILED}+1))
 		echo -e ">  ClusterRoleBinding ${TARGET_ROLEBINDING} check........FAILED" | tee -a ${ERR_LOG}
@@ -139,7 +151,7 @@ function install_cr {
 	elif [ "${TARGET_ROLENAME}" != "cluster-admin" ]; then
 		TARGET_ROLENAME="${TARGET_ROLENAME}-${CR_DEPLOY_NAME}-${NS}"
 	fi
-	kubectl get ClusterRole "${TARGET_ROLENAME}" >/dev/null
+	$KUBECTL get ClusterRole "${TARGET_ROLENAME}" >/dev/null
 	if [ $? -gt 0 ]; then
 		FAILED=$((${FAILED}+1))
 		echo -e ">  ClusterRole ${TARGET_ROLENAME} check........FAILED" | tee -a ${ERR_LOG}
@@ -161,15 +173,47 @@ function uninstall_cr {
 	CR_FILE=$2
 
 	if [ -f "${CR_FILE}" ] && [ -n "${NS}" ]; then
-		kubectl delete -f ${CR_FILE} -n ${NS}
+		$KUBECTL delete -f ${CR_FILE} -n ${NS}
 	fi
 
 	[ -f "${CR_FILE}" ] && rm ${CR_FILE}
-	[ -n "${NS}" ] && kubectl delete ns ${NS}
+	[ -n "${NS}" ] && $KUBECTL delete ns ${NS}
 }
 
+function update_cr_for_logging {
+	CR_NS1=$1
+	CR_FILE1=$2
+	LOGGING_LEVEL=$3
+	echo -e "Updating CR to add logging level..."
+	# old method: adding spec.args.logginglevel causes pod to restart
+	# sed -i -e "$ a\  args:" $CR_FILE1
+	# sed -i -e "$ a\    logginglevel: 4" $CR_FILE1
+	# new method: adding spec.logging.level should not cause a restart
+	sed -i -e '$ a\  logging:' $CR_FILE1
+	sed -i -e "$ a\    level: $LOGGING_LEVEL" $CR_FILE1	
+	$KUBECTL apply -f ${CR_FILE} -n ${NS}
+}
 
-function main {
+function wait_for_logging_update {
+	NAMESPACE=$1
+	POD_NAME=$2
+	MSG=""
+	declare -i COUNT=0
+
+	while [ -z "$MSG" ]
+	do 
+		echo "Wait for 10s for log level changes to be reflected..."
+		sleep 10
+		MSG=$($KUBECTL -n ${NAMESPACE} logs ${POD_NAME} | grep "Logging level is changed from")
+		if [ $COUNT -eq 10 ]; then
+			echo "Timed out waiting for log level changes..." | tee -a ${ERR_LOG} && return
+		fi
+		COUNT+=1
+	done
+	echo $MSG
+}
+
+function test_kubeturbo_setup {
 	echo -e "> Tearing up kubeturbo tests"
 
 	# turbo is the default namespace that matches the one using in
@@ -200,9 +244,84 @@ function main {
 	TEST_RESULT=$(cat ${ERR_LOG})
 	if [ -n "${TEST_RESULT}" ]; then
 		echo -e "Kubeturbo test failed see logs at: ${ERR_LOG}" && exit 1
+	else
+		echo "Test passed!"
 	fi
 
 	rm ${ERR_LOG}
 }
 
+
+function test_dynamic_logging {
+	echo -e "> Running dynamic logging tests"
+	NEW_LOGGING_LEVEL=5
+	OPERATOR_NS=turbo
+	install_operator ${OPERATOR_NS}
+
+	CR_NS1=testns1
+	CR_LABEL=testcr1
+	CR_FILE1=$(create_cr ${CR_LABEL})
+	install_cr ${CR_NS1} ${CR_FILE1} "Deploy kubeturbo for dynamic logging"
+	POD_NAME=$($KUBECTL get pod -n ${NS} | grep ${CR_LABEL} | awk '{print $1}')
+	NUM_RESTART_BEFORE=$($KUBECTL get pod -n ${NS} ${POD_NAME} | awk 'FNR == 2 {print $4}')
+	HEAD_LOGS_BEFORE=$($KUBECTL -n ${NS} logs ${POD_NAME} | head -n 2)
+	# DEBUGGING ONLY
+	# echo "-------------Pod log before-----------------------------------------"
+	# $KUBECTL -n ${NS} logs ${POD_NAME}
+	# echo "-------------End Pod log before-----------------------------------------"
+	update_cr_for_logging ${CR_NS1} ${CR_FILE1} ${NEW_LOGGING_LEVEL}
+
+	# wait until log level changes msg shows up
+	wait_for_logging_update ${NS} ${POD_NAME}
+
+	#rediscover kubeturbo to generate new logs
+	TARGET_NAME=Kubernetes-${CR_LABEL} 
+	rediscover_target $TARGET_NAME	&& echo -e "Wait for 10s to finish rediscovering"
+	sleep 10
+
+	# check to make sure new logging level is updated in the configmap
+	# expecting something like this in the configmap "{\n \"logging\": {\n \"level\": 5\n }\n}"
+	LOGLEVEL_CM=$($KUBECTL get cm turbo-config-kubeturbo-${CR_LABEL} -n ${CR_NS1} -o json | jq '.data."turbo-autoreload.config"')
+	SEARCH_STR='level\\": '$NEW_LOGGING_LEVEL
+	[[ -z $(echo $LOGLEVEL_CM | grep "$SEARCH_STR") ]] && echo "Error: incorrect turbo-autoreload.config $LOGLEVEL_CM" | tee -a ${ERR_LOG}	
+
+	# check to make sure pod still exists
+	[[ $($KUBECTL get pod -n ${NS} ${POD_NAME} | grep "not found") ]] && echo "Error: pod not found after update" | tee -a ${ERR_LOG}	
+	
+	NUM_RESTART_AFTER=$($KUBECTL get pod -n ${NS} ${POD_NAME} | awk 'FNR == 2 {print $4}')
+	HEAD_LOGS_AFTER=$($KUBECTL -n ${NS} logs ${POD_NAME} | head -n 2)
+	# check the pod restart number before and after cr update
+	[[ $NUM_RESTART_BEFORE != $NUM_RESTART_AFTER ]] && echo "Pod restarted after updating logging level" | tee -a ${ERR_LOG}	
+	# check if previous logs are preserved
+	[[ $HEAD_LOGS_BEFORE != $HEAD_LOGS_AFTER ]] && echo "Logs before CR update was erased\n$HEAD_LOGS_BEFORE\n$HEAD_LOGS_AFTER" | tee -a ${ERR_LOG}
+	# check if new logs contains message that should only show up in the new logging level
+	NEW_LOGLEVEL_MSG="Adding label commodity" # example level 5 msg
+	[[ -z $($KUBECTL -n ${NS} logs ${POD_NAME} | grep "$NEW_LOGLEVEL_MSG") ]] && echo "Error: expected new log not found" | tee -a ${ERR_LOG}	
+
+	# DEBUGGING ONLY
+	# echo "-------------Pod log after-----------------------------------------"
+	# $KUBECTL -n ${NS} logs ${POD_NAME}
+	# echo "-------------End Pod log after-----------------------------------------"
+
+	echo -e "Cleanup..."
+	uninstall_cr ${CR_NS1} ${CR_FILE1}
+	uninstall_operator ${OPERATOR_NS}
+
+	TEST_RESULT=$(cat ${ERR_LOG})
+	if [ -n "${TEST_RESULT}" ]; then
+		echo -e "Dynamic logging test failed see logs at: ${ERR_LOG}" && exit 1
+	else
+		echo "Test passed!"
+	fi
+}
+
+function main {	
+	test_kubeturbo_setup
+	test_dynamic_logging
+	rm ${ERR_LOG}
+}
+
+
+# uninstall_cr testns1 /tmp/tmp.aa9qujUvuO_kubeturbo_cr_testcr1.yaml && uninstall_operator turbo
 main
+# rediscover_target Kubernetes-testcr1

--- a/deploy/kubeturbo-operator/test.sh
+++ b/deploy/kubeturbo-operator/test.sh
@@ -3,9 +3,7 @@
 SCRIPT_DIR="$(cd "$(dirname $0)" && pwd)"
 ERR_LOG=$(mktemp --suffix _kube.errlog)
 WAIT_FOR_DEPLOYMENT=30
-OPERATOR_IMAGE_VERSION="8.9.5-SNAPSHOT"
 OPERATOR_IMAGE="icr.io\/cpopen\/kubeturbo-operator:${OPERATOR_IMAGE_VERSION}"
-KUBETURBO_IMAGE_VERSION="8.9.5-SNAPSHOT"
 KUBETURBO_IMAGE_REPO="icr.io/cpopen/turbonomic/kubeturbo"
 KUBECTL=kubectl
 # username and password for the local ops-manager
@@ -321,6 +319,5 @@ function main {
 	test_dynamic_logging
 	rm ${ERR_LOG}
 }
-
 
 main

--- a/deploy/kubeturbo-operator/test.sh
+++ b/deploy/kubeturbo-operator/test.sh
@@ -114,7 +114,8 @@ function install_cr {
 
 	# check if the kubeturbo deployment get generated
 	FAILED=0
-	CR_DEPLOY=$($KUBECTL get deploy -n ${NS} -o NAME)
+	# assumes there is only one deployment in the ns aside from operator deployment
+	CR_DEPLOY=$($KUBECTL get deploy -n ${NS} -o NAME | grep -v operator)
 	if [ -z "${CR_DEPLOY}" ]; then
 		echo -e "> ${TEST_DESC}........FAILED" | tee -a ${ERR_LOG}
 		return


### PR DESCRIPTION
# Intent
https://vmturbo.testrail.com/index.php?/cases/view/403081&group_by=cases:section_id&group_order=asc&display_deleted_cases=0&group_id=96899

Add automation tests for dynamic log change feature (https://github.com/turbonomic/kubeturbo/pull/900). The test performs the following: 
1. Create ns
2. Install kubeturbo through operator
~~3. Rediscover in case discovery is not initiated in time.~~
4. Check kubeturbo pod to make sure deployment is successful.
5. Change log level by updating CR (spec.logging.level)
6. Look for msg "Logging level is changed from 2 to 5"
7. Check pod doesn't restart and old logs are preserved
8. Check that cm is updated
~~9. Rediscover to generate new logs~~
~~10. Check pod logs again to make sure logs with correct loglevel are showing up.~~

# Background

Details on dynamic log changes. https://jsw.ibm.com/browse/TRB-43185

# Testing

Automation tests results documented in the jira issue above. Here's the log output from the tests:

Logs for test run:
```
OPERATOR_IMAGE_VERSION=8.9.5-SNAPSHOT KUBETURBO_IMAGE_VERSION=8.9.5-SNAPSHOT bash ./test.sh
> Tearing up kubeturbo tests
namespace/turbo created
customresourcedefinition.apiextensions.k8s.io "kubeturbos.charts.helm.k8s.io" deleted
customresourcedefinition.apiextensions.k8s.io/kubeturbos.charts.helm.k8s.io created
serviceaccount/kubeturbo-operator created
clusterrolebinding.rbac.authorization.k8s.io/kubeturbo-operator created
deployment.apps/kubeturbo-operator created
> Start testing for Deploy single kubeturbo test
namespace/testns1 created
kubeturbo.charts.helm.k8s.io/kubeturbo-testcr1 created
Wait for 30s to finish container creation
>  Deployment deployment.apps/kubeturbo-testcr1 cr check........PASSED
>  Deployment deployment.apps/kubeturbo-testcr1 log check........PASSED
>  ClusterRoleBinding turbo-all-binding-kubeturbo-testcr1-testns1 check........PASSED
>  ClusterRole cluster-admin check........PASSED
> Deploy single kubeturbo test........PASSED
> Start testing for Deploy multiple kubeturbos test
namespace/testns2 created
kubeturbo.charts.helm.k8s.io/kubeturbo-testcr2 created
Wait for 30s to finish container creation
>  Deployment deployment.apps/kubeturbo-testcr2 cr check........PASSED
>  Deployment deployment.apps/kubeturbo-testcr2 log check........PASSED
>  ClusterRoleBinding turbo-all-binding-kubeturbo-testcr2-testns2 check........PASSED
>  ClusterRole cluster-admin check........PASSED
> Deploy multiple kubeturbos test........PASSED
> Start testing for Deploy single turbo-cluster-reader kubeturbo test
namespace/testns3 created
kubeturbo.charts.helm.k8s.io/kubeturbo-testcr3 created
Wait for 30s to finish container creation
>  Deployment deployment.apps/kubeturbo-testcr3 cr check........PASSED
>  Deployment deployment.apps/kubeturbo-testcr3 log check........PASSED
>  ClusterRoleBinding turbo-all-binding-kubeturbo-testcr3-testns3 check........PASSED
>  ClusterRole turbo-cluster-reader-kubeturbo-testcr3-testns3 check........PASSED
> Deploy single turbo-cluster-reader kubeturbo test........PASSED
> Start testing for Deploy multiple turbo-cluster-reader kubeturbos test
namespace/testns4 created
kubeturbo.charts.helm.k8s.io/kubeturbo-testcr4 created
Wait for 30s to finish container creation
>  Deployment deployment.apps/kubeturbo-testcr4 cr check........PASSED
>  Deployment deployment.apps/kubeturbo-testcr4 log check........PASSED
>  ClusterRoleBinding turbo-all-binding-kubeturbo-testcr4-testns4 check........PASSED
>  ClusterRole turbo-cluster-reader-kubeturbo-testcr4-testns4 check........PASSED
> Deploy multiple turbo-cluster-reader kubeturbos test........PASSED
> Tearing down kubeturbo tests
kubeturbo.charts.helm.k8s.io "kubeturbo-testcr1" deleted
namespace "testns1" deleted
kubeturbo.charts.helm.k8s.io "kubeturbo-testcr2" deleted
namespace "testns2" deleted
kubeturbo.charts.helm.k8s.io "kubeturbo-testcr3" deleted
namespace "testns3" deleted
kubeturbo.charts.helm.k8s.io "kubeturbo-testcr4" deleted
namespace "testns4" deleted
deployment.apps "kubeturbo-operator" deleted
clusterrolebinding.rbac.authorization.k8s.io "kubeturbo-operator" deleted
serviceaccount "kubeturbo-operator" deleted
namespace "turbo" deleted
Test passed!
> Running dynamic logging tests
namespace/turbo created
customresourcedefinition.apiextensions.k8s.io "kubeturbos.charts.helm.k8s.io" deleted
customresourcedefinition.apiextensions.k8s.io/kubeturbos.charts.helm.k8s.io created
serviceaccount/kubeturbo-operator created
clusterrolebinding.rbac.authorization.k8s.io/kubeturbo-operator created
deployment.apps/kubeturbo-operator created
> Start testing for Deploy kubeturbo for dynamic logging
namespace/testns1 created
kubeturbo.charts.helm.k8s.io/kubeturbo-testcr1 created
Wait for 30s to finish container creation
>  Deployment deployment.apps/kubeturbo-testcr1 cr check........PASSED
>  Deployment deployment.apps/kubeturbo-testcr1 log check........PASSED
>  ClusterRoleBinding turbo-all-binding-kubeturbo-testcr1-testns1 check........PASSED
>  ClusterRole cluster-admin check........PASSED
> Deploy kubeturbo for dynamic logging........PASSED
Updating CR to add logging level...
kubeturbo.charts.helm.k8s.io/kubeturbo-testcr1 configured
Wait for 10s for log level changes to be reflected...
Wait for 10s for log level changes to be reflected...
Wait for 10s for log level changes to be reflected...
Wait for 10s for log level changes to be reflected...
I0725 16:38:46.720125 1 kubeturbo_builder.go:1045] Logging level is changed from 2 to 5
Cleanup...
kubeturbo.charts.helm.k8s.io "kubeturbo-testcr1" deleted
namespace "testns1" deleted
deployment.apps "kubeturbo-operator" deleted
clusterrolebinding.rbac.authorization.k8s.io "kubeturbo-operator" deleted
serviceaccount "kubeturbo-operator" deleted
namespace "turbo" deleted
Test passed!

```

```

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [ ] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [ ] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

_(@ mention any `review/...` groups or people that should be aware of this merge request)_

