### PR TITLE
[TRB-46371] Support kubeturbo SLO scaling via ORM v2

### DIFF
--- a/pkg/action/executor/horizontal_scaler.go
+++ b/pkg/action/executor/horizontal_scaler.go
@@ -38,7 +38,7 @@ func (h *HorizontalScaler) Execute(input *TurboActionExecutorInput) (*TurboActio
 	if pod != nil && actionType != proto.ActionItemDTO_HORIZONTAL_SCALE {
 		targetFullName = util.BuildIdentifier(pod.Namespace, pod.Name)
 		controllerUpdater, updaterErr = newK8sControllerUpdaterViaPod(h.clusterScraper,
-			pod, h.ormClient, h.gitConfig, h.k8sClusterId)
+			pod, h.ormClient, h.gitConfig, h.k8sClusterId, proto.ActionItemDTO_HORIZONTAL_SCALE)
 	} else {
 		namespace, controllerName, kind, err := getWorkloadControllerInfo(actionItem.GetTargetSE())
 		if err != nil {
@@ -47,7 +47,7 @@ func (h *HorizontalScaler) Execute(input *TurboActionExecutorInput) (*TurboActio
 		}
 		targetFullName = util.BuildIdentifier(namespace, controllerName)
 		controllerUpdater, updaterErr = newK8sControllerUpdater(h.clusterScraper, h.ormClient, kind, controllerName,
-			"", namespace, h.k8sClusterId, nil, h.gitConfig)
+			"", namespace, h.k8sClusterId, nil, h.gitConfig, proto.ActionItemDTO_HORIZONTAL_SCALE)
 	}
 
 	if updaterErr != nil {

--- a/pkg/action/executor/resize_container_util.go
+++ b/pkg/action/executor/resize_container_util.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"math"
 
 	"github.com/golang/glog"
@@ -184,7 +185,8 @@ func resizeControllerContainer(clusterScraper *cluster.ClusterScraper, pod *k8sa
 	ormClientManager *resourcemapping.ORMClientManager,
 	gitConfig gitops.GitConfig, clusterId string) error {
 	// prepare controllerUpdater
-	controllerUpdater, err := newK8sControllerUpdaterViaPod(clusterScraper, pod, ormClientManager, gitConfig, clusterId)
+	controllerUpdater, err := newK8sControllerUpdaterViaPod(
+		clusterScraper, pod, ormClientManager, gitConfig, clusterId, proto.ActionItemDTO_RIGHT_SIZE)
 	if err != nil {
 		glog.Errorf("Failed to create controllerUpdater: %v", err)
 		return err

--- a/pkg/action/executor/workload_controller_resizer.go
+++ b/pkg/action/executor/workload_controller_resizer.go
@@ -263,7 +263,7 @@ func resizeWorkloadController(clusterScraper *cluster.ClusterScraper, ormClient 
 	gitConfig gitops.GitConfig) error {
 	// prepare controllerUpdater
 	controllerUpdater, err := newK8sControllerUpdater(clusterScraper, ormClient, kind, controllerName,
-		"", namespace, clusterId, managerApp, gitConfig)
+		"", namespace, clusterId, managerApp, gitConfig, proto.ActionItemDTO_RIGHT_SIZE)
 	if err != nil {
 		glog.Errorf("Failed to create controllerUpdater: %v", err)
 		return err

--- a/pkg/resourcemapping/orm_client_manager.go
+++ b/pkg/resourcemapping/orm_client_manager.go
@@ -4,62 +4,63 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	discoveryutil "github.com/turbonomic/kubeturbo/pkg/discovery/util"
-	ormv2 "github.com/turbonomic/kubeturbo/pkg/resourcemapping/v2"
-	devopsv1alpha1 "github.com/turbonomic/orm/api/v1alpha1"
+	"github.com/turbonomic/orm/api/v1alpha1"
 	"github.com/turbonomic/orm/kubernetes"
-	ormutils "github.com/turbonomic/orm/utils"
-	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	"github.com/turbonomic/orm/utils"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
-	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/rest"
+
+	"github.com/turbonomic/kubeturbo/pkg/discovery/util"
+	v2 "github.com/turbonomic/kubeturbo/pkg/resourcemapping/v2"
 )
 
 // ORMClientManager defines top level object that will connect to the Kubernetes cluster
-// to provide an interface to the kubeturbo ORM v1 and v2 resources.
+// to provide an interface to the ORM v1 and v2 resources.
 type ORMClientManager struct {
 	// Legacy v1 ORM client
 	*ORMClient
 	// v2 ORM client
-	*ormv2.ORMv2Client
+	*v2.ORMv2Client
 }
 
-// New instance for ORMClientManager.
+// NewORMClientManager creates new instance for ORMClientManager.
 // dynamicClient is used to obtain ORM v1 resources.
 // controller runtime client is used to obtain ORM v2 resources.
-func NewORMClientManager(dynamicClient dynamic.Interface, kubeConfig *restclient.Config) *ORMClientManager {
+func NewORMClientManager(dynamicClient dynamic.Interface, kubeConfig *rest.Config) *ORMClientManager {
 
 	// ORM v1 client
 	// TODO: Replace apiExtClient with runtimeClient
-	apiExtClient, err := apiextclient.NewForConfig(kubeConfig)
+	apiExtClient, err := v1.NewForConfig(kubeConfig)
 	if err != nil {
 		glog.Fatalf("Failed to generate apiExtensions client for kubernetes target: %v", err)
 	}
-	ormv1Client := NewORMClient(dynamicClient, apiExtClient)
+	v1Client := NewORMClient(dynamicClient, apiExtClient)
 
 	// ORM v2 client
-	ormv2Client, err := ormv2.NewORMv2Client(kubeConfig)
+	v2Client, err := v2.NewORMv2Client(kubeConfig)
 	if err != nil {
 		glog.Fatalf("Failed to create ORM v2 client: %v", err)
 	}
 
 	return &ORMClientManager{
-		ormv1Client,
-		ormv2Client,
+		v1Client,
+		v2Client,
 	}
 }
 
-// Discover and cache ORMs v1 and v2.
-func (manager *ORMClientManager) DiscoverORMs() {
+// DiscoverORMs discovers and caches ORMs v1 and v2.
+func (ormClientMgr *ORMClientManager) DiscoverORMs() {
 	// ORM v1 are saved as a map in ORMClient
-	manager.CacheORMSpecMap()
-	numV1CRs := manager.CacheORMSpecMap()
+	ormClientMgr.CacheORMSpecMap()
+	numV1CRs := ormClientMgr.CacheORMSpecMap()
 	if numV1CRs > 0 {
 		glog.Infof("Discovered %v v1 ORM Resources.", numV1CRs)
 	}
 
 	// ORM v2 are saved in a registry, see github.com/turbonomic/orm/registry/registry.go
-	numV2CRs := manager.RegisterORMs()
+	numV2CRs := ormClientMgr.RegisterORMs()
 	if numV2CRs > 0 {
 		glog.Infof("Discovered %v v2 ORM Resources.", numV2CRs)
 	}
@@ -69,13 +70,73 @@ type OwnerResources struct {
 	ControllerObj *unstructured.Unstructured
 	//---  V2 or V1
 	// mapping of owner and the owner path for a given source/owned path
-	OwnerResourcesMap map[string][]devopsv1alpha1.ResourcePath
+	OwnerResourcesMap map[string][]v1alpha1.ResourcePath
 	isV1ORM           bool
 }
 
-// This helper function will determine if the owner resources are found in orm V1, since we are returning the source/owned obj resourcepaths if it cannot
-// locate owner paths. This will determine to check and log if it actually found the owners resources from v1 orm
-func ownerResourcesFound(ownedObj *unstructured.Unstructured, allOwnerResourcePaths map[string][]devopsv1alpha1.ResourcePath) bool {
+// GetOwnerResourcesForOwnedResources returns the owner resources to modify for a given source resource path
+// to change the resources based an action recommendation from the Turbo server.
+func (ormClientMgr *ORMClientManager) GetOwnerResourcesForOwnedResources(ownedObj *unstructured.Unstructured,
+	ownerReference util.OwnerInfo, ownedResourcePaths []string) (*OwnerResources, error) {
+	var err error
+	owned := createObjRef(ownedObj)
+	allOwnerResourcePathObjs := make(map[string][]v1alpha1.ResourcePath)
+
+	// Find ORM v2 given the source owned resource
+	var ownedResourcePathObjs []*v1alpha1.ResourcePath
+	for _, ownedResourcePath := range ownedResourcePaths {
+		var ownedResourcePathObj = &v1alpha1.ResourcePath{
+			ObjectReference: owned,
+			Path:            ownedResourcePath,
+		}
+		ownedResourcePathObjs = append(ownedResourcePathObjs, ownedResourcePathObj)
+		// If there are nested/hierarchy of owners, this always fetch the top owner resource. any updates on the top
+		// owner resource will flow down the chain to get its children to update.
+		ownerResourcePathObjs := ormClientMgr.SeekTopOwnersResourcePathsForOwnedResourcePath(*ownedResourcePathObj)
+		// The ownerResourcePaths will never be empty, as the SeekTopOwnersResourcePathsForOwnedResourcePath function
+		// returns the owned resource kind if it cannot find the corresponding owner resources and their paths. So
+		// check if the ownerResourcePaths returned are the same as resourcePath, if same then it didn't find any
+		// mappings related to V2 ORM.
+		for _, ownerResourcePath := range ownerResourcePathObjs {
+			if ownerResourcePath != *ownedResourcePathObj {
+				allOwnerResourcePathObjs[ownedResourcePath] = ownerResourcePathObjs
+			}
+		}
+	}
+
+	foundORMV1 := false
+	if len(allOwnerResourcePathObjs) > 0 {
+		glog.Infof("Found owner resource paths using ORM v2 for owned object %s:%s:%s",
+			ownedObj.GetKind(), ownedObj.GetNamespace(), ownedObj.GetName())
+	} else {
+		// Find legacy orm v1 if orm v2 is empty
+		glog.Infof("Cannot locate owner resource paths using ORM v2 for owned object %s:%s:%s. Try ORM v1 ...",
+			ownedObj.GetKind(), ownedObj.GetNamespace(), ownedObj.GetName())
+		allOwnerResourcePathObjs, err = ormClientMgr.LocateOwnerPaths(ownedObj, ownerReference, ownedResourcePathObjs)
+		if err != nil {
+			return nil, err
+		}
+		// if it cannot locate owner resource path mappings from V1 orm, it returns the source/owned resource mapping path similar to above
+		// V2 orm flow.
+		if ownerResourcesFoundForORMV1(ownedObj, allOwnerResourcePathObjs) {
+			foundORMV1 = true
+			glog.Infof("Found owner resource paths using ORM v1 for owned object %s:%s:%s",
+				ownedObj.GetKind(), ownedObj.GetNamespace(), ownedObj.GetName())
+		}
+	}
+
+	return &OwnerResources{
+		ControllerObj:     ownedObj,
+		OwnerResourcesMap: allOwnerResourcePathObjs,
+		isV1ORM:           foundORMV1,
+	}, nil
+
+}
+
+// ownerResourcesFoundForORMV1 determines if the owner resources are found in orm V1, since we are returning the owned obj
+// resourcePaths if it cannot locate owner paths. This will check and log if it actually found the owners resources
+// from v1 orm
+func ownerResourcesFoundForORMV1(ownedObj *unstructured.Unstructured, allOwnerResourcePaths map[string][]v1alpha1.ResourcePath) bool {
 	for _, resourcePaths := range allOwnerResourcePaths {
 		for _, resourcePath := range resourcePaths {
 			if ownedObj.GetKind() != resourcePath.ObjectReference.Kind {
@@ -86,74 +147,14 @@ func ownerResourcesFound(ownedObj *unstructured.Unstructured, allOwnerResourcePa
 	return false
 }
 
-// Return the owner resources to modify for a given source resource path
-// to change the resources based an action recommendation from the Turbo server.
-func (manager *ORMClientManager) GetOwnerResourcesForSource(ownedObj *unstructured.Unstructured,
-	ownerReference discoveryutil.OwnerInfo, paths []string) (*OwnerResources, error) {
-	var err error
-	owned := createObjRef(ownedObj)
-	allOwnerResourcePaths := make(map[string][]devopsv1alpha1.ResourcePath)
-	//find ORM v2 given the source owned resource
-	var sourceResourcePath []*devopsv1alpha1.ResourcePath
-	foundORMV1 := false
-	for _, path := range paths {
-		var resourcePath *devopsv1alpha1.ResourcePath = &devopsv1alpha1.ResourcePath{
-			ObjectReference: owned,
-			Path:            path,
-		}
-		sourceResourcePath = append(sourceResourcePath, resourcePath)
-		// If there are nested/hierarchy of owners, this always fetch the top owner resource. any updates on the top
-		// owner resource will flow down the chain to get it's children to update
-		ownerResourcePaths := manager.SeekTopOwnersResourcePathsForOwnedResourcePath(*resourcePath)
-		// ownerResourcePaths will never be empty, as it returns the source/owned resource kind if it cannot
-		// find the corresponding owner resources and it's paths. so check if the ownerResourcePaths returned
-		// are same as resourcePath, if same then it didn't find any mappings related to V2 orm
-		for _, ownerResourcePath := range ownerResourcePaths {
-			if ownerResourcePath != *resourcePath {
-				allOwnerResourcePaths[path] = ownerResourcePaths
-			}
-		}
-	}
-
-	if len(allOwnerResourcePaths) > 0 {
-		glog.Infof("Found owner resource paths using ORM v2 for owned object %s:%s:%s",
-			ownedObj.GetKind(), ownedObj.GetNamespace(), ownedObj.GetName())
-	}
-	// find legacy orm if cannot locate v2 orm
-	if len(allOwnerResourcePaths) == 0 {
-		allOwnerResourcePaths, err = manager.LocateOwnerPaths(ownedObj, ownerReference, sourceResourcePath)
-		if err != nil {
-			return &OwnerResources{
-				ControllerObj:     ownedObj,
-				OwnerResourcesMap: allOwnerResourcePaths,
-				isV1ORM:           foundORMV1,
-			}, err
-		}
-		// if it cannot locate owner resource path mappings from V1 orm, it returns the source/owned resource mapping path similar to above
-		// V2 orm flow.
-		if len(allOwnerResourcePaths) > 0 && ownerResourcesFound(ownedObj, allOwnerResourcePaths) {
-			foundORMV1 = true
-			glog.Infof("Found owner resource paths using ORM v1 for owned object %s:%s:%s",
-				ownedObj.GetKind(), ownedObj.GetNamespace(), ownedObj.GetName())
-		}
-	}
-
-	return &OwnerResources{
-		ControllerObj:     ownedObj,
-		OwnerResourcesMap: allOwnerResourcePaths,
-		isV1ORM:           foundORMV1,
-	}, nil
-
-}
-
 // UpdateOwners updates the corresponding owner CR for an owned manged resource
 // updatedControllerObj -- updated K8s controller object based on Turbo actionItem, from which the resource value is fetched
 //
 //	and will be set to the corresponding CR
 //
-// controllerOwnerReference -- ownerReference of a K8s controller, which contains metadata of a owner CR
+// controllerOwnerReference -- ownerReference of a K8s controller, which contains metadata of owner CR
 // ownerResources -- mapping of owner resource obj with owner resource path and source/owned controller obj
-func (ormClient *ORMClientManager) UpdateOwners(updatedControllerObj *unstructured.Unstructured, controllerOwnerReference discoveryutil.OwnerInfo, ownerResources *OwnerResources) error {
+func (ormClientMgr *ORMClientManager) UpdateOwners(updatedControllerObj *unstructured.Unstructured, controllerOwnerReference util.OwnerInfo, ownerResources *OwnerResources) error {
 	updated := false
 	operatorResKind := controllerOwnerReference.Kind //operator kind and instance
 	operatorResName := controllerOwnerReference.Name
@@ -171,15 +172,16 @@ func (ormClient *ORMClientManager) UpdateOwners(updatedControllerObj *unstructur
 			ownerResName := ownerObj.Name
 			ownerRes := ownerResKind + "/" + ownerResName
 			ownerResNamespace := ownerObj.Namespace
-			// ownerResources might have source/owned resource kind with their resource paths if it cannot find the owner resource mapping from ORM.
-			// so we check if the owner kind and the contoller kind we get from action is same, in that case we cannot perform this update operation
-			// on source/owned resource kind without owner resource found
+			// The ownerResources might have owned resource kind as their resource paths if it cannot find the owner
+			// resource mapping from ORM.
+			// We check if the owner kind and the controller kind we get from the action are the same, in which case
+			// we cannot perform this update operation on owned resource kind without owner resource found.
 			if ownerResKind == updatedControllerObj.GetKind() {
 				glog.Warningf("owner resource not found for owned object: '%s' in namespace %s, skip updating owner CR",
 					sourceRes, ownerResNamespace)
 				continue
 			}
-			glog.Infof("Update owner %s/%s resource found for source %s/%s",
+			glog.V(4).Infof("Update owner %s/%s resource found for source %s/%s",
 				ownerResKind, ownerResName,
 				sourceResKind, sourceResName)
 			ownerCR, err := kubernetes.Toolbox.GetResourceWithObjectReference(ownerObj)
@@ -187,12 +189,12 @@ func (ormClient *ORMClientManager) UpdateOwners(updatedControllerObj *unstructur
 				return fmt.Errorf("failed to get owner CR with owner object %s for %s in namespace %s: %v", ownerRes, sourceRes, ownerResNamespace, err)
 			}
 			// get the new resource value from the source obj
-			newCRValue, found, err := ormutils.NestedField(updatedControllerObj.Object, ownedPath)
+			newCRValue, found, err := utils.NestedField(updatedControllerObj.Object, ownedPath)
 			if err != nil || !found {
 				return fmt.Errorf("failed to get value for source/owned resource %s from path '%s' in action controller, error: %v", sourceRes, ownedPath, err)
 			}
 			// get the original resource value from the owner obj
-			origCRValue, found, err := ormutils.NestedField(ownerCR.Object, ownerPath)
+			origCRValue, found, err := utils.NestedField(ownerCR.Object, ownerPath)
 			if err != nil {
 				return fmt.Errorf("failed to get value for owner resource %s from path '%s' in ownerCR for %s, error: %v", ownerRes, ownerPath, sourceRes, err)
 			}
@@ -200,12 +202,13 @@ func (ormClient *ORMClientManager) UpdateOwners(updatedControllerObj *unstructur
 				glog.V(4).Infof("no values found for owner resource %s from path '%s' in ownerCR for %s",
 					ownerRes, ownerPath, sourceRes)
 			}
-			// set new resource values to owenr cr obj
-			if err := ormutils.SetNestedField(ownerCR.Object, newCRValue, ownerPath); err != nil {
+			// set new resource values to owner cr obj
+			if err := utils.SetNestedField(ownerCR.Object, newCRValue, ownerPath); err != nil {
 				return fmt.Errorf("failed to set new value %v to owner CR %s at owner path '%s' for %s in namespace %s: %v",
 					newCRValue, ownerRes, ownerPath, sourceRes, ownerResNamespace, err)
 			}
-			glog.V(2).Infof("updating owner resource %s for %s in namespace %s at owner path %s", ownerRes, sourceRes, ownerObj.Namespace, ownerPath)
+			glog.V(2).Infof("Updating owner resource %s for %s in namespace %s at owner path %s ...",
+				ownerRes, sourceRes, ownerObj.Namespace, ownerPath)
 			// update the owner cr object with new values set
 			err = kubernetes.Toolbox.UpdateResourceWithGVK(ownerCR.GroupVersionKind(), ownerCR)
 			if err != nil {
@@ -213,15 +216,16 @@ func (ormClient *ORMClientManager) UpdateOwners(updatedControllerObj *unstructur
 			}
 			//set orm status only for owner object if this not orm V1
 			if !ownerResources.isV1ORM {
-				ormClient.SetORMStatusForOwner(ownerCR, nil)
+				ormClientMgr.SetORMStatusForOwner(ownerCR, nil)
 			}
 			updated = true
-			glog.Infof("successfully updated owner CR %s for path '%s' from %v to %v for %s in namespace %s", ownerRes, ownerPath, origCRValue, newCRValue, sourceRes, ownerResNamespace)
+			glog.V(2).Infof("Successfully updated owner CR %s for path '%s' from %v to %v for %s in namespace %s.",
+				ownerRes, ownerPath, origCRValue, newCRValue, sourceRes, ownerResNamespace)
 		}
 	}
 	// If updated is false at this stage, it means there are some changes turbo server is recommending to make but not
 	// defined in the ORM resource mapping templates. In this case, the resource field may be missing to be defined in
-	// ORM CR so it couldn't find any owner resource paths to update.
+	// ORM CR, so it couldn't find any owner resource paths to update.
 	// We send an action failure notification here because nothing gets changes after the action execution.
 	if !updated {
 		return fmt.Errorf("failed to update owner CR %s for %s in namespace %s, missing owner resource", operatorRes, sourceRes, resourceNamespace)


### PR DESCRIPTION
# Intent
This PR implements support in `kubeturbo` to allow updating workload controller replicas via ORM v2.

# Background
Our existing [ORM v2 improvement](https://jsw.ibm.com/browse/TRB-18317) only implemented support for container resize with kubeturbo. This PR extends the ORM v2 support in `kubeturbo` for horizontal scale.

# Implementation
* Added `actionType` to the `parentController` struct to indicate the type of an action (resize or horizontal scale) associate with a controller.
* Added a predefined map `actionTypeToPathTemplate` to map from controller type and action type to the corresponding resource path. This makes it easy to look up the owned resource path during ORM v2 mapping.
* The core change is in the function `getOwnedResourcePaths`.
* The rest of the changes in this PR are mainly code refactoring.

# Testing
* Make sure full build passes
* Deploy a dev build in Maximo's environment, and execute a horizontal scale action via ORM v2. Confirmed the action is successful, and the following message is logged by `kubeturbo`:
```
I0823 19:59:45.297637       1 remote_mediation_client.go:216] [handleServerMessages][ServerRequestEndpoint] : received message with request type Action.
I0823 19:59:45.297768       1 action_handler.go:368] Received an action HORIZONTAL_SCALE for entity WORKLOAD_CONTROLLER [masinst1-tenant1-mea] in namespace [mas-masinst1-manage]
I0823 19:59:45.297986       1 k8s_controller_updater.go:156] Begin to update Deployment mas-masinst1-manage/masinst1-tenant1-mea ...
I0823 19:59:45.314505       1 k8s_controller_updater.go:191] Try to update replicas of Deployment mas-masinst1-manage/masinst1-tenant1-mea from 1 to 3.
I0823 19:59:45.315325       1 k8s_controller.go:186] Updating Deployment mas-masinst1-manage/masinst1-tenant1-mea via operator for HORIZONTAL_SCALE action ...
I0823 19:59:45.315385       1 k8s_controller.go:194] Detected owned resource paths .spec.replicas for action HORIZONTAL_SCALE.
I0823 19:59:45.315423       1 orm_client_manager.go:122] Found owner resource paths using ORM v2 for owned object Deployment:mas-masinst1-manage:masinst1-tenant1-mea
I0823 19:59:45.315449       1 k8s_controller.go:200] Detected top level owner resources.
I0823 19:59:45.337096       1 orm_client_manager.go:209] Updating owner resource ManageWorkspace/masinst1-tenant1 for Deployment/masinst1-tenant1-mea in namespace mas-masinst1-manage at owner path .spec.settings.deployment.serverBundles[?(@.name=="mea")].replica ...
I0823 19:59:45.684932       1 orm_client_manager.go:221] Successfully updated owner CR ManageWorkspace/masinst1-tenant1 for path '.spec.settings.deployment.serverBundles[?(@.name=="mea")].replica' from 1 to 3 for Deployment/masinst1-tenant1-mea in namespace mas-masinst1-manage.
I0823 19:59:45.684966       1 k8s_controller_updater.go:174] Successfully updated Deployment mas-masinst1-manage/masinst1-tenant1-mea.
I0823 19:59:45.684982       1 horizontal_scaler.go:63] Action HorizontalScale for workload controller[mas-masinst1-manage/masinst1-tenant1-mea] succeeded.
```

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [x] Developer Checks
    - [x] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [x] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

_(@ mention any `review/...` groups or people that should be aware of this merge request)_

