### PR TITLE
[TRB-46978]:Ignore the namespace resourcequotas with a Terminating scope

### DIFF
--- a/pkg/discovery/repository/kube_cluster.go
+++ b/pkg/discovery/repository/kube_cluster.go
@@ -533,6 +533,22 @@ func (kubeNamespace *KubeNamespace) ReconcileQuotas(quotas []*v1.ResourceQuota) 
 	// Quota resources by collecting resources from the list of resource quota objects
 	var quotaNames []string
 	for _, item := range quotas {
+		//  Ignore the resourcequotas with a Terminating scope
+		ignore := false
+		if len(item.Spec.Scopes) > 0 || item.Spec.ScopeSelector != nil {
+			glog.V(2).Infof("Found a resourcequota %v in the namespace %v with the scopes(%v) or scopeSelector(%v)", item.Name, item.Namespace, item.Spec.Scopes, item.Spec.ScopeSelector)
+		}
+		for _, scope := range item.Spec.Scopes {
+			if scope == v1.ResourceQuotaScopeTerminating {
+				ignore = true
+				break
+			}
+		}
+		if ignore {
+			glog.V(2).Infof("Ignore the resourcequota %v in the namespace %v as it has a Terminating scope", item.Name, item.Namespace)
+			continue
+		}
+
 		//quotaListStr = quotaListStr + item.Name + ","
 		quotaNames = append(quotaNames, item.Name)
 		// Resources in each quota


### PR DESCRIPTION
# Intent

When dealing with multiple resourcequotas in the same namespace,  we decide to skip the ones which have Scope defined and the scope contains `Terminating`. 

# Background

https://jsw.ibm.com/browse/TRB-46978

# Testing

**1.Define 2 resourcequotas in a namespace, one of them has the `Terminating` scope**
```
[root@api.ocp410kev.cp.fyre.ibm.com ~]# k get resourcequotas 
NAME                          AGE    REQUEST   LIMIT
quotatest-single-container2   269d             limits.cpu: 30m/330m, limits.memory: 300Mi/330Mi
quotatest-small               16m              limits.cpu: 0/10m, limits.memory: 0/10Mi
[root@api.ocp410kev.cp.fyre.ibm.com ~]# k describe resourcequotas quotatest-small 
Name:       quotatest-small
Namespace:  quotatest-single-container2
Scopes:     NotBestEffort, Terminating  <--------------here
 * Matches all pods that have at least one resource requirement set. These pods have a burstable or guaranteed quality of service.
 * Matches all pods that have an active deadline. These pods have a limited lifespan on a node before being actively terminated by the system.
Resource       Used  Hard
--------       ----  ----
limits.cpu     0     10m
limits.memory  0     10Mi
```

**2.Create a deployment and rediscover+broadcast, and check the Kubeturbo log**
```
k logs -f kubeturbo-kw-114-869856f484-tjs7r |grep resourcequota
I0908 20:02:30.654860       1 kube_cluster.go:539] Found a resourcequota quotatest-small in the namespace quotatest-single-container2 with the scopes([Terminating NotBestEffort]) or scopeSelector(nil)
I0908 20:02:30.654870       1 kube_cluster.go:548] Ignore the resourcequota quotatest-small in the namespace quotatest-single-container2 as it has a Terminating scope
```
**3.Check the `Capacity and Usage` on the UI for that namespace**
The capacity doesn't pick up the smaller one defined in the `quotatest-small` resourcequota
![image](https://github.com/turbonomic/kubeturbo/assets/61252360/0499b0ca-d6b2-44b8-966c-2bf42b9d23d8)


# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [x] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [x] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience

_(@ mention any `review/...` groups or people that should be aware of this merge request)_

