### PR TITLE
[TRB-45107] operator watch ns

### DIFF
--- a/deploy/kubeturbo-operator/deploy/operator.yaml
+++ b/deploy/kubeturbo-operator/deploy/operator.yaml
@@ -29,3 +29,9 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "kubeturbo-operator"
+          volumeMount:
+            - mountPath: /tmp
+              name: operator-tmpfs0
+      volumes:
+        - name: operator-tmpfs0
+          emptyDir: {}

--- a/deploy/kubeturbo-operator/deploy/operator.yaml
+++ b/deploy/kubeturbo-operator/deploy/operator.yaml
@@ -29,7 +29,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "kubeturbo-operator"
-          volumeMount:
+          volumeMounts:
             - mountPath: /tmp
               name: operator-tmpfs0
       volumes:

--- a/deploy/kubeturbo-operator/deploy/operator.yaml
+++ b/deploy/kubeturbo-operator/deploy/operator.yaml
@@ -20,7 +20,9 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              value: ""
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
 # Intent

Resolves bug https://jsw.ibm.com/browse/TRB-45107

# Background

Make changes to operator.yaml to make sure that the operator is only monitoring CRs in the same ns as the operator. Otherwise, this might cause conflicts when there are multiple operators watching over the same ns.

# Testing

It's tested as part of the kubeturbo operator deployment test [here](https://github.ibm.com/turbonomic/core-python/blob/c77819cdcd49fd4b5bb7d0c1fb3eef9fee28b6f3/tests_dev_it/api/kubernetes/regression/operator/test_kubeturbo_operator.py#L150) where multiple operators are deployed simultaneously. The WATCH_NAMESPACE is already limited to the same ns as the operator.

Also tested manually by deploying kubeturbo through operator and made sure that it only monitored CRs created in the same ns and that the kubeturbo deployment is successful with these changes to the operator.

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [ ] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [x] Integration tests added / updated
    - [x] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

_(@ mention any `review/...` groups or people that should be aware of this merge request)_

