### PR TITLE
[TRB-45490] Kubeturbo certified operator bundle automation enhancement

### DIFF
--- a/deploy/kubeturbo-operator/Makefile
+++ b/deploy/kubeturbo-operator/Makefile
@@ -216,7 +216,7 @@ verify-operator-release-channel:
 verify-stable-operator-release-version:
 	if [ "$(OPERATOR_RELEASE_CHANNEL)" = "stable" ]; then \
         echo "Checking if the stable release version $(OPERATOR_RELEASE_VERSION) exists..."; \
-         if [ -n "$$(curl -H "Authorization: Bearer $(ACCESS_TOKEN)" -s "$(GITHUB_REPO_URL)" | jq -r 'map(select(.type == "dir")) | .[].name | match("$(OPERATOR_RELEASE_VERSION)") | try .string')" ]; then \
+         if [ -n "$$(curl -H "Authorization: Bearer $(ACCESS_TOKEN)" -s "$(GITHUB_REPO_URL)" | jq -r 'map(select(.type == "dir" and .name == "$(OPERATOR_RELEASE_VERSION)")) | .[].name')" ]; then \
             echo "Error: The operator release version already exists for stable channel: $(OPERATOR_RELEASE_VERSION)."; \
             exit 1; \
         fi; \

--- a/deploy/kubeturbo-operator/Makefile
+++ b/deploy/kubeturbo-operator/Makefile
@@ -179,35 +179,59 @@ $(PYTHON):
 
 
 
-OPERATOR_VERSION_BETA ?= $(if $(OPERATOR_BETA_RELEASE_MINOR_VERSION),beta.$(OPERATOR_BETA_RELEASE_MINOR_VERSION),beta.1)
 OPERATOR_OLM_INCLUSIVE_RANGE_VERSION ?= 8.7.5
 OPERATOR_OLM_INCLUSIVE_BETA_VERSION ?= beta.1
-OPERATOR_RELEASE_FILTER ?= beta
+OPERATOR_BETA_RELEASE_FILTER ?= beta
+OPERATOR_BETA_RELEASE_VERSION_SNAPSHOT ?= SNAPSHOT
 OPERATOR_CERTIFIED ?= kubeturbo-certified
 OPERATOR_BUNDLE_DIR ?= certified-operator-bundle
 OPERATOR_BUNDLE_TEMPLATE_DIR ?= bundle-template
 OPERATOR_CRD_FILE_PATH ?= deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
 CLUSTER_PERMISSION_ROLE_YAML_FILE_PATH ?= deploy/kubeturbo-operator-cluster-role.yaml
 CERTIFIED_OPERATOR_CLUSTER_SERVICE_VERSION_YAML_FILE_PATH ?= $(OPERATOR_BUNDLE_DIR)/manifest/kubeturbo-certified.clusterserviceversion.yaml
-
+GITHUB_REPO_URL := https://api.github.com/repos/turbodeploy/certified-operators/contents/operators/kubeturbo-certified
+ifndef ACCESS_TOKEN
+$(error ACCESS_TOKEN is missing. It is required for validating the release versions from Git. Please provide the ACCESS_TOKEN to proceed with the release of the certified operator bundle.)
+endif
+OPERATOR_VERSION_BETA := $(shell \
+	OPERATOR_BETA_RELEASE_MINOR_VERSION=$$(curl -H "Authorization: Bearer $(ACCESS_TOKEN)" -s "$(GITHUB_REPO_URL)" | \
+	jq -r 'map(select(.type == "dir")) | .[].name | match("$(OPERATOR_RELEASE_VERSION)-beta\\.[0-9]+") | try .string catch "0"' | \
+	awk -F'.' 'BEGIN{max=0} {n=substr($$0, index($$0, "beta.")+5)+0; if (n>max) max=n} END{print max}'); \
+	if [ -z "$$OPERATOR_BETA_RELEASE_MINOR_VERSION" ]; then \
+		OPERATOR_BETA_RELEASE_MINOR_VERSION=1; \
+	else \
+		OPERATOR_BETA_RELEASE_MINOR_VERSION=$$(($$OPERATOR_BETA_RELEASE_MINOR_VERSION + 1)); \
+	fi; \
+	OPERATOR_VERSION_BETA=beta.$$OPERATOR_BETA_RELEASE_MINOR_VERSION; \
+	echo "$$OPERATOR_VERSION_BETA" \
+)
 .PHONY: build-certified-operator-bundle
-build-certified-operator-bundle:yq python verify-operator-release-channel verify_image_digest_version create_certified_operator_bundle_directory update_image_digest_in_operator_bundle update_operator_version_in_operator_bundle update_olm_skipRange_in_operator_bundle update_cluster_permissions_in_operator_bundle update_release_channel_in_operator_bundle
+build-certified-operator-bundle:yq python verify-operator-release-channel verify-stable-operator-release-version verify_image_digest_version create_certified_operator_bundle_directory update_image_digest_in_operator_bundle update_operator_version_in_operator_bundle update_olm_skipRange_in_operator_bundle update_cluster_permissions_in_operator_bundle update_release_channel_in_operator_bundle
 ## verify operator release channel, to allow only valid releases
 verify-operator-release-channel:
     ifneq ($(filter $(OPERATOR_RELEASE_CHANNEL),stable beta),$(OPERATOR_RELEASE_CHANNEL))
         $(error Invalid operator release channel parameter - $(OPERATOR_RELEASE_CHANNEL). valid release channels are either "stable" or "beta only".)
     endif
-
+## verify operator release version on stable channel, to avoid multiple releases of same version
+verify-stable-operator-release-version:
+	if [ "$(OPERATOR_RELEASE_CHANNEL)" = "stable" ]; then \
+        echo "Checking if the stable release version $(OPERATOR_RELEASE_VERSION) exists..."; \
+         if [ -n "$$(curl -H "Authorization: Bearer $(ACCESS_TOKEN)" -s "$(GITHUB_REPO_URL)" | jq -r 'map(select(.type == "dir")) | .[].name | match("$(OPERATOR_RELEASE_VERSION)") | try .string')" ]; then \
+            echo "Error: The operator release version already exists for stable channel: $(OPERATOR_RELEASE_VERSION)."; \
+            exit 1; \
+        fi; \
+    fi
 ## verify if the version field value is present in the image to proceed, if empty exit the execution
 verify_image_digest_version:
 	@echo "Verify Image Digest version field value"
-	docker pull $(REGISTRY)/$(OPERATOR_NAME)-operator:$(OPERATOR_RELEASE_VERSION)
-	version=$$(docker inspect $(REGISTRY)/$(OPERATOR_NAME)-operator:$(OPERATOR_RELEASE_VERSION) | grep '"version":' | awk '{print $$2}' | tr -d '",'); \
+	$(eval OPERATOR_IMAGE_RELEASE_VERSION := $(if $(filter $(OPERATOR_BETA_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_RELEASE_VERSION)-$(OPERATOR_BETA_RELEASE_VERSION_SNAPSHOT),$(OPERATOR_RELEASE_VERSION)))
+	docker pull $(REGISTRY)/$(OPERATOR_NAME)-operator:$(OPERATOR_IMAGE_RELEASE_VERSION)
+	version=$$(docker inspect $(REGISTRY)/$(OPERATOR_NAME)-operator:$(OPERATOR_IMAGE_RELEASE_VERSION) | grep '"version":' | awk '{print $$2}' | tr -d '",'); \
 	if [ -z "$$version" ]; then \
 		echo "Error: Image digest version field is empty, cannot procced with $(OPERATOR_CERTIFIED)-operator bundle release."; \
 		exit 1; \
-	elif [ "$$version" != "$(OPERATOR_RELEASE_VERSION)" ]; then \
-		echo "Error: Image digest version field: ($$version) does not match operator release version: ($(OPERATOR_RELEASE_VERSION))."; \
+	elif [ "$$version" != "$(OPERATOR_IMAGE_RELEASE_VERSION)" ]; then \
+		echo "Error: Image digest version field: ($$version) does not match operator release version: ($(OPERATOR_IMAGE_RELEASE_VERSION))."; \
 		exit 1; \
 	else \
 		echo "Image digest validation successful, proceeding with next steps."; \
@@ -226,7 +250,8 @@ create_certified_operator_bundle_directory:
 ## update image digest key
 update_image_digest_in_operator_bundle:
 	@echo "Updating image digest in $(OPERATOR_CERTIFIED)-clusterserviceversion..."
-	digest=$$(docker inspect --format='{{index .RepoDigests 0}}' $(REGISTRY)/$(OPERATOR_NAME)-operator:$(OPERATOR_RELEASE_VERSION) | awk -F@ '{print $$2}'); \
+	$(eval OPERATOR_IMAGE_RELEASE_VERSION := $(if $(filter $(OPERATOR_BETA_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_RELEASE_VERSION)-$(OPERATOR_BETA_RELEASE_VERSION_SNAPSHOT),$(OPERATOR_RELEASE_VERSION)))
+	digest=$$(docker inspect --format='{{index .RepoDigests 0}}' $(REGISTRY)/$(OPERATOR_NAME)-operator:$(OPERATOR_IMAGE_RELEASE_VERSION) | awk -F@ '{print $$2}'); \
 	if [ -z "$$digest" ]; then \
 		echo "Error: Image digest is empty, cannot proceed with $(OPERATOR_CERTIFIED)-operator bundle release."; \
 		exit 1; \
@@ -239,7 +264,7 @@ update_image_digest_in_operator_bundle:
 ## update release version
 update_operator_version_in_operator_bundle:
 	@echo "Updating release versions in $(OPERATOR_CERTIFIED)-clusterserviceversion..."
-	$(eval OPERATOR_RELEASE_CHANNEL_VERSION := $(if $(filter $(OPERATOR_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_RELEASE_VERSION)-$(OPERATOR_VERSION_BETA),$(OPERATOR_RELEASE_VERSION)))
+	$(eval OPERATOR_RELEASE_CHANNEL_VERSION := $(if $(filter $(OPERATOR_BETA_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_RELEASE_VERSION)-$(OPERATOR_VERSION_BETA),$(OPERATOR_RELEASE_VERSION)))
 	$(YQ) eval -i '.metadata.name |= sub("kubeturbo-operator.v.*", "kubeturbo-operator.v$(OPERATOR_RELEASE_CHANNEL_VERSION)") | .spec.version = "$(OPERATOR_RELEASE_CHANNEL_VERSION)"' \
 		$(OPERATOR_BUNDLE_DIR)/manifest/$(OPERATOR_CERTIFIED).clusterserviceversion.yaml
 	@echo "$(OPERATOR_CERTIFIED)-clusterserviceversion release versions updated successfully."
@@ -247,8 +272,8 @@ update_operator_version_in_operator_bundle:
 ## update skipRange based on inclusive and exclusive release versions set
 update_olm_skipRange_in_operator_bundle:
 	@echo "Updating olm.skipRange in $(OPERATOR_CERTIFIED)-clusterserviceversion..."
-	$(YQ) eval -i '.metadata.annotations."olm.skipRange" |= sub(">=[^<]+", ">=$(if $(filter $(OPERATOR_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_OLM_INCLUSIVE_RANGE_VERSION)-$(OPERATOR_OLM_INCLUSIVE_BETA_VERSION),$(OPERATOR_OLM_INCLUSIVE_RANGE_VERSION))") \
-	| .metadata.annotations."olm.skipRange" |= sub("<[^<]+", " <$(if $(filter $(OPERATOR_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_RELEASE_VERSION)-$(OPERATOR_VERSION_BETA),$(OPERATOR_RELEASE_VERSION))")' \
+	$(YQ) eval -i '.metadata.annotations."olm.skipRange" |= sub(">=[^<]+", ">=$(if $(filter $(OPERATOR_BETA_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_OLM_INCLUSIVE_RANGE_VERSION)-$(OPERATOR_OLM_INCLUSIVE_BETA_VERSION),$(OPERATOR_OLM_INCLUSIVE_RANGE_VERSION))") \
+	| .metadata.annotations."olm.skipRange" |= sub("<[^<]+", " <$(if $(filter $(OPERATOR_BETA_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_RELEASE_VERSION)-$(OPERATOR_VERSION_BETA),$(OPERATOR_RELEASE_VERSION))")' \
 	   $(OPERATOR_BUNDLE_DIR)/manifest/$(OPERATOR_CERTIFIED).clusterserviceversion.yaml
 	@echo "$(OPERATOR_CERTIFIED)-clusterserviceversion olm.skipRange updated successfully."
 

--- a/deploy/kubeturbo-operator/Makefile
+++ b/deploy/kubeturbo-operator/Makefile
@@ -191,7 +191,7 @@ CLUSTER_PERMISSION_ROLE_YAML_FILE_PATH ?= deploy/kubeturbo-operator-cluster-role
 CERTIFIED_OPERATOR_CLUSTER_SERVICE_VERSION_YAML_FILE_PATH ?= $(OPERATOR_BUNDLE_DIR)/manifest/kubeturbo-certified.clusterserviceversion.yaml
 GITHUB_REPO_URL := https://api.github.com/repos/turbodeploy/certified-operators/contents/operators/kubeturbo-certified
 ifndef ACCESS_TOKEN
-$(error ACCESS_TOKEN is missing. It is required for validating the release versions from Git. Please provide the ACCESS_TOKEN to proceed with the release of the certified operator bundle.)
+$(error ACCESS_TOKEN is missing. It is required to verify the release versions from Git. Please provide the ACCESS_TOKEN to proceed with the release of the certified operator bundle.)
 endif
 OPERATOR_VERSION_BETA := $(shell \
 	OPERATOR_BETA_RELEASE_MINOR_VERSION=$$(curl -H "Authorization: Bearer $(ACCESS_TOKEN)" -s "$(GITHUB_REPO_URL)" | \


### PR DESCRIPTION
 This PR is an enhancement to the already merged PR - https://github.com/turbonomic/kubeturbo/pull/893

# Intent
This PR has a few enhancements from the previous [one](https://github.com/turbonomic/kubeturbo/pull/893)

**Note:**
- The `OPERATOR_BETA_RELEASE_MINOR_VERSION` parameter is no longer necessary and has been eliminated, as the recipe itself can now determine the minor version by querying the repository.
- The `beta` release channel will **always** have the `SNAPSHOT` version of the image.
- The `stable` release channel will **always** have the `non-SNAPSHOT` version of the image.


# Background

**Enhancements are as follows**

- Now, utilizing GitHub API, this recipe is capable of querying the turbodeploy GitHub repository to examine the release versions for both the stable and beta channels.
- In the case of a stable release, an error will be returned if the version directory already exists, as multiple releases with the same versions cannot be issued.
- As for a beta release, if the version directory already exists, it will determine the maximum minor version for the release and increment the new release by 1. For instance, if we intend to release version `1.2.3` in the `beta` channel, and versions `1.2.3-beta.1` and `1.2.3-beta.2` already exist, the script will retrieve the maximum minor version, which is `2`, and create a new release by incrementing the minor version to `3`, resulting in `1.2.3-beta.3`.

**Execution Instructions**

- Utilize the make command: `make build-certified-operator-bundle`
- A model command for launching a certified operator bundle in a stable release: `make build-certified-operator-bundle OPERATOR_RELEASE_VERSION=1.2.3 OPERATOR_RELEASE_CHANNEL=stable ACCESS_TOKEN=xxxxxxxxxx`
- A model command for launching a certified operator bundle in a beta release: `make build-certified-operator-bundle OPERATOR_RELEASE_VERSION=1.2.3 OPERATOR_RELEASE_CHANNEL=beta ACCESS_TOKEN=xxxxxxxxxx`

**Parameters Required to run**
- `OPERATOR_RELEASE_VERSION` - This refers to the operator version you aim to release on ocp.
-  `OPERATOR_RELEASE_CHANNEL` -  This specifies the release channel you intend to use for ocp release. The options are restricted to `stable` or `beta`.
-  `ACCESS_TOKEN` - This is to access the GitHub Repo of turbodeploy. It assists in averting rate limitations imposed by the API. **(Note: This is merely used to avoid GitHub API's rate restrictions in case they hit their upper limit)**

# Testing

**Release of operator**
![Screenshot 2023-08-07 at 3 49 38 PM (2)](https://github.com/turbonomic/kubeturbo/assets/112518353/c2713417-f4e3-4c1b-81da-7586658fffcb)

![Screenshot 2023-08-07 at 4 04 10 PM (2)](https://github.com/turbonomic/kubeturbo/assets/112518353/d215d957-eb48-44db-837d-ed07dc6d51a7)

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [ ] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [x] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

_(@ mention any `review/...` groups or people that should be aware of this merge request)_

