### PR TITLE
[TRB-44836] Fix missing stitching metadata for SEGMENTATION commodities

### DIFF
--- a/pkg/discovery/stitching/stitching_manager.go
+++ b/pkg/discovery/stitching/stitching_manager.go
@@ -230,7 +230,8 @@ func (s *StitchingManager) GenerateReconciliationMetaData() (*proto.EntityDTO_Re
 		PatchSellingWithProperty(proto.CommodityDTO_VCPU_REQUEST_QUOTA, usedAndCapacityPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_VMEM_REQUEST_QUOTA, usedAndCapacityPropertyNames).
 		PatchSellingWithProperty(proto.CommodityDTO_NUMBER_CONSUMERS, usedAndCapacityPropertyNames).
-		PatchSellingWithProperty(proto.CommodityDTO_VSTORAGE, usedAndCapacityPropertyNames)
+		PatchSellingWithProperty(proto.CommodityDTO_VSTORAGE, usedAndCapacityPropertyNames).
+		PatchSellingWithProperty(proto.CommodityDTO_SEGMENTATION, capacityOnlyPropertyNames)
 	meta := replacementEntityMetaDataBuilder.Build()
 	return meta, nil
 }

--- a/pkg/registration/supply_chain_factory.go
+++ b/pkg/registration/supply_chain_factory.go
@@ -30,6 +30,7 @@ var (
 	numberReplicasType     = proto.CommodityDTO_NUMBER_REPLICAS
 	taintType              = proto.CommodityDTO_TAINT
 	labelType              = proto.CommodityDTO_LABEL
+	segmentationType       = proto.CommodityDTO_SEGMENTATION
 
 	fakeKey = "fake"
 
@@ -69,11 +70,12 @@ var (
 	vMemRequestQuotaTemplateCommWithKey = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &vMemRequestQuotaType}
 	storageAmountTemplateCommWithKey    = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &storageAmountType}
 	// Access commodities
-	vmpmAccessTemplateComm         = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &vmPMAccessType}
-	applicationTemplateCommWithKey = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &appCommType}
-	clusterTemplateCommWithKey     = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &clusterType}
-	taintTemplateCommWithKey       = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &taintType}
-	labelTemplateCommWithKey       = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &labelType}
+	vmpmAccessTemplateComm          = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &vmPMAccessType}
+	applicationTemplateCommWithKey  = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &appCommType}
+	clusterTemplateCommWithKey      = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &clusterType}
+	taintTemplateCommWithKey        = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &taintType}
+	labelTemplateCommWithKey        = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &labelType}
+	segmentationTemplateCommWithKey = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &segmentationType}
 
 	// Resold TemplateCommodity with key
 	vCpuLimitQuotaTemplateCommWithKeyResold   = &proto.TemplateCommodity{Key: &fakeKey, CommodityType: &vCpuLimitQuotaType, IsResold: &commIsResold}
@@ -223,7 +225,7 @@ func (f *SupplyChainFactory) createSupplyChain() ([]*proto.TemplateDTO, error) {
 
 // Stitching metadata required for stitching with XL
 func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntityMetadata, error) {
-	fieldsCapactiy := map[string][]string{
+	fieldsCapacity := map[string][]string{
 		builder.PropertyCapacity: {},
 	}
 	fieldsUsedCapacity := map[string][]string{
@@ -260,10 +262,10 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 	boughtCommTypes := []proto.CommodityDTO_CommodityType{proto.CommodityDTO_CLUSTER}
 
 	return mergedEntityMetadataBuilder.
-		PatchSoldMetadata(proto.CommodityDTO_CLUSTER, fieldsCapactiy).
-		PatchSoldMetadata(proto.CommodityDTO_VMPM_ACCESS, fieldsCapactiy).
-		PatchSoldMetadata(proto.CommodityDTO_TAINT, fieldsCapactiy).
-		PatchSoldMetadata(proto.CommodityDTO_LABEL, fieldsCapactiy).
+		PatchSoldMetadata(proto.CommodityDTO_CLUSTER, fieldsCapacity).
+		PatchSoldMetadata(proto.CommodityDTO_VMPM_ACCESS, fieldsCapacity).
+		PatchSoldMetadata(proto.CommodityDTO_TAINT, fieldsCapacity).
+		PatchSoldMetadata(proto.CommodityDTO_LABEL, fieldsCapacity).
 		PatchSoldMetadata(proto.CommodityDTO_VCPU, fieldsUsedCapacityPeak).
 		PatchSoldMetadata(proto.CommodityDTO_VMEM, fieldsUsedCapacityPeak).
 		PatchSoldMetadata(proto.CommodityDTO_VCPU_REQUEST, fieldsUsedCapacity).
@@ -274,6 +276,7 @@ func (f *SupplyChainFactory) buildNodeMergedEntityMetadata() (*proto.MergedEntit
 		PatchSoldMetadata(proto.CommodityDTO_VMEM_REQUEST_QUOTA, fieldsUsedCapacity).
 		PatchSoldMetadata(proto.CommodityDTO_NUMBER_CONSUMERS, fieldsUsedCapacity).
 		PatchSoldMetadata(proto.CommodityDTO_VSTORAGE, fieldsUsedCapacity).
+		PatchSoldMetadata(proto.CommodityDTO_SEGMENTATION, fieldsCapacity).
 		PatchBoughtList(proto.EntityDTO_CONTAINER_PLATFORM_CLUSTER, boughtCommTypes).
 		Build()
 }
@@ -293,6 +296,7 @@ func (f *SupplyChainFactory) buildNodeSupplyBuilder() (*proto.TemplateDTO, error
 		Sells(vStorageTemplateComm).           // sells to Pods
 		Sells(taintTemplateCommWithKey).
 		Sells(labelTemplateCommWithKey).
+		Sells(segmentationTemplateCommWithKey).
 		Provider(proto.EntityDTO_CONTAINER_PLATFORM_CLUSTER, proto.Provider_HOSTING).
 		Buys(clusterTemplateCommWithKey) // buys from cluster
 	// also sells Cluster to Pods
@@ -372,6 +376,7 @@ func (f *SupplyChainFactory) buildPodSupplyBuilder() (*proto.TemplateDTO, error)
 		Buys(vStorageTemplateComm).
 		Buys(taintTemplateCommWithKey).
 		Buys(labelTemplateCommWithKey).
+		Buys(segmentationTemplateCommWithKey).
 		ProviderOpt(proto.EntityDTO_WORKLOAD_CONTROLLER, proto.Provider_HOSTING, &isProviderOptional).
 		Buys(vCpuLimitQuotaTemplateCommWithKey).
 		Buys(vMemLimitQuotaTemplateCommWithKey).


### PR DESCRIPTION
# Intent
Fix https://jsw.ibm.com/browse/TRB-44836

# Background

Stitching metadata to ensure the segmentation commodities are patches on to the primary VM entities from proxy k8s VM entities was missing

# Testing

No reconfigure actions generated post the fix
<img width="1791" alt="image" src="https://github.com/turbonomic/kubeturbo/assets/10027921/27d19dd8-59e9-48de-af19-04678818cce5">

<img width="1791" alt="image" src="https://github.com/turbonomic/kubeturbo/assets/10027921/c673ac16-291b-4660-885c-9a22964e8c9b">


# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [x] Full build with unit tests and fmt and vet checks
    - [ ] ~~Unit tests added / updated~~
    - [x] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] ~~Integration tests added / updated~~
    - [x] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] ~~Developer wiki updated (and linked to this description)~~
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

@amd-ibm @kevinwangcn @andreiastra 

