### PR TITLE
[TRB-46576]: Missing cluster role permissions for secrets

### DIFF
--- a/deploy/kubeturbo-operator/deploy/kubeturbo-operator-cluster-role.yaml
+++ b/deploy/kubeturbo-operator/deploy/kubeturbo-operator-cluster-role.yaml
@@ -13,9 +13,14 @@ rules:
       - nodes
       - pods
       - configmaps
+      - endpoints
+      - events
       - deployments
+      - persistentvolumeclaims
       - replicasets
       - replicationcontrollers
+      - services
+      - secrets
       - serviceaccounts
   - verbs:
       - get
@@ -27,16 +32,16 @@ rules:
       - extensions
       - policy
     resources:
-      - services
-      - endpoints
-      - namespaces
-      - limitranges
-      - resourcequotas
       - daemonsets
+      - endpoints
+      - limitranges
+      - namespaces
       - persistentvolumes
       - persistentvolumeclaims
       - poddisruptionbudget
-      - secrets
+      - resourcequotas
+      - services
+      - statefulsets
   - verbs:
       - get
     apiGroups:

--- a/deploy/kubeturbo-operator/deploy/kubeturbo-operator-cluster-role.yaml
+++ b/deploy/kubeturbo-operator/deploy/kubeturbo-operator-cluster-role.yaml
@@ -36,6 +36,7 @@ rules:
       - persistentvolumes
       - persistentvolumeclaims
       - poddisruptionbudget
+      - secrets
   - verbs:
       - get
     apiGroups:

--- a/deploy/kubeturbo-operator/deploy/operator.yaml
+++ b/deploy/kubeturbo-operator/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: kubeturbo-operator
           # Replace this with the built image name
-          image: icr.io/cpopen/kubeturbo-operator:8.9.2
+          image: icr.io/cpopen/kubeturbo-operator:8.10.0
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/kubeturbo-operator/deploy/role_binding.yaml
+++ b/deploy/kubeturbo-operator/deploy/role_binding.yaml
@@ -5,8 +5,9 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: kubeturbo-operator
-  namespace: turbo
+  # Make sure that it matches your namespace
+  namespace: kubeturbo
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: kubeturbo-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/kubeturbo-operator/deploy/role_binding.yaml
+++ b/deploy/kubeturbo-operator/deploy/role_binding.yaml
@@ -6,7 +6,7 @@ subjects:
 - kind: ServiceAccount
   name: kubeturbo-operator
   # Make sure that it matches your namespace
-  namespace: kubeturbo
+  namespace: turbo
 roleRef:
   kind: ClusterRole
   name: kubeturbo-operator


### PR DESCRIPTION
**Problem**

When deploying Kubeturbo Operator, got error
```
User \"system:serviceaccount:tmtrflaavzwctbo-y-ib-x-001:kubeturbo-operator\" cannot list resource \"secrets\" in API group \"\"
```

**Fix**

Made `kubeturbo/deploy/kubeturbo-operator/deploy/kubeturbo-operator-cluster-role.yaml` permissions to match the ones in `kubeturbo/deploy/kubeturbo-operator/config/crd/bases/charts.helm.k8s.io_kubeturboes.yaml`

I used `permissions`, not `cluster-permissions`

**Testing**

I see that the permissions in 

https://github.com/turbonomic/kubeturbo/blob/master/deploy/kubeturbo-operator/bundle-template/template/kubeturbo-certified.clusterserviceversion.yaml 

are exactly the same as in 

https://github.com/redhat-openshift-ecosystem/certified-operators/blob/main/operators/kubeturbo-certified/8.9.7/manifests/kubeturbo-certified.clusterserviceversion.yaml

I was able to deploy Kubeturbo Operator and to deploy Kubeturbo:

```
$ k logs kubeturbo-operator-5bc58945b7-m7pc7 | more
{"level":"info","ts":1693326738.7495341,"logger":"cmd","msg":"Version","Go Version":"go1.19.5","GOOS":"linux","GOARCH":"amd64","helm-operator":"v1.25.4","commit":"f0a975ce1a61175429fb171a7c509a43420d83b6"}
{"level":"info","ts":1693326738.7499502,"logger":"cmd","msg":"Environment variable OPERATOR_NAME has been deprecated, use --leader-election-id instead."}
{"level":"info","ts":1693326738.7499988,"logger":"cmd","msg":"Watching single namespace.","Namespace":"turbo"}
I0829 16:32:19.801364       1 request.go:682] Waited for 1.041722431s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/performance.openshift.io/v1alpha1?timeout=32s
{"level":"info","ts":1693326741.104778,"logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":":8080"}
{"level":"info","ts":1693326741.1057541,"logger":"helm.controller","msg":"Watching resource","apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Kubeturbo","namespace":"turbo","reconcilePeriod":"1m0s"}
{"level":"info","ts":1693326741.106251,"msg":"Starting server","path":"/metrics","kind":"metrics","addr":"[::]:8080"}
{"level":"info","ts":1693326741.1063101,"msg":"Starting EventSource","controller":"kubeturbo-controller","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":1693326741.1063447,"msg":"Starting Controller","controller":"kubeturbo-controller"}
{"level":"info","ts":1693326741.1063437,"msg":"Starting server","kind":"health probe","addr":"[::]:8081"}
{"level":"info","ts":1693326741.2074893,"msg":"Starting workers","controller":"kubeturbo-controller","worker count":8}
W0829 16:32:24.019350       1 warnings.go:70] would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "kubeturbo" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "kubeturbo" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "kubeturbo" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "kubeturbo" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
{"level":"info","ts":1693326744.0423706,"msg":"Starting EventSource","controller":"kubeturbo-controller","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":1693326744.0424378,"logger":"helm.controller","msg":"Watching dependent resource","ownerApiVersion":"charts.helm.k8s.io/v1alpha1","ownerKind":"Kubeturbo","apiVersion":"apps/v1","kind":"Deployment"}
{"level":"info","ts":1693326744.0425842,"msg":"Starting EventSource","controller":"kubeturbo-controller","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":1693326744.0426064,"logger":"helm.controller","msg":"Watching dependent resource","ownerApiVersion":"charts.helm.k8s.io/v1alpha1","ownerKind":"Kubeturbo","apiVersion":"v1","kind":"ServiceAccount"}
{"level":"info","ts":1693326744.0430396,"msg":"Starting EventSource","controller":"kubeturbo-controller","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":1693326744.0431156,"logger":"helm.controller","msg":"Watching dependent resource","ownerApiVersion":"charts.helm.k8s.io/v1alpha1","ownerKind":"Kubeturbo","apiVersion":"v1","kind":"ConfigMap"}
{"level":"info","ts":1693326744.0436645,"msg":"Starting EventSource","controller":"kubeturbo-controller","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":1693326744.043691,"logger":"helm.controller","msg":"Watching dependent resource","ownerApiVersion":"charts.helm.k8s.io/v1alpha1","ownerKind":"Kubeturbo","apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole"}
{"level":"info","ts":1693326744.0439076,"msg":"Starting EventSource","controller":"kubeturbo-controller","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":1693326744.0439491,"logger":"helm.controller","msg":"Watching dependent resource","ownerApiVersion":"charts.helm.k8s.io/v1alpha1","ownerKind":"Kubeturbo","apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRoleBinding"}
{"level":"info","ts":1693326744.043959,"logger":"helm.controller","msg":"Installed release","namespace":"turbo","name":"astra-kubeturbo","apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Kubeturbo","release":"astra-kubeturbo"}
{"level":"info","ts":1693326744.0508182,"logger":"KubeAPIWarningLogger","msg":"unknown field \"status\""}
{"level":"info","ts":1693326746.860259,"logger":"helm.controller","msg":"Reconciled release","namespace":"turbo","name":"astra-kubeturbo","apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Kubeturbo","release":"astra-kubeturbo"}
{"level":"info","ts":1693326749.6356926,"logger":"helm.controller","msg":"Reconciled release","namespace":"turbo","name":"astra-kubeturbo","apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Kubeturbo","release":"astra-kubeturbo"}
```

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [ ] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [x] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

_(@ mention any `review/...` groups or people that should be aware of this merge request)_

