### PR TITLE
[TRB-45569]:Add resource spec for cpufreqgetter job

### DIFF
--- a/pkg/kubeclient/cpufrequency.go
+++ b/pkg/kubeclient/cpufrequency.go
@@ -17,6 +17,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -30,7 +31,9 @@ const (
 	defaultCpuFreq        = float64(2600) //MHz
 	// cpufreq job by default is created every 10 mins
 	// if there has been failures, a backoff delay would be added to retrials
-	defaultInitialDelay = 10 * time.Minute
+	defaultInitialDelay   = 10 * time.Minute
+	defaultCpuResQuantity = "10m"
+	defaultMemResQuantity = "50Mi"
 )
 
 var (
@@ -297,6 +300,16 @@ func (n *NodeCpuFrequencyGetter) getCpuFreqJobDefinition(nodeName string) *batch
 							Name:            "cpufreq",
 							Image:           n.cpuFreqGetterImage,
 							ImagePullPolicy: "IfNotPresent",
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse(defaultCpuResQuantity),
+									corev1.ResourceMemory: resource.MustParse(defaultMemResQuantity),
+								},
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse(defaultCpuResQuantity),
+									corev1.ResourceMemory: resource.MustParse(defaultMemResQuantity),
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
# Intent

Specify the resource spec for the cpufreqgetter job

# Background

https://jsw.ibm.com/browse/TRB-45569

# Testing

## Build the custom image and check the job description when doing the discovery
```
apiVersion: v1
kind: Pod
metadata:
  labels:
    controller-uid: b81a9848-0ec9-4e22-9652-cce07e79dfc0
    job-name: kubeturbo-cpufreq-1euecu32aokif
  name: kubeturbo-cpufreq-1euecu32aokif-glzsm
  namespace: default
  ownerReferences:
  - apiVersion: batch/v1
    blockOwnerDeletion: true
    controller: true
    kind: Job
    name: kubeturbo-cpufreq-1euecu32aokif
    uid: b81a9848-0ec9-4e22-9652-cce07e79dfc0
  resourceVersion: "139919916"
  uid: ca835cfd-54cc-4dc9-b02f-20aeff791ac1
spec:
  containers:
  - image: icr.io/cpopen/turbonomic/cpufreqgetter
    imagePullPolicy: IfNotPresent
    name: cpufreq
    resources:    
      limits:
        cpu: 10m    <------------- HERE
        memory: 30Mi
      requests:
        cpu: 10m
        memory: 30Mi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-v5brp
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  imagePullSecrets:
  - {}
  nodeName: master2.ocp410kev.cp.fyre.ibm.com
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Never
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  - effect: NoSchedule
    key: node.kubernetes.io/memory-pressure
    operator: Exists
  volumes:
  - name: kube-api-access-v5brp
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
      - configMap:
          items:
          - key: service-ca.crt
            path: service-ca.crt
          name: openshift-service-ca.crt
status:
...
```

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [ ] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [x] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

_(@ mention any `review/...` groups or people that should be aware of this merge request)_

