### PR TITLE
[TRB-46798]: Removed coveralls integration from travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,11 @@ go:
 go_import_path: github.com/turbonomic/kubeturbo
 
 before_install:
-  - go install -v github.com/mattn/goveralls@HEAD
   - go mod vendor
  
 script:
   - make fmtcheck
   - make vet
-  - $HOME/gopath/bin/goveralls -v -race -service=travis-ci -package='github.com/turbonomic/kubeturbo/cmd/kubeturbo github.com/turbonomic/kubeturbo/cmd/kubeturbo/app github.com/turbonomic/kubeturbo/pkg github.com/turbonomic/kubeturbo/pkg/action github.com/turbonomic/kubeturbo/pkg/action/executor github.com/turbonomic/kubeturbo/pkg/action/util github.com/turbonomic/kubeturbo/pkg/cluster github.com/turbonomic/kubeturbo/pkg/discovery github.com/turbonomic/kubeturbo/pkg/discovery/configs github.com/turbonomic/kubeturbo/pkg/discovery/detectors github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory github.com/turbonomic/kubeturbo/pkg/discovery/dtofactory/property github.com/turbonomic/kubeturbo/pkg/discovery/metrics github.com/turbonomic/kubeturbo/pkg/discovery/monitoring github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/kubelet github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/master github.com/turbonomic/kubeturbo/pkg/discovery/monitoring/types github.com/turbonomic/kubeturbo/pkg/discovery/processor github.com/turbonomic/kubeturbo/pkg/discovery/repository github.com/turbonomic/kubeturbo/pkg/discovery/stitching github.com/turbonomic/kubeturbo/pkg/discovery/task github.com/turbonomic/kubeturbo/pkg/discovery/util github.com/turbonomic/kubeturbo/pkg/discovery/worker github.com/turbonomic/kubeturbo/pkg/discovery/worker/aggregation github.com/turbonomic/kubeturbo/pkg/discovery/worker/compliance github.com/turbonomic/kubeturbo/pkg/kubeclient github.com/turbonomic/kubeturbo/pkg/registration github.com/turbonomic/kubeturbo/pkg/resourcemapping github.com/turbonomic/kubeturbo/pkg/turbostore github.com/turbonomic/kubeturbo/pkg/util github.com/turbonomic/kubeturbo/pkg/discovery/worker/k8sappcomponents'
   - ./hack/download_test_binaries.sh
   - ./hack/create_kind_cluster.sh
   - ./hack/deploy_istio.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 script:
   - make fmtcheck
   - make vet
+  - make test
   - ./hack/download_test_binaries.sh
   - ./hack/create_kind_cluster.sh
   - ./hack/deploy_istio.sh


### PR DESCRIPTION
# Intent

Remove coveralls integrations from Travis builds.

# Background

Coveralls is free for public repositories, but requires licenses for private/enterprise repos. Since we are moving to IBM enterprise Git, we need to remove this integration. We should be able to capture code coverage using SonarQube, or some other approved, tool in the future. 

# Testing

N/A - will test enterprise build after merging.

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [ ] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [ ] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

_(@ mention any `review/...` groups or people that should be aware of this merge request)_

