### PR TITLE
[TRB-44974] Dynamic Configuration for Node Scaling in Kubeturbo

### DIFF
--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -1052,8 +1052,8 @@ func WatchConfigMap() {
 				}
 			}
 		}
-		updateClusterConfig("cluster.minNodes", &currentMinNodes, cluster.DefaultClusterMinNodes)
-		updateClusterConfig("cluster.maxNodes", &currentMaxNodes, cluster.DefaultClusterMaxNodes)
+		updateClusterConfig(cluster.MinNodesConfigKey, &currentMinNodes, cluster.DefaultClusterMinNodes)
+		updateClusterConfig(cluster.MaxNodesConfigKey, &currentMaxNodes, cluster.DefaultClusterMaxNodes)
 	}
 	updateConfigClosure() //update the logging level during startup
 	viper.OnConfigChange(func(in fsnotify.Event) {

--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -42,6 +42,7 @@ import (
 
 	kubeturbo "github.com/turbonomic/kubeturbo/pkg"
 	"github.com/turbonomic/kubeturbo/pkg/action/executor/gitops"
+	"github.com/turbonomic/kubeturbo/pkg/cluster"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/processor"
 	nodeUtil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/worker"
@@ -71,8 +72,6 @@ const (
 	DefaultDiscoverySampleIntervalSec = 60
 	DefaultGCIntervalMin              = 10
 	DefaultReadinessRetryThreshold    = 60
-	DefaultClusterMinNodes            = 1
-	DefaultClusterMaxNodes            = 1000
 )
 
 var (
@@ -1032,8 +1031,8 @@ func WatchConfigMap() {
 		}
 	}
 
-	currentMinNodes := DefaultClusterMinNodes
-	currentMaxNodes := DefaultClusterMaxNodes
+	currentMinNodes := cluster.DefaultClusterMinNodes
+	currentMaxNodes := cluster.DefaultClusterMaxNodes
 
 	glog.V(1).Infof("Start watching the autoreload config file %s/%s", autoReloadConfigFilePath, autoReloadConfigFileName)
 	updateConfigClosure := func() {
@@ -1053,8 +1052,8 @@ func WatchConfigMap() {
 				}
 			}
 		}
-		updateClusterConfig("cluster.minNodes", &currentMinNodes, DefaultClusterMinNodes)
-		updateClusterConfig("cluster.maxNodes", &currentMaxNodes, DefaultClusterMaxNodes)
+		updateClusterConfig("cluster.minNodes", &currentMinNodes, cluster.DefaultClusterMinNodes)
+		updateClusterConfig("cluster.maxNodes", &currentMaxNodes, cluster.DefaultClusterMaxNodes)
 	}
 	updateConfigClosure() //update the logging level during startup
 	viper.OnConfigChange(func(in fsnotify.Event) {

--- a/cmd/kubeturbo/app/kubeturbo_builder.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder.go
@@ -1052,8 +1052,8 @@ func WatchConfigMap() {
 				}
 			}
 		}
-		updateClusterConfig(cluster.MinNodesConfigKey, &currentMinNodes, cluster.DefaultClusterMinNodes)
-		updateClusterConfig(cluster.MaxNodesConfigKey, &currentMaxNodes, cluster.DefaultClusterMaxNodes)
+		updateClusterConfig(cluster.MinNodesConfigKey, &currentMinNodes, cluster.DefaultClusterMinNodes, viper.GetString)
+		updateClusterConfig(cluster.MaxNodesConfigKey, &currentMaxNodes, cluster.DefaultClusterMaxNodes, viper.GetString)
 	}
 	updateConfigClosure() //update the logging level during startup
 	viper.OnConfigChange(func(in fsnotify.Event) {
@@ -1067,9 +1067,9 @@ func WatchConfigMap() {
 // If the configuration value is empty, it uses the provided defaultValue.
 // If the configuration value is not a valid integer or is negative, it uses the defaultValue and logs an error.
 // If the configuration value is different from the currentValue, it updates the currentValue and logs the change.
-func updateClusterConfig(configKey string, currentValue *int, defaultValue int) {
+func updateClusterConfig(configKey string, currentValue *int, defaultValue int, getKeyStringVal func(string) string) {
 	glog.V(1).Infof("Cluster %s  current value is %v ", configKey, *currentValue)
-	newValueStr := viper.GetString(configKey)
+	newValueStr := getKeyStringVal(configKey)
 
 	if newValueStr == "" {
 		glog.V(1).Infof("Empty value for %s in the configuration, using default value %d", configKey, defaultValue)
@@ -1080,6 +1080,7 @@ func updateClusterConfig(configKey string, currentValue *int, defaultValue int) 
 	newValue, err := strconv.Atoi(newValueStr)
 	if err != nil || newValue < 0 {
 		glog.Errorf("Invalid %s value: %v specified, using default value %d", configKey, newValue, defaultValue)
+		*currentValue = defaultValue
 		return
 	}
 

--- a/cmd/kubeturbo/app/kubeturbo_builder_test.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder_test.go
@@ -72,7 +72,7 @@ func TestOptionsSet(t *testing.T) {
 	s.AddFlags(pflag.CommandLine)
 }
 
-func TestUpdateClusterConfig(t *testing.T) {
+func TestUpdateNodePoolConfig(t *testing.T) {
 	testCases := []struct {
 		name            string
 		configKey       string
@@ -117,7 +117,7 @@ func TestUpdateClusterConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			updateClusterConfig(tc.configKey, &tc.currentValue, tc.defaultValue, tc.getKeyStringVal)
+			updateNodePoolConfig(tc.configKey, &tc.currentValue, tc.defaultValue, tc.getKeyStringVal)
 
 			if tc.currentValue != tc.expectedValue {
 				t.Errorf("Expected value: %d, got: %d", tc.expectedValue, tc.currentValue)

--- a/cmd/kubeturbo/app/kubeturbo_builder_test.go
+++ b/cmd/kubeturbo/app/kubeturbo_builder_test.go
@@ -71,3 +71,57 @@ func TestOptionsSet(t *testing.T) {
 	}
 	s.AddFlags(pflag.CommandLine)
 }
+
+func TestUpdateClusterConfig(t *testing.T) {
+	testCases := []struct {
+		name            string
+		configKey       string
+		currentValue    int
+		defaultValue    int
+		getKeyStringVal func(string) string
+		expectedValue   int
+	}{
+		{
+			name:            "EmptyValue",
+			configKey:       "SomeKey",
+			currentValue:    42,
+			defaultValue:    100,
+			getKeyStringVal: func(key string) string { return "" },
+			expectedValue:   100,
+		},
+		{
+			name:            "InvalidValue",
+			configKey:       "AnotherKey",
+			currentValue:    42,
+			defaultValue:    100,
+			getKeyStringVal: func(key string) string { return "invalid" },
+			expectedValue:   100,
+		},
+		{
+			name:            "NegativeValue",
+			configKey:       "YetAnotherKey",
+			currentValue:    42,
+			defaultValue:    100,
+			getKeyStringVal: func(key string) string { return "-50" },
+			expectedValue:   100,
+		},
+		{
+			name:            "ValidValue",
+			configKey:       "ValidKey",
+			currentValue:    42,
+			defaultValue:    100,
+			getKeyStringVal: func(key string) string { return "75" },
+			expectedValue:   75,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			updateClusterConfig(tc.configKey, &tc.currentValue, tc.defaultValue, tc.getKeyStringVal)
+
+			if tc.currentValue != tc.expectedValue {
+				t.Errorf("Expected value: %d, got: %d", tc.expectedValue, tc.currentValue)
+			}
+		})
+	}
+}

--- a/deploy/kubeturbo-operator/config/crd/bases/charts.helm.k8s.io_kubeturboes.yaml
+++ b/deploy/kubeturbo-operator/config/crd/bases/charts.helm.k8s.io_kubeturboes.yaml
@@ -161,6 +161,16 @@ spec:
                    level:
                      description: Define logging level, default is info = 2
                      type: integer
+              nodePoolSize:
+                 description: Optional node pool configuration. Changing this value does not require restart of Kubeturbo but takes about 1 minute to take effect
+                 type: object
+                 properties:
+                   min:
+                     description: minimum number of nodes allowed in the node pool. default is 1
+                     type: integer
+                   max:
+                     description: maximum number of nodes allowed in the node pool, default is 1000
+                     type: integer                    
               args:
                 description: Kubeturbo command line arguments
                 type: object

--- a/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_cr.yaml
+++ b/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_cr.yaml
@@ -43,6 +43,9 @@ spec:
   # Changing this value does not require restart of Kubeturbo but takes about 1 minute to take effect
   # logging:
   #   level: 2
+  # nodePoolSize:
+  #   min: 1
+  #   max: 1000
 
   # Uncomment next lines to specify a repository and image tag for kubeturbo
   #image:

--- a/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
+++ b/deploy/kubeturbo-operator/deploy/crds/charts_v1alpha1_kubeturbo_crd.yaml
@@ -164,6 +164,16 @@ spec:
                    level:
                      description: Define logging level, default is info = 2
                      type: integer
+              nodePoolSize:
+                  description: Optional node pool configuration. Changing this value does not require restart of Kubeturbo but takes about 1 minute to take effect
+                  type: object
+                  properties:
+                    min:
+                      description: minimum number of nodes allowed in the node pool. default is 1
+                      type: integer
+                    max:
+                      description: maximum number of nodes allowed in the node pool, default is 1000
+                      type: integer                    
               args:
                 description: Kubeturbo command line arguments
                 type: object

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/templates/configmap.yaml
@@ -61,4 +61,8 @@ data:
       "logging": {
         "level": {{ .Values.logging.level }}
       }
+      "nodePoolSize": {
+           "min": 1,
+           "max": 1000
+        }
     }

--- a/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
+++ b/deploy/kubeturbo-operator/helm-charts/kubeturbo/values.yaml
@@ -103,6 +103,9 @@ HANodeConfig:
 # Logging level. Changing this value does not require restart of Kubeturbo but takes about 1 minute to take effect
 logging:
   level: 2
+nodePoolSize:
+  min: 1
+  max: 1000  
 
 args:
   # logging level

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -61,4 +61,8 @@ data:
       "logging": {
         "level": {{ .Values.logging.level }}
       }
+      "cluster": {
+        "minNodes": {{ .Values.cluster.minNodes }},
+        "maxNodes": {{ .Values.cluster.maxNodes }}
+      }
     }

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -62,7 +62,7 @@ data:
         "level": {{ .Values.logging.level }}
       }
       "nodePoolSize": {
-        "minNodes": {{ .Values.nodePoolSize.min }},
-        "maxNodes": {{ .Values.nodePoolSize.max }}
+        "min": {{ .Values.nodePoolSize.min }},
+        "max": {{ .Values.nodePoolSize.max }}
       }
     }

--- a/deploy/kubeturbo/templates/configmap.yaml
+++ b/deploy/kubeturbo/templates/configmap.yaml
@@ -61,8 +61,8 @@ data:
       "logging": {
         "level": {{ .Values.logging.level }}
       }
-      "cluster": {
-        "minNodes": {{ .Values.cluster.minNodes }},
-        "maxNodes": {{ .Values.cluster.maxNodes }}
+      "nodePoolSize": {
+        "minNodes": {{ .Values.nodePoolSize.min }},
+        "maxNodes": {{ .Values.nodePoolSize.max }}
       }
     }

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -94,11 +94,11 @@ HANodeConfig:
 logging:
   level: 2
 # Define the default values for your cluster configuration
-# `minNodes`: This parameter defines the minimum number of nodes allowed in the node pool. 
+# `nodePoolSize.min`: This parameter defines the minimum number of nodes allowed in the node pool. 
 #             It ensures that the node pool remains resilient and can continue its normal operations even if some nodes become 
 #             unavailable due to hardware failures or other issues. The minimum number of nodes should be set based on the desired 
 #             level of resiliency and the specific requirements of the applications running in the node pool.
-# `maxNodes`: This parameter defines the maximum number of nodes allowed in the node pool. It prevents the cluster from growing 
+# `nodePoolSize.max`: This parameter defines the maximum number of nodes allowed in the node pool. It prevents the cluster from growing 
 #             uncontrollably and helps manage the available resources efficiently. The maximum number of nodes should be set based 
 #             on the available resources in the environment, such as IP addresses, CPU, memory, storage capacity, and networking bandwidth.
 #             It should also consider the application requirements and performance characteristics of the workloads running on the node pool.

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -89,9 +89,22 @@ HANodeConfig:
 #   GitopsApps: false (default: true)
 #   GoMemLimit: true (default: false)
 
-# Logging level. Changing this value does not require restart of Kubeturbo but takes about 1 minute to take effect
+# Dynamic configuration Changing this value does not require restart of Kubeturbo but takes about 1 minute to take effect
+# logging level
 logging:
   level: 2
+# Define the default values for your cluster configuration
+# `minNodes`: This parameter defines the minimum number of nodes allowed in the cluster. 
+#             It ensures that the cluster remains resilient and can continue its normal operations even if some nodes become 
+#             unavailable due to hardware failures or other issues. The minimum number of nodes should be set based on the desired 
+#             level of resiliency and the specific requirements of the applications running in the cluster.
+# `maxNodes`: This parameter defines the maximum number of nodes allowed in the cluster. It prevents the cluster from growing 
+#             uncontrollably and helps manage the available resources efficiently. The maximum number of nodes should be set based 
+#             on the available resources in the environment, such as IP addresses, CPU, memory, storage capacity, and networking bandwidth.
+#             It should also consider the application requirements and performance characteristics of the workloads running on the cluster.
+cluster:
+  minNodes: 1
+  maxNodes: 1000
 
 args:
   # logging level

--- a/deploy/kubeturbo/values.yaml
+++ b/deploy/kubeturbo/values.yaml
@@ -94,17 +94,17 @@ HANodeConfig:
 logging:
   level: 2
 # Define the default values for your cluster configuration
-# `minNodes`: This parameter defines the minimum number of nodes allowed in the cluster. 
-#             It ensures that the cluster remains resilient and can continue its normal operations even if some nodes become 
+# `minNodes`: This parameter defines the minimum number of nodes allowed in the node pool. 
+#             It ensures that the node pool remains resilient and can continue its normal operations even if some nodes become 
 #             unavailable due to hardware failures or other issues. The minimum number of nodes should be set based on the desired 
-#             level of resiliency and the specific requirements of the applications running in the cluster.
-# `maxNodes`: This parameter defines the maximum number of nodes allowed in the cluster. It prevents the cluster from growing 
+#             level of resiliency and the specific requirements of the applications running in the node pool.
+# `maxNodes`: This parameter defines the maximum number of nodes allowed in the node pool. It prevents the cluster from growing 
 #             uncontrollably and helps manage the available resources efficiently. The maximum number of nodes should be set based 
 #             on the available resources in the environment, such as IP addresses, CPU, memory, storage capacity, and networking bandwidth.
-#             It should also consider the application requirements and performance characteristics of the workloads running on the cluster.
-cluster:
-  minNodes: 1
-  maxNodes: 1000
+#             It should also consider the application requirements and performance characteristics of the workloads running on the node pool.
+nodePoolSize:
+  min: 1
+  max: 1000
 
 args:
   # logging level

--- a/deploy/kubeturbo_yamls/step4_turbo_configMap_sample.yaml
+++ b/deploy/kubeturbo_yamls/step4_turbo_configMap_sample.yaml
@@ -61,4 +61,8 @@ data:
         "logging": {
            "level": 2
         }
+        "cluster": {
+           "minNodes": 3,
+           "maxNodes": 10
+        }
     }

--- a/deploy/kubeturbo_yamls/step4_turbo_configMap_sample.yaml
+++ b/deploy/kubeturbo_yamls/step4_turbo_configMap_sample.yaml
@@ -61,8 +61,8 @@ data:
         "logging": {
            "level": 2
         }
-        "cluster": {
-           "minNodes": 1,
-           "maxNodes": 1000
+        "nodePoolSize": {
+           "min": 1,
+           "max": 1000
         }
     }

--- a/deploy/kubeturbo_yamls/step4_turbo_configMap_sample.yaml
+++ b/deploy/kubeturbo_yamls/step4_turbo_configMap_sample.yaml
@@ -62,7 +62,7 @@ data:
            "level": 2
         }
         "cluster": {
-           "minNodes": 3,
-           "maxNodes": 10
+           "minNodes": 1,
+           "maxNodes": 1000
         }
     }

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -47,10 +47,8 @@ const (
 	DefaultClusterMinNodes = 1
 	// default value of the maximum number of nodes allowed in the cluster.
 	DefaultClusterMaxNodes = 1000
-
 	// configuration key for the minimum number of nodes in the cluster in the ConfigMap file turbo-autoreload.config.
 	MinNodesConfigKey = "cluster.minNodes"
-
 	// configuration key for the maximum number of nodes in the cluster in the ConfigMap file turbo-autoreload.config.
 	MaxNodesConfigKey = "cluster.maxNodes"
 )

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -41,6 +41,14 @@ const (
 	clusterAPIGroupVersion = "machine.openshift.io/v1beta1"
 )
 
+// Exported constants
+const (
+	// default value of the minimum number of nodes allowed in the cluster.
+	DefaultClusterMinNodes = 1
+	// default value of the maximum number of nodes allowed in the cluster.
+	DefaultClusterMaxNodes = 1000
+)
+
 var (
 	labelSelectEverything = labels.Everything().String()
 	fieldSelectEverything = fields.Everything().String()

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -47,6 +47,12 @@ const (
 	DefaultClusterMinNodes = 1
 	// default value of the maximum number of nodes allowed in the cluster.
 	DefaultClusterMaxNodes = 1000
+
+	// configuration key for the minimum number of nodes in the cluster in the ConfigMap file turbo-autoreload.config.
+	MinNodesConfigKey = "cluster.minNodes"
+
+	// configuration key for the maximum number of nodes in the cluster in the ConfigMap file turbo-autoreload.config.
+	MaxNodesConfigKey = "cluster.maxNodes"
 )
 
 var (

--- a/pkg/cluster/cluster_info_scraper.go
+++ b/pkg/cluster/cluster_info_scraper.go
@@ -43,14 +43,14 @@ const (
 
 // Exported constants
 const (
-	// default value of the minimum number of nodes allowed in the cluster.
-	DefaultClusterMinNodes = 1
-	// default value of the maximum number of nodes allowed in the cluster.
-	DefaultClusterMaxNodes = 1000
-	// configuration key for the minimum number of nodes in the cluster in the ConfigMap file turbo-autoreload.config.
-	MinNodesConfigKey = "cluster.minNodes"
-	// configuration key for the maximum number of nodes in the cluster in the ConfigMap file turbo-autoreload.config.
-	MaxNodesConfigKey = "cluster.maxNodes"
+	// default value of the minimum number of nodes allowed in the node pool.
+	DefaultMinNodePoolSize = 1
+	// default value of the maximum number of nodes allowed in the node pool.
+	DefaultMaxNodePoolSize = 1000
+	// configuration key for the minimum number of nodes in the node pool in the ConfigMap file turbo-autoreload.config.
+	MinNodesConfigKey = "nodePoolSize.min"
+	// configuration key for the maximum number of nodes in the node pool in the ConfigMap file turbo-autoreload.config.
+	MaxNodesConfigKey = "nodePoolSize.max"
 )
 
 var (


### PR DESCRIPTION
# Intent

_set the min/max node information in the configmap of kubeturbo to be auto loaded for kubeturbo_

# Background
For customers looking to gain insights into cluster capacity for running their workloads, we offer provision and suspend actions as a means to understand real-time demand. By utilizing our analysis, customers can accurately determine the number of nodes required, as opposed to relying solely on thresholds used with cluster autoscalers. Our customers seek to align these actions with their specific definitions of minimum and maximum node numbers, and they require Turbo to discover these definitions and allow them to define policies regarding node suspension and provisioning.

wiki: https://ibm-turbo-wiki.fyre.ibm.com/en/CON/AE/Advanced-Engineering/Cloud-Native-Control/new-page

# Testing

Edit config map yaml with different cluster minNodes and maxNodes bvalues and apply the change with command 
vi configMap.yaml
oc -n turbo apply -f configMap.yaml

oc -n turbo  logs -f kubeturbo-c9b7c9f4c-8tbks  | grep -i "Cluster clus" -A1 -B1
```
********MinNodes = 10, maxNodes not specified
I0808 02:52:24.146801       1 kubeturbo_builder.go:1038] Start watching the autoreload config file /etc/kubeturbo/turbo-autoreload.config
I0808 02:52:24.146823       1 kubeturbo_builder.go:1072] Cluster cluster.minNodes  current value is 1
I0808 02:52:24.148957       1 kubeturbo_builder.go:1088] Cluster cluster.minNodes changed from 1 to 10
I0808 02:52:24.148966       1 kubeturbo_builder.go:1072] Cluster cluster.maxNodes  current value is 1000
I0808 02:52:24.148973       1 kubeturbo_builder.go:1076] Empty value for cluster.maxNodes in the configuration, using default value 1000
--

********MinNodes =15, maxNodes= 180
I0808 02:52:38.300563       1 api_client.go:320] Successfully updated target via API service.
I0808 02:57:42.787640       1 kubeturbo_builder.go:1072] Cluster cluster.minNodes  current value is 10
I0808 02:57:42.787665       1 kubeturbo_builder.go:1088] Cluster cluster.minNodes changed from 10 to 15
I0808 02:57:42.787670       1 kubeturbo_builder.go:1072] Cluster cluster.maxNodes  current value is 1000
I0808 02:57:42.787676       1 kubeturbo_builder.go:1088] Cluster cluster.maxNodes changed from 1000 to 180
I0808 02:58:41.510006       1 remote_mediation_client.go:216] [handleServerMessages][ServerRequestEndpoint] : received message with request type Discovery.
--

********MinNodes =-15, maxNodes= 185
I0808 02:59:00.796572       1 remote_mediation_client.go:363] Discovery has finished for 4217:FULL
I0808 02:59:11.622246       1 kubeturbo_builder.go:1072] Cluster cluster.minNodes  current value is 15
E0808 02:59:11.622273       1 kubeturbo_builder.go:1083] Invalid cluster.minNodes value: -15 specified, using default value 1
I0808 02:59:11.622493       1 kubeturbo_builder.go:1072] Cluster cluster.maxNodes  current value is 180
I0808 02:59:11.622516       1 kubeturbo_builder.go:1088] Cluster cluster.maxNodes changed from 180 to 185


```
# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [X] Full build with unit tests and fmt and vet checks
    - [X] Unit tests added / updated
    - [X] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [X] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [X] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

_(@ mention any `review/...` groups or people that should be aware of this merge request)_

