### PR TITLE
[TRB-45953]: Updated SLO policy logic to revert to default values when min replicas > max

### DIFF
--- a/pkg/discovery/processor/turbo_policy_processor_test.go
+++ b/pkg/discovery/processor/turbo_policy_processor_test.go
@@ -361,7 +361,7 @@ func TestConvertTurboPolicyWithInvalidReplicas(t *testing.T) {
 		svc1: {},
 	}
 	groupDTOs := groupDiscoveryWorker.BuildTurboPolicyDTOsFromPolicyBindings()
-	assert.Equal(t, 0, len(groupDTOs))
+	assert.Equal(t, 1, len(groupDTOs))
 	kubeCluster.TurboPolicyBindings = nil
 }
 

--- a/pkg/discovery/worker/group_discovery_policy_slo.go
+++ b/pkg/discovery/worker/group_discovery_policy_slo.go
@@ -165,7 +165,7 @@ func validateReplicas(minReplicas *int32, maxReplicas *int32) (*int32, *int32, e
 	return minReplicas, maxReplicas, nil
 }
 
-// isWithinValidRange check if the number of replicas is within the valid range of 1 to 10000
+// isWithinValidRange check if the number of replicas is within the valid range
 func isWithinValidRange(replicas int32) bool {
 	return replicas >= defaultMinReplicas && replicas <= defaultMaxReplicas
 }

--- a/pkg/discovery/worker/group_discovery_policy_slo.go
+++ b/pkg/discovery/worker/group_discovery_policy_slo.go
@@ -6,10 +6,16 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/turbonomic/kubeturbo/pkg/discovery/repository"
 	"github.com/turbonomic/turbo-go-sdk/pkg/builder/group"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"github.com/turbonomic/turbo-policy/api/v1alpha1"
+)
+
+const (
+	defaultMinReplicas int32 = 1
+	defaultMaxReplicas int32 = 10000
 )
 
 func buildSLOHorizontalScalePolicy(
@@ -148,15 +154,18 @@ func validateReplicas(minReplicas *int32, maxReplicas *int32) (*int32, *int32, e
 		return nil, nil, fmt.Errorf("invalid maxReplicas %v. Must be between 1 and 10000 inclusive", *maxReplicas)
 	}
 	if minReplicas != nil && maxReplicas != nil && *minReplicas > *maxReplicas {
-		return nil, nil, fmt.Errorf("minReplicas %v is larger than maxReplicas %v", *minReplicas, *maxReplicas)
+		glog.Warningf("invalid SLOHorizontalScale: minReplicas (%v) must be less than or equal to maxReplicas (%v) -- using default min (%v) and max (%v) values",
+			*minReplicas, *maxReplicas, defaultMinReplicas, defaultMaxReplicas)
+		// Can't get the address of a constant so need to store it into a variable first
+		min := defaultMinReplicas
+		max := defaultMaxReplicas
+		minReplicas = &min
+		maxReplicas = &max
 	}
 	return minReplicas, maxReplicas, nil
 }
 
 // isWithinValidRange check if the number of replicas is within the valid range of 1 to 10000
 func isWithinValidRange(replicas int32) bool {
-	if replicas >= 1 && replicas <= 10000 {
-		return true
-	}
-	return false
+	return replicas >= defaultMinReplicas && replicas <= defaultMaxReplicas
 }

--- a/pkg/discovery/worker/group_discovery_policy_slo_test.go
+++ b/pkg/discovery/worker/group_discovery_policy_slo_test.go
@@ -1,0 +1,138 @@
+package worker
+
+import (
+	"errors"
+	"testing"
+)
+
+// Helper function to convert an int32 into a *int32. Golang does not support creating pointers
+// against constants, so this eliminates the need to create temporary variables from which to create
+// the pointers.
+func pointer(value int32) *int32 {
+	return &value
+}
+
+func TestValidateReplicas(t *testing.T) {
+	tests := map[string]struct {
+		min         *int32
+		max         *int32
+		expectedMin *int32
+		expectedMax *int32
+		expectedErr error
+	}{
+		"defaults": {
+			min:         pointer(defaultMinReplicas),
+			max:         pointer(defaultMaxReplicas),
+			expectedMin: pointer(defaultMinReplicas),
+			expectedMax: pointer(defaultMaxReplicas),
+			expectedErr: nil,
+		},
+		"valid range": {
+			min:         pointer(1),
+			max:         pointer(10),
+			expectedMin: pointer(1),
+			expectedMax: pointer(10),
+			expectedErr: nil,
+		},
+		"equal min/max": {
+			min:         pointer(10),
+			max:         pointer(10),
+			expectedMin: pointer(10),
+			expectedMax: pointer(10),
+			expectedErr: nil,
+		},
+		"invalid minReplicas": {
+			min:         pointer(0),
+			max:         pointer(10000),
+			expectedMin: pointer(0),
+			expectedMax: pointer(10000),
+			expectedErr: errors.New("ERROR"),
+		},
+		"invalid maxReplicas": {
+			min:         pointer(1),
+			max:         pointer(1000000000),
+			expectedMin: pointer(1),
+			expectedMax: pointer(1000000000),
+			expectedErr: errors.New("ERROR"),
+		},
+		"min > max": {
+			min:         pointer(10),
+			max:         pointer(1),
+			expectedMin: pointer(defaultMinReplicas),
+			expectedMax: pointer(defaultMaxReplicas),
+			expectedErr: nil,
+		},
+		"nils": {
+			min:         nil,
+			max:         nil,
+			expectedMin: nil,
+			expectedMax: nil,
+			expectedErr: nil,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			min, max, err := validateReplicas(test.min, test.max)
+			if err != nil {
+				if test.expectedErr == nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if min == nil && test.expectedMin != nil {
+					t.Fatalf("expected %v minReplicas but found %v", test.expectedMin, min)
+				}
+				if min != nil && test.expectedMin != nil && *min != *test.expectedMin {
+					t.Fatalf("expected %v minReplicas but found %v", test.expectedMin, *min)
+				}
+				if max == nil && test.expectedMax != nil {
+					t.Fatalf("expected %v maxReplicas but found %v", test.expectedMax, max)
+				}
+				if max != nil && test.expectedMax != nil && *max != *test.expectedMax {
+					t.Fatalf("expected %v maxReplicas but found %v", test.expectedMax, *max)
+				}
+			}
+		})
+	}
+}
+
+func TestIsWithinValidRange(t *testing.T) {
+	tests := map[string]struct {
+		replicas       int32
+		expectedResult bool
+	}{
+		"valid replicas": {
+			replicas:       10,
+			expectedResult: true,
+		},
+		"replicas equal to min allowed": {
+			replicas:       defaultMinReplicas,
+			expectedResult: true,
+		},
+		"replicas equal to max allowed": {
+			replicas:       defaultMaxReplicas,
+			expectedResult: true,
+		},
+		"replicas below valid range": {
+			replicas:       defaultMinReplicas - 1,
+			expectedResult: false,
+		},
+		"replicas above valid range": {
+			replicas:       defaultMaxReplicas + 1,
+			expectedResult: false,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualResult := isWithinValidRange(test.replicas)
+			if actualResult != test.expectedResult {
+				t.Fatalf("expected %v for %v replicas but found %v", test.expectedResult, test.replicas, actualResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Intent

Revert min/max replicas to the default values when the SLOHorizontalScale policy defines the min as greater than the max.

# Background

Older versions of Kubernetes do not support the new `x-kubernetes-validations` validation rules that all use to ensure that the `minReplicas` are less than or equal to the the `maxReplicas` on the `SLOHorizontalScale` CR. For those older versions, we will revert to the default values (as if the user had not specified them on the CR) and log a warning. 

# Testing

Debugged kubeturbo locally against appliance. 

Deployed the following SLOHorizontalScale CR to test the updated logic:
```
apiVersion: policy.turbonomic.io/v1alpha1
kind: SLOHorizontalScale
metadata:
  name: slo-horizontal-scale-sample
spec:
  minReplicas: 10
  maxReplicas: 1
  objectives:
    - name: ResponseTime
      value: 300
    - name: Transaction
      value: 20
  behavior:
    scaleUp: Automatic
    scaleDown: Disabled
```

Verified that the logs warn that the values were "invalid" and it is reverting to the defaults: 
![Screenshot 2023-09-06 at 3 32 15 PM](https://github.com/turbonomic/kubeturbo/assets/97479009/0a26b216-46b9-4fe9-ba96-1036a804fdbd)

Verified that the policy displayed in the UI also displays the defaults:
![Screenshot 2023-09-06 at 3 33 27 PM](https://github.com/turbonomic/kubeturbo/assets/97479009/e1919d60-0f50-4757-b85d-9365d2d4f055)

Added unit tests for updated methods.

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [x] Full build with unit tests and fmt and vet checks
    - [x] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [x] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

@libai98 @ading1977 @KevinWang0204 

